### PR TITLE
u8-string-length, string->utf8, u8-substring

### DIFF
--- a/Goldfish.tmu
+++ b/Goldfish.tmu
@@ -508,7 +508,7 @@
 
     \ \ bytevector-u8-ref bytevector-u8-set!
 
-    \ \ utf8-\<gtr\>string string-\<gtr\>utf8 u8-string-length
+    \ \ utf8-\<gtr\>string string-\<gtr\>utf8 u8-string-length u8-substring
 
     \ \ ; Input and Output
 
@@ -1743,11 +1743,13 @@
     \;
   </scm-chunk>
 
-  <paragraph|u8-string-length>
+  <paragraph|u8-string-length><index|u8-string-length>
 
   <value|r7rs><paragraph|utf8-\<gtr\>string><index|utf8-\<gtr\>string>
 
   <value|r7rs><paragraph|string-\<gtr\>utf8><index|string-\<gtr\>utf8>
+
+  <paragraph|u8-substring><index|u8-substring>
 
   这三个函数依赖于一样的公共子函数，故而放在一起实现。
 
@@ -1974,6 +1976,10 @@
 
     \ \ 
 
+    \ \ (when (not (string? str))
+
+    \ \ \ \ (error 'type-error "str must be string"))
+
     \ \ (let ((N (u8-string-length str)))
 
     \ \ \ \ (when (or (\<less\> start 0) (\<gtr\>= start N))
@@ -2042,6 +2048,28 @@
 
     \;
   </scm-chunk>
+
+  <subparagraph|实现u8-substring>
+
+  <\scm-chunk|goldfish/liii/base.scm|true|true>
+    (define* (u8-substring str (start 0) (end #t))
+
+    \ \ (utf8-\<gtr\>string (string-\<gtr\>utf8 str start end)))
+
+    \;
+  </scm-chunk>
+
+  <\scm-chunk|tests/goldfish/liii/base-test.scm|true|true>
+    (check (u8-substring "汉字书写" 0 1) =\<gtr\> "汉")
+
+    (check (u8-substring "汉字书写" 0 4) =\<gtr\> "汉字书写")
+
+    (check (u8-substring "汉字书写" 0) =\<gtr\> "汉字书写")
+
+    \;
+  </scm-chunk>
+
+  \;
 
   <section|控制流>
 

--- a/Goldfish.tmu
+++ b/Goldfish.tmu
@@ -1711,7 +1711,7 @@
     \;
   </scm-chunk>
 
-  <paragraph|bytevector-length>
+  <value|r7rs><paragraph|bytevector-length>
 
   <\scm-chunk|goldfish/scheme/base.scm|true|true>
     (define bytevector-length length)
@@ -1719,7 +1719,7 @@
     \;
   </scm-chunk>
 
-  <paragraph|bytevector-u8-ref>
+  <value|r7rs><paragraph|bytevector-u8-ref>
 
   <\scm-chunk|goldfish/scheme/base.scm|true|true>
     (define bytevector-u8-ref byte-vector-ref)
@@ -1729,7 +1729,7 @@
 
   \;
 
-  <paragraph|bytevector-u8-set!>
+  <value|r7rs><paragraph|bytevector-u8-set!>
 
   <\scm-chunk|goldfish/scheme/base.scm|true|true>
     (define bytevector-u8-set! byte-vector-set!)
@@ -1737,112 +1737,162 @@
     \;
   </scm-chunk>
 
+  <paragraph|u8-decode>
+
+  \;
+
+  <\session|goldfish|default>
+    <\unfolded-io>
+      \<gtr\>\ 
+    <|unfolded-io>
+      \;
+    <|unfolded-io>
+      <goldfish-result|bytevector-advance-u8>
+    </unfolded-io>
+
+    <\unfolded-io>
+      \<gtr\>\ 
+    <|unfolded-io>
+      (bytevector-advance-u8 #u8(#xF0 #x9F #x91 #x8D) 4)
+    <|unfolded-io>
+      <goldfish-result|4>
+    </unfolded-io>
+
+    <\input>
+      \<gtr\>\ 
+    <|input>
+      \;
+    </input>
+  </session>
+
+  \;
+
   <paragraph|utf8-\<gtr\>string>
+
+  <paragraph|string-\<gtr\>utf8>
+
+  首先定义公共子函数<scm|bytevector-advance-u8>：<scm|(bv index end) =\<gtr\> index>。
+
+  <\enumerate>
+    <item>当前位置超过指定的开区间的结尾时，直接返回当前位置
+
+    <item>当前位置是非法位置，直接返回当前位置
+
+    <item>当前位置是合法位置，返回下一个位置
+  </enumerate>
+
+  <\scm-chunk|goldfish/scheme/base.scm|true|true>
+    (define* (bytevector-advance-u8 bv index (end (length bv)))
+
+    \ \ (if (\<gtr\>= index end)
+
+    \ \ \ \ \ \ index \ ; Reached the end without errors, sequence is valid
+
+    \ \ \ \ \ \ (let ((byte (bv index)))
+
+    \ \ \ \ \ \ \ \ (cond
+
+    \ \ \ \ \ \ \ \ \ ;; 1-byte sequence (0xxxxxxx)
+
+    \ \ \ \ \ \ \ \ \ ((\<less\> byte #x80)
+
+    \ \ \ \ \ \ \ \ \ \ (+ index 1))
+
+    \ \ \ \ \ \ \ \ \ \ \ 
+
+    \ \ \ \ \ \ \ \ \ ;; 2-byte sequence (110xxxxx 10xxxxxx)
+
+    \ \ \ \ \ \ \ \ \ ((\<less\> byte #xe0)
+
+    \ \ \ \ \ \ \ \ \ \ (if (\<gtr\>= (+ index 1) end)
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ index \ ; Incomplete sequence
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ (let ((next-byte (bv (+ index 1))))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (if (not (= (logand next-byte #xc0) #x80))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ index \ ; Invalid continuation byte
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (+ index 2)))))
+
+    \ \ \ \ \ \ \ \ \ \ \ 
+
+    \ \ \ \ \ \ \ \ \ ;; 3-byte sequence (1110xxxx 10xxxxxx 10xxxxxx)
+
+    \ \ \ \ \ \ \ \ \ ((\<less\> byte #xf0)
+
+    \ \ \ \ \ \ \ \ \ \ (if (\<gtr\>= (+ index 2) end)
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ index \ ; Incomplete sequence
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ (let ((next-byte1 (bytevector-u8-ref bv (+ index 1)))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (next-byte2 (bytevector-u8-ref bv (+ index 2))))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (if (or (not (= (logand next-byte1 #xc0) #x80))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (not (= (logand next-byte2 #xc0) #x80)))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ index \ ; Invalid continuation byte(s)
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (+ index 3)))))
+
+    \ \ \ \ \ \ \ \ \ \ \ 
+
+    \ \ \ \ \ \ \ \ \ ;; 4-byte sequence (11110xxx 10xxxxxx 10xxxxxx 10xxxxxx)
+
+    \ \ \ \ \ \ \ \ \ ((\<less\> byte #xf8)
+
+    \ \ \ \ \ \ \ \ \ \ (if (\<gtr\>= (+ index 3) end)
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ index \ ; Incomplete sequence
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ (let ((next-byte1 (bv (+ index 1)))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (next-byte2 (bv (+ index 2)))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (next-byte3 (bv (+ index 3))))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (if (or (not (= (logand next-byte1 #xc0) #x80))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (not (= (logand next-byte2 #xc0) #x80))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (not (= (logand next-byte3 #xc0) #x80)))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ index \ ; Invalid continuation byte(s)
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (+ index 4)))))
+
+    \ \ \ \ \ \ \ \ \ (else index))))) \ ; Invalid leading byte
+
+    \;
+  </scm-chunk>
 
   <\scm-chunk|goldfish/scheme/base.scm|true|true>
     (define* (utf8-\<gtr\>string bv (start 0) (end (bytevector-length bv)))
-
-    \ \ (define (validate-utf8 bv index end)
-
-    \ \ \ \ (if (\<gtr\>= index end)
-
-    \ \ \ \ \ \ \ \ #t \ ; Reached the end without errors, sequence is valid
-
-    \ \ \ \ \ \ \ \ (let ((byte (bytevector-u8-ref bv index)))
-
-    \ \ \ \ \ \ \ \ \ \ (cond
-
-    \ \ \ \ \ \ \ \ \ \ \ ;; 1-byte sequence (0xxxxxxx)
-
-    \ \ \ \ \ \ \ \ \ \ \ ((\<less\> byte #x80)
-
-    \ \ \ \ \ \ \ \ \ \ \ \ (validate-utf8 bv (+ index 1) end))
-
-    \ \ \ \ \ \ \ \ \ \ \ 
-
-    \ \ \ \ \ \ \ \ \ \ \ ;; 2-byte sequence (110xxxxx 10xxxxxx)
-
-    \ \ \ \ \ \ \ \ \ \ \ ((\<less\> byte #xe0)
-
-    \ \ \ \ \ \ \ \ \ \ \ \ (if (\<gtr\>= (+ index 1) end)
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ index \ ; Incomplete sequence
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (let ((next-byte (bytevector-u8-ref bv (+ index 1))))
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (if (not (= (logand next-byte #xc0) #x80))
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ index \ ; Invalid continuation byte
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (validate-utf8 bv (+ index 2) end)))))
-
-    \ \ \ \ \ \ \ \ \ \ \ 
-
-    \ \ \ \ \ \ \ \ \ \ \ ;; 3-byte sequence (1110xxxx 10xxxxxx 10xxxxxx)
-
-    \ \ \ \ \ \ \ \ \ \ \ ((\<less\> byte #xf0)
-
-    \ \ \ \ \ \ \ \ \ \ \ \ (if (\<gtr\>= (+ index 2) end)
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ index \ ; Incomplete sequence
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (let ((next-byte1 (bytevector-u8-ref bv (+ index 1)))
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (next-byte2 (bytevector-u8-ref bv (+ index 2))))
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (if (or (not (= (logand next-byte1 #xc0) #x80))
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (not (= (logand next-byte2 #xc0) #x80)))
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ index \ ; Invalid continuation byte(s)
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (validate-utf8 bv (+ index 3) end)))))
-
-    \ \ \ \ \ \ \ \ \ \ \ 
-
-    \ \ \ \ \ \ \ \ \ \ \ ;; 4-byte sequence (11110xxx 10xxxxxx 10xxxxxx 10xxxxxx)
-
-    \ \ \ \ \ \ \ \ \ \ \ ((\<less\> byte #xf8)
-
-    \ \ \ \ \ \ \ \ \ \ \ \ (if (\<gtr\>= (+ index 3) end)
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ index \ ; Incomplete sequence
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (let ((next-byte1 (bytevector-u8-ref bv (+ index 1)))
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (next-byte2 (bytevector-u8-ref bv (+ index 2)))
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (next-byte3 (bytevector-u8-ref bv (+ index 3))))
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (if (or (not (= (logand next-byte1 #xc0) #x80))
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (not (= (logand next-byte2 #xc0) #x80))
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (not (= (logand next-byte3 #xc0) #x80)))
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ index \ ; Invalid continuation byte(s)
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (validate-utf8 bv (+ index 4) end)))))
-
-    \ \ \ \ \ \ \ \ \ \ \ 
-
-    \ \ \ \ \ \ \ \ \ \ \ (else index))))) \ ; Invalid leading byte
-
-    \ \ 
 
     \ \ (if (or (\<less\> start 0) (\<gtr\> end (bytevector-length bv)) (\<gtr\> start end))
 
     \ \ \ \ \ \ (error 'out-of-range start end)
 
-    \ \ \ \ \ \ (let ((validation-result (validate-utf8 bv start end)))
+    \ \ \ \ \ \ (let loop ((pos start))
 
-    \ \ \ \ \ \ \ \ (if (eq? validation-result #t)
+    \ \ \ \ \ \ \ \ (let ((next-pos (bytevector-advance-u8 bv pos end)))
 
-    \ \ \ \ \ \ \ \ \ \ \ \ (copy bv (make-string (- end start)) start end)
+    \ \ \ \ \ \ \ \ \ \ (cond
 
-    \ \ \ \ \ \ \ \ \ \ \ \ (error 'value-error
+    \ \ \ \ \ \ \ \ \ \ \ ((= next-pos end)
 
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ "Invalid UTF-8 sequence at index: " validation-result)))))
+    \ \ \ \ \ \ \ \ \ \ \ \ (copy bv (make-string (- end start)) start end))
+
+    \ \ \ \ \ \ \ \ \ \ \ ((= next-pos pos)
+
+    \ \ \ \ \ \ \ \ \ \ \ \ (error 'value-error "Invalid UTF-8 sequence at index: " pos))
+
+    \ \ \ \ \ \ \ \ \ \ \ (else
+
+    \ \ \ \ \ \ \ \ \ \ \ \ (loop next-pos)))))))
 
     \;
   </scm-chunk>
@@ -1862,6 +1912,12 @@
 
     \;
   </scm-chunk>
+
+  <paragraph|string-\<gtr\>utf8>
+
+  \;
+
+  \;
 
   <section|控制流>
 

--- a/Goldfish.tmu
+++ b/Goldfish.tmu
@@ -1958,7 +1958,7 @@
 
     \ \ \ \ \ \ \ \ \ \ \ ((and (integer? end) (= cnt end))
 
-    \ \ \ \ \ \ \ \ \ \ \ \ (copy bv (make-byte-vector (- pos start-pos)) pos next-pos))
+    \ \ \ \ \ \ \ \ \ \ \ \ (copy bv (make-byte-vector (- pos start-pos)) start-pos pos))
 
     \ \ \ \ \ \ \ \ \ \ \ ((and end (= next-pos N))
 

--- a/Goldfish.tmu
+++ b/Goldfish.tmu
@@ -424,7 +424,9 @@
 
     \ \ bytevector? make-bytevector bytevector bytevector-length
 
-    \ \ bytevector-u8-ref bytevector-u8-set! utf8-\<gtr\>string
+    \ \ bytevector-u8-ref bytevector-u8-set!
+
+    \ \ utf8-\<gtr\>string string-\<gtr\>utf8 u8-string-length
 
     \ \ ; Input and Output
 
@@ -502,7 +504,11 @@
 
     \ \ bytevector? make-bytevector bytevector bytevector-length
 
-    \ \ bytevector-u8-ref bytevector-u8-set! utf8-\<gtr\>string
+    \ \ bytevector-u8-ref bytevector-u8-set!
+
+    \ \ bytevector-u8-ref bytevector-u8-set!
+
+    \ \ utf8-\<gtr\>string string-\<gtr\>utf8 u8-string-length
 
     \ \ ; Input and Output
 
@@ -1737,39 +1743,15 @@
     \;
   </scm-chunk>
 
-  <paragraph|u8-decode>
+  <paragraph|u8-string-length>
 
-  \;
+  <value|r7rs><paragraph|utf8-\<gtr\>string><index|utf8-\<gtr\>string>
 
-  <\session|goldfish|default>
-    <\unfolded-io>
-      \<gtr\>\ 
-    <|unfolded-io>
-      \;
-    <|unfolded-io>
-      <goldfish-result|bytevector-advance-u8>
-    </unfolded-io>
+  <value|r7rs><paragraph|string-\<gtr\>utf8><index|string-\<gtr\>utf8>
 
-    <\unfolded-io>
-      \<gtr\>\ 
-    <|unfolded-io>
-      (bytevector-advance-u8 #u8(#xF0 #x9F #x91 #x8D) 4)
-    <|unfolded-io>
-      <goldfish-result|4>
-    </unfolded-io>
+  这三个函数依赖于一样的公共子函数，故而放在一起实现。
 
-    <\input>
-      \<gtr\>\ 
-    <|input>
-      \;
-    </input>
-  </session>
-
-  \;
-
-  <paragraph|utf8-\<gtr\>string>
-
-  <paragraph|string-\<gtr\>utf8>
+  <subparagraph|公共子函数>
 
   首先定义公共子函数<scm|bytevector-advance-u8>：<scm|(bv index end) =\<gtr\> index>。
 
@@ -1869,6 +1851,42 @@
     \;
   </scm-chunk>
 
+  <subparagraph|实现u8-string-length>
+
+  <\scm-chunk|goldfish/scheme/base.scm|true|true>
+    (define (u8-string-length str)
+
+    \ \ (let ((bv (string-\<gtr\>byte-vector str))
+
+    \ \ \ \ \ \ \ \ (N (string-length str)))
+
+    \ \ \ \ (let loop ((pos 0) (cnt 0))
+
+    \ \ \ \ \ \ (let ((next-pos (bytevector-advance-u8 bv pos N)))
+
+    \ \ \ \ \ \ \ \ (cond
+
+    \ \ \ \ \ \ \ \ \ ((= next-pos N)
+
+    \ \ \ \ \ \ \ \ \ \ (+ cnt 1))
+
+    \ \ \ \ \ \ \ \ \ ((= next-pos pos)
+
+    \ \ \ \ \ \ \ \ \ \ (error 'value-error "Invalid UTF-8 sequence at index: " pos))
+
+    \ \ \ \ \ \ \ \ \ (else (loop next-pos (+ cnt 1))))))))
+
+    \;
+  </scm-chunk>
+
+  <\scm-chunk|tests/goldfish/liii/base-test.scm|true|true>
+    (check (u8-string-length "中文") =\<gtr\> 2)
+
+    \;
+  </scm-chunk>
+
+  <subparagraph|实现utf8-\<gtr\>string>
+
   <\scm-chunk|goldfish/scheme/base.scm|true|true>
     (define* (utf8-\<gtr\>string bv (start 0) (end (bytevector-length bv)))
 
@@ -1913,11 +1931,87 @@
     \;
   </scm-chunk>
 
-  <paragraph|string-\<gtr\>utf8>
-
   \;
 
-  \;
+  <subparagraph|实现string-\<gtr\>utf8>
+
+  <\scm-chunk|goldfish/scheme/base.scm|true|true>
+    (define* (string-\<gtr\>utf8 str (start 0) (end #t))
+
+    \ \ ; start \<less\> end in this case
+
+    \ \ (define (string-\<gtr\>utf8-sub str start end)
+
+    \ \ \ \ (let ((bv (string-\<gtr\>byte-vector str))
+
+    \ \ \ \ \ \ \ \ \ \ (N (string-length str)))
+
+    \ \ \ \ \ \ (let loop ((pos 0) (cnt 0) (start-pos 0))
+
+    \ \ \ \ \ \ \ \ (let ((next-pos (bytevector-advance-u8 bv pos N)))
+
+    \ \ \ \ \ \ \ \ \ \ (cond
+
+    \ \ \ \ \ \ \ \ \ \ \ ((and (not (zero? start)) (= cnt start))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ (loop next-pos (+ cnt 1) pos))
+
+    \ \ \ \ \ \ \ \ \ \ \ ((and (integer? end) (= cnt end))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ (copy bv (make-byte-vector (- pos start-pos)) pos next-pos))
+
+    \ \ \ \ \ \ \ \ \ \ \ ((and end (= next-pos N))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ (copy bv (make-byte-vector (- N start-pos)) start-pos N))
+
+    \ \ \ \ \ \ \ \ \ \ \ ((= next-pos pos)
+
+    \ \ \ \ \ \ \ \ \ \ \ \ (error 'value-error "Invalid UTF-8 sequence at index: " pos))
+
+    \ \ \ \ \ \ \ \ \ \ \ (else
+
+    \ \ \ \ \ \ \ \ \ \ \ \ (loop next-pos (+ cnt 1) start-pos)))))))
+
+    \;
+
+    \ \ (when (\<less\> start 0)
+
+    \ \ \ \ \ \ \ \ (error 'out-of-range "start must be greater than 0"))
+
+    \ \ (when (and (integer? end) (\<gtr\>= end (string-length str)))
+
+    \ \ \ \ \ \ \ \ (error 'out-of-range "end must be smaller than string length: "
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ end (string-length str)))
+
+    \ \ (when (and (integer? end) (\<gtr\> start end))
+
+    \ \ \ \ \ \ \ \ (error 'out-of-range "start \<less\>= end failed" start end))
+
+    \ \ 
+
+    \ \ (if (and (integer? end) (= start end))
+
+    \ \ \ \ \ \ (byte-vector)
+
+    \ \ \ \ \ \ (string-\<gtr\>utf8-sub str start end)))
+
+    \;
+  </scm-chunk>
+
+  <\scm-chunk|tests/goldfish/liii/base-test.scm|true|true>
+    (check (string-\<gtr\>utf8 "Hello") =\<gtr\> (bytevector #x48 #x65 #x6C #x6C #x6F))
+
+    (check (string-\<gtr\>utf8 "Hello" 1 2) =\<gtr\> #u8(#x65))
+
+    (check (string-\<gtr\>utf8 "ä") =\<gtr\> #u8(#xC3 #xA4))
+
+    (check (string-\<gtr\>utf8 "中") =\<gtr\> #u8(#xE4 #xB8 #xAD))
+
+    (check (string-\<gtr\>utf8 "👍") =\<gtr\> #u8(#xF0 #x9F #x91 #x8D))
+
+    \;
+  </scm-chunk>
 
   <section|控制流>
 

--- a/Goldfish.tmu
+++ b/Goldfish.tmu
@@ -1952,7 +1952,7 @@
 
     \ \ \ \ \ \ \ \ \ \ (cond
 
-    \ \ \ \ \ \ \ \ \ \ \ ((and (not (zero? start)) (= cnt start))
+    \ \ \ \ \ \ \ \ \ \ \ ((and (not (zero? start)) (zero? start-pos) (= cnt start))
 
     \ \ \ \ \ \ \ \ \ \ \ \ (loop next-pos (+ cnt 1) pos))
 
@@ -1972,29 +1972,33 @@
 
     \ \ \ \ \ \ \ \ \ \ \ \ (loop next-pos (+ cnt 1) start-pos)))))))
 
-    \;
-
-    \ \ (when (\<less\> start 0)
-
-    \ \ \ \ \ \ \ \ (error 'out-of-range "start must be greater than 0"))
-
-    \ \ (when (and (integer? end) (\<gtr\>= end (string-length str)))
-
-    \ \ \ \ \ \ \ \ (error 'out-of-range "end must be smaller than string length: "
-
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ end (string-length str)))
-
-    \ \ (when (and (integer? end) (\<gtr\> start end))
-
-    \ \ \ \ \ \ \ \ (error 'out-of-range "start \<less\>= end failed" start end))
-
     \ \ 
 
-    \ \ (if (and (integer? end) (= start end))
+    \ \ (let ((N (u8-string-length str)))
+
+    \ \ \ \ (when (or (\<less\> start 0) (\<gtr\>= start N))
+
+    \ \ \ \ \ \ \ \ (error 'out-of-range
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (string-append "start must \<gtr\>= 0 and \<less\> " (number-\<gtr\>string N))))
+
+    \ \ \ \ (when (and (integer? end) (or (\<less\> end 0) (\<gtr\>= end (+ N 1))))
+
+    \ \ \ \ \ \ \ \ \ \ (error 'out-of-range
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (string-append "end must \<gtr\>= 0 and \<less\> " (number-\<gtr\>string (+ N 1))))) \ \ \ \ \ \ \ \ 
+
+    \ \ \ \ (when (and (integer? end) (\<gtr\> start end))
+
+    \ \ \ \ \ \ \ \ \ \ (error 'out-of-range "start \<less\>= end failed" start end))
+
+    \ \ \ \ 
+
+    \ \ \ \ (if (and (integer? end) (= start end))
 
     \ \ \ \ \ \ (byte-vector)
 
-    \ \ \ \ \ \ (string-\<gtr\>utf8-sub str start end)))
+    \ \ \ \ \ \ (string-\<gtr\>utf8-sub str start end))))
 
     \;
   </scm-chunk>
@@ -2002,7 +2006,27 @@
   <\scm-chunk|tests/goldfish/liii/base-test.scm|true|true>
     (check (string-\<gtr\>utf8 "Hello") =\<gtr\> (bytevector #x48 #x65 #x6C #x6C #x6F))
 
-    (check (string-\<gtr\>utf8 "Hello" 1 2) =\<gtr\> #u8(#x65))
+    (check (utf8-\<gtr\>string (string-\<gtr\>utf8 "Hello" 1 2)) =\<gtr\> "e")
+
+    (check (utf8-\<gtr\>string (string-\<gtr\>utf8 "Hello" 0 2)) =\<gtr\> "He")
+
+    (check (utf8-\<gtr\>string (string-\<gtr\>utf8 "Hello" 2)) =\<gtr\> "llo")
+
+    \;
+
+    (check (utf8-\<gtr\>string (string-\<gtr\>utf8 "汉字书写")) =\<gtr\> "汉字书写")
+
+    (check (utf8-\<gtr\>string (string-\<gtr\>utf8 "汉字书写" 1)) =\<gtr\> "字书写")
+
+    (check (utf8-\<gtr\>string (string-\<gtr\>utf8 "汉字书写" 2)) =\<gtr\> "书写")
+
+    (check (utf8-\<gtr\>string (string-\<gtr\>utf8 "汉字书写" 3)) =\<gtr\> "写")
+
+    \;
+
+    (check-catch 'out-of-range (string-\<gtr\>utf8 "汉字书写" 4))
+
+    \;
 
     (check (string-\<gtr\>utf8 "ä") =\<gtr\> #u8(#xC3 #xA4))
 

--- a/Goldfish.tmu
+++ b/Goldfish.tmu
@@ -2012,6 +2012,12 @@
 
     (check (utf8-\<gtr\>string (string-\<gtr\>utf8 "Hello" 2)) =\<gtr\> "llo")
 
+    (check (utf8-\<gtr\>string (string-\<gtr\>utf8 "Hello" 2 5)) =\<gtr\> "llo")
+
+    \;
+
+    (check-catch 'out-of-range (string-\<gtr\>utf8 "Hello" 2 6))
+
     \;
 
     (check (utf8-\<gtr\>string (string-\<gtr\>utf8 "汉字书写")) =\<gtr\> "汉字书写")

--- a/goldfish/liii/base.scm
+++ b/goldfish/liii/base.scm
@@ -39,7 +39,9 @@
   vector-copy vector-copy! vector-fill!
   ; R7RS 6.9 Bytevectors
   bytevector? make-bytevector bytevector bytevector-length
-  bytevector-u8-ref bytevector-u8-set! utf8->string
+  bytevector-u8-ref bytevector-u8-set!
+  bytevector-u8-ref bytevector-u8-set!
+  utf8->string string->utf8 u8-string-length
   ; Input and Output
   call-with-port port? binary-port? textual-port?
   input-port-open? output-port-open?

--- a/goldfish/liii/base.scm
+++ b/goldfish/liii/base.scm
@@ -41,7 +41,7 @@
   bytevector? make-bytevector bytevector bytevector-length
   bytevector-u8-ref bytevector-u8-set!
   bytevector-u8-ref bytevector-u8-set!
-  utf8->string string->utf8 u8-string-length
+  utf8->string string->utf8 u8-string-length u8-substring
   ; Input and Output
   call-with-port port? binary-port? textual-port?
   input-port-open? output-port-open?
@@ -60,6 +60,9 @@
   == != display* in? let1 compose identity typed-lambda
 )
 (begin
+
+(define* (u8-substring str (start 0) (end #t))
+  (utf8->string (string->utf8 str start end)))
 
 (define == equal?)
 

--- a/goldfish/scheme/base.scm
+++ b/goldfish/scheme/base.scm
@@ -292,6 +292,8 @@
            (else
             (loop next-pos (+ cnt 1) start-pos)))))))
   
+  (when (not (string? str))
+    (error 'type-error "str must be string"))
   (let ((N (u8-string-length str)))
     (when (or (< start 0) (>= start N))
         (error 'out-of-range

--- a/goldfish/scheme/base.scm
+++ b/goldfish/scheme/base.scm
@@ -204,58 +204,61 @@
 
 (define bytevector-u8-set! byte-vector-set!)
 
+(define* (bytevector-advance-u8 bv index (end (length bv)))
+  (if (>= index end)
+      index  ; Reached the end without errors, sequence is valid
+      (let ((byte (bv index)))
+        (cond
+         ;; 1-byte sequence (0xxxxxxx)
+         ((< byte #x80)
+          (+ index 1))
+           
+         ;; 2-byte sequence (110xxxxx 10xxxxxx)
+         ((< byte #xe0)
+          (if (>= (+ index 1) end)
+              index  ; Incomplete sequence
+              (let ((next-byte (bv (+ index 1))))
+                (if (not (= (logand next-byte #xc0) #x80))
+                    index  ; Invalid continuation byte
+                    (+ index 2)))))
+           
+         ;; 3-byte sequence (1110xxxx 10xxxxxx 10xxxxxx)
+         ((< byte #xf0)
+          (if (>= (+ index 2) end)
+              index  ; Incomplete sequence
+              (let ((next-byte1 (bytevector-u8-ref bv (+ index 1)))
+                    (next-byte2 (bytevector-u8-ref bv (+ index 2))))
+                (if (or (not (= (logand next-byte1 #xc0) #x80))
+                        (not (= (logand next-byte2 #xc0) #x80)))
+                    index  ; Invalid continuation byte(s)
+                    (+ index 3)))))
+           
+         ;; 4-byte sequence (11110xxx 10xxxxxx 10xxxxxx 10xxxxxx)
+         ((< byte #xf8)
+          (if (>= (+ index 3) end)
+              index  ; Incomplete sequence
+              (let ((next-byte1 (bv (+ index 1)))
+                    (next-byte2 (bv (+ index 2)))
+                    (next-byte3 (bv (+ index 3))))
+                (if (or (not (= (logand next-byte1 #xc0) #x80))
+                        (not (= (logand next-byte2 #xc0) #x80))
+                        (not (= (logand next-byte3 #xc0) #x80)))
+                    index  ; Invalid continuation byte(s)
+                    (+ index 4)))))
+         (else index)))))  ; Invalid leading byte
+
 (define* (utf8->string bv (start 0) (end (bytevector-length bv)))
-  (define (validate-utf8 bv index end)
-    (if (>= index end)
-        #t  ; Reached the end without errors, sequence is valid
-        (let ((byte (bytevector-u8-ref bv index)))
-          (cond
-           ;; 1-byte sequence (0xxxxxxx)
-           ((< byte #x80)
-            (validate-utf8 bv (+ index 1) end))
-           
-           ;; 2-byte sequence (110xxxxx 10xxxxxx)
-           ((< byte #xe0)
-            (if (>= (+ index 1) end)
-                index  ; Incomplete sequence
-                (let ((next-byte (bytevector-u8-ref bv (+ index 1))))
-                  (if (not (= (logand next-byte #xc0) #x80))
-                      index  ; Invalid continuation byte
-                      (validate-utf8 bv (+ index 2) end)))))
-           
-           ;; 3-byte sequence (1110xxxx 10xxxxxx 10xxxxxx)
-           ((< byte #xf0)
-            (if (>= (+ index 2) end)
-                index  ; Incomplete sequence
-                (let ((next-byte1 (bytevector-u8-ref bv (+ index 1)))
-                      (next-byte2 (bytevector-u8-ref bv (+ index 2))))
-                  (if (or (not (= (logand next-byte1 #xc0) #x80))
-                          (not (= (logand next-byte2 #xc0) #x80)))
-                      index  ; Invalid continuation byte(s)
-                      (validate-utf8 bv (+ index 3) end)))))
-           
-           ;; 4-byte sequence (11110xxx 10xxxxxx 10xxxxxx 10xxxxxx)
-           ((< byte #xf8)
-            (if (>= (+ index 3) end)
-                index  ; Incomplete sequence
-                (let ((next-byte1 (bytevector-u8-ref bv (+ index 1)))
-                      (next-byte2 (bytevector-u8-ref bv (+ index 2)))
-                      (next-byte3 (bytevector-u8-ref bv (+ index 3))))
-                  (if (or (not (= (logand next-byte1 #xc0) #x80))
-                          (not (= (logand next-byte2 #xc0) #x80))
-                          (not (= (logand next-byte3 #xc0) #x80)))
-                      index  ; Invalid continuation byte(s)
-                      (validate-utf8 bv (+ index 4) end)))))
-           
-           (else index)))))  ; Invalid leading byte
-  
   (if (or (< start 0) (> end (bytevector-length bv)) (> start end))
       (error 'out-of-range start end)
-      (let ((validation-result (validate-utf8 bv start end)))
-        (if (eq? validation-result #t)
-            (copy bv (make-string (- end start)) start end)
-            (error 'value-error
-                   "Invalid UTF-8 sequence at index: " validation-result)))))
+      (let loop ((pos start))
+        (let ((next-pos (bytevector-advance-u8 bv pos end)))
+          (cond
+           ((= next-pos end)
+            (copy bv (make-string (- end start)) start end))
+           ((= next-pos pos)
+            (error 'value-error "Invalid UTF-8 sequence at index: " pos))
+           (else
+            (loop next-pos)))))))
 
 (define (raise . args)
   (apply throw #t args))

--- a/goldfish/scheme/base.scm
+++ b/goldfish/scheme/base.scm
@@ -284,7 +284,7 @@
            ((and (not (zero? start)) (= cnt start))
             (loop next-pos (+ cnt 1) pos))
            ((and (integer? end) (= cnt end))
-            (copy bv (make-byte-vector (- pos start-pos)) pos next-pos))
+            (copy bv (make-byte-vector (- pos start-pos)) start-pos pos))
            ((and end (= next-pos N))
             (copy bv (make-byte-vector (- N start-pos)) start-pos N))
            ((= next-pos pos)

--- a/tests/goldfish/liii/base-test.scm
+++ b/tests/goldfish/liii/base-test.scm
@@ -279,6 +279,9 @@
 (check (utf8->string (string->utf8 "Hello" 1 2)) => "e")
 (check (utf8->string (string->utf8 "Hello" 0 2)) => "He")
 (check (utf8->string (string->utf8 "Hello" 2)) => "llo")
+(check (utf8->string (string->utf8 "Hello" 2 5)) => "llo")
+
+(check-catch 'out-of-range (string->utf8 "Hello" 2 6))
 
 (check (utf8->string (string->utf8 "汉字书写")) => "汉字书写")
 (check (utf8->string (string->utf8 "汉字书写" 1)) => "字书写")

--- a/tests/goldfish/liii/base-test.scm
+++ b/tests/goldfish/liii/base-test.scm
@@ -294,6 +294,10 @@
 (check (string->utf8 "中") => #u8(#xE4 #xB8 #xAD))
 (check (string->utf8 "👍") => #u8(#xF0 #x9F #x91 #x8D))
 
+(check (u8-substring "汉字书写" 0 1) => "汉")
+(check (u8-substring "汉字书写" 0 4) => "汉字书写")
+(check (u8-substring "汉字书写" 0) => "汉字书写")
+
 (check (apply + (list 3 4)) => 7)
 (check (apply + (list 2 3 4)) => 9)
 

--- a/tests/goldfish/liii/base-test.scm
+++ b/tests/goldfish/liii/base-test.scm
@@ -266,12 +266,20 @@
 
 (check-catch 'wrong-type-arg (bytevector 256))
 
+(check (u8-string-length "中文") => 2)
+
 (check (utf8->string (bytevector #x48 #x65 #x6C #x6C #x6F)) => "Hello")
 (check (utf8->string #u8(#xC3 #xA4)) => "ä")
 (check (utf8->string #u8(#xE4 #xB8 #xAD)) => "中")
 (check (utf8->string #u8(#xF0 #x9F #x91 #x8D)) => "👍")
 
 (check-catch 'value-error (utf8->string (bytevector #xFF #x65 #x6C #x6C #x6F)))
+
+(check (string->utf8 "Hello") => (bytevector #x48 #x65 #x6C #x6C #x6F))
+(check (string->utf8 "Hello" 1 2) => #u8(#x65))
+(check (string->utf8 "ä") => #u8(#xC3 #xA4))
+(check (string->utf8 "中") => #u8(#xE4 #xB8 #xAD))
+(check (string->utf8 "👍") => #u8(#xF0 #x9F #x91 #x8D))
 
 (check (apply + (list 3 4)) => 7)
 (check (apply + (list 2 3 4)) => 9)

--- a/tests/goldfish/liii/base-test.scm
+++ b/tests/goldfish/liii/base-test.scm
@@ -276,7 +276,17 @@
 (check-catch 'value-error (utf8->string (bytevector #xFF #x65 #x6C #x6C #x6F)))
 
 (check (string->utf8 "Hello") => (bytevector #x48 #x65 #x6C #x6C #x6F))
-(check (string->utf8 "Hello" 1 2) => #u8(#x65))
+(check (utf8->string (string->utf8 "Hello" 1 2)) => "e")
+(check (utf8->string (string->utf8 "Hello" 0 2)) => "He")
+(check (utf8->string (string->utf8 "Hello" 2)) => "llo")
+
+(check (utf8->string (string->utf8 "汉字书写")) => "汉字书写")
+(check (utf8->string (string->utf8 "汉字书写" 1)) => "字书写")
+(check (utf8->string (string->utf8 "汉字书写" 2)) => "书写")
+(check (utf8->string (string->utf8 "汉字书写" 3)) => "写")
+
+(check-catch 'out-of-range (string->utf8 "汉字书写" 4))
+
 (check (string->utf8 "ä") => #u8(#xC3 #xA4))
 (check (string->utf8 "中") => #u8(#xE4 #xB8 #xAD))
 (check (string->utf8 "👍") => #u8(#xF0 #x9F #x91 #x8D))


### PR DESCRIPTION
## What
+ u8-string-length
+ u8-substring
+ string->utf8

## Why
char type in S7 Scheme does not support unicode. As a result, `string-length` and `string-ref` should not support unicode. That's why I didn't rewrite string-length and string-ref to add unicode support.