### PR TITLE
optimized list-view by removing unnecessary `length` | 优化了 list-view，减少了其中多余的 length 调用

### DIFF
--- a/goldfish/liii/list.scm
+++ b/goldfish/liii/list.scm
@@ -35,19 +35,33 @@
   ; Liii List extensions
   list-view flatmap
   list-null? list-not-null? not-null-list?
+  length=
 )
 (import (srfi srfi-1))
 (begin
 
+(define (length= x scheme-list)
+  (cond ((and (= x 0) (null? scheme-list)) #t)
+        ((or (= x 0) (null? scheme-list)) #f)
+        (else (length= (- x 1) (cdr scheme-list)))))
+
 (define (list-view scheme-list)
+  (define (f-inner-reducer scheme-list filter filter-func rest-funcs)
+    (cond ((null? rest-funcs) (list-view (filter filter-func scheme-list)))
+          (else
+           (f-inner-reducer (filter filter-func scheme-list)
+                            (car rest-funcs)
+                            (cadr rest-funcs)
+                            (cddr rest-funcs)))))
   (define (f-inner . funcs)
     (cond ((null? funcs) scheme-list)
-          ((= (length funcs) 2)
+          ((length= 2 scheme-list)
            (list-view ((car funcs) (cadr funcs) scheme-list)))
           ((even? (length funcs))
-           (apply
-             (f-inner (car funcs) (cadr funcs))
-             (cddr funcs)))
+           (f-inner-reducer scheme-list
+                            (car funcs)
+                            (cadr funcs)
+                            (cddr funcs)))
           (else (error 'wrong-number-of-args
                        "list-view only accepts even number of args"))))
   f-inner)

--- a/goldfish/liii/list.scm
+++ b/goldfish/liii/list.scm
@@ -35,7 +35,7 @@
   ; Liii List extensions
   list-view flatmap
   list-null? list-not-null? not-null-list?
-  length=
+  length=?
 )
 (import (srfi srfi-1))
 (begin
@@ -43,7 +43,7 @@
 (define (length=? x scheme-list)
   (cond ((and (= x 0) (null? scheme-list)) #t)
         ((or (= x 0) (null? scheme-list)) #f)
-        (else (length= (- x 1) (cdr scheme-list)))))
+        (else (length=? (- x 1) (cdr scheme-list)))))
 
 (define (list-view scheme-list)
   (define (f-inner-reducer scheme-list filter filter-func rest-funcs)
@@ -55,7 +55,7 @@
                             (cddr rest-funcs)))))
   (define (f-inner . funcs)
     (cond ((null? funcs) scheme-list)
-          ((length= 2 scheme-list)
+          ((length=? 2 scheme-list)
            (list-view ((car funcs) (cadr funcs) scheme-list)))
           ((even? (length funcs))
            (f-inner-reducer scheme-list

--- a/goldfish/liii/list.scm
+++ b/goldfish/liii/list.scm
@@ -40,7 +40,7 @@
 (import (srfi srfi-1))
 (begin
 
-(define (length= x scheme-list)
+(define (length=? x scheme-list)
   (cond ((and (= x 0) (null? scheme-list)) #t)
         ((or (= x 0) (null? scheme-list)) #f)
         (else (length= (- x 1) (cdr scheme-list)))))

--- a/goldfish/liii/list.scm
+++ b/goldfish/liii/list.scm
@@ -55,7 +55,7 @@
                             (cddr rest-funcs)))))
   (define (f-inner . funcs)
     (cond ((null? funcs) scheme-list)
-          ((length=? 2 scheme-list)
+          ((length=? 2 funcs)
            (list-view ((car funcs) (cadr funcs) scheme-list)))
           ((even? (length funcs))
            (f-inner-reducer scheme-list

--- a/tests/liii/list-test.scm
+++ b/tests/liii/list-test.scm
@@ -3,9 +3,9 @@
 
 (check-set-mode! 'report-failed)
 
-(check ((length= 3 (list 1 2 3))) => #t)
-(check ((length= 2 (list 1 2 3))) => #f)
-(check ((length= 4 (list 1 2 3))) => #f)
+(check (length= 3 (list 1 2 3)) => #t)
+(check (length= 2 (list 1 2 3)) => #f)
+(check (length= 4 (list 1 2 3)) => #f)
 
 (check ((list-view (list 1 2 3))) => (list 1 2 3))
 

--- a/tests/liii/list-test.scm
+++ b/tests/liii/list-test.scm
@@ -3,9 +3,9 @@
 
 (check-set-mode! 'report-failed)
 
-(check (length= 3 (list 1 2 3)) => #t)
-(check (length= 2 (list 1 2 3)) => #f)
-(check (length= 4 (list 1 2 3)) => #f)
+(check (length=? 3 (list 1 2 3)) => #t)
+(check (length=? 2 (list 1 2 3)) => #f)
+(check (length=? 4 (list 1 2 3)) => #f)
 
 (check ((list-view (list 1 2 3))) => (list 1 2 3))
 

--- a/tests/liii/list-test.scm
+++ b/tests/liii/list-test.scm
@@ -3,6 +3,10 @@
 
 (check-set-mode! 'report-failed)
 
+(check ((length= 3 (list 1 2 3))) => #t)
+(check ((length= 2 (list 1 2 3))) => #f)
+(check ((length= 4 (list 1 2 3))) => #f)
+
 (check ((list-view (list 1 2 3))) => (list 1 2 3))
 
 (check (((list-view (list 1 2 3))


### PR DESCRIPTION
        edited:     goldfish/liii/list.scm
                    optimized list-view
                    add function length=

        修改：goldfish/liii/list.scm
                    优化了 list-view
                    添加了函数 length=
                    
        edited:     tests/liii/list-test.scm
                    add test for function length=
                    
        修改：tests/liii/list-test.scm
                   给 length= 添加了测试