### PR TITLE
bitwise-and and bitwise-or in (liii bitwise)

### DIFF
--- a/Goldfish.tmu
+++ b/Goldfish.tmu
@@ -1,4 +1,4 @@
-<TMU|<tuple|1.0.4|1.2.9.3-rc1>>
+<TMU|<tuple|1.0.3|1.2.9.2>>
 
 <style|<tuple|book|chinese|literate|goldfish|reduced-margins|guile|smart-ref|preview-ref>>
 
@@ -931,7 +931,7 @@
 
   <value|r7rs><paragraph|define-values><index|define-values>
 
-  <\scm-chunk|goldfish/scheme/base.scm|true|false>
+  <\scm-chunk|goldfish/scheme/base.scm|true|true>
     ; 0-clause BSD by Bill Schottstaedt from S7 source repo: s7test.scm
 
     (define-macro (define-values vars expression)
@@ -6904,6 +6904,252 @@
   </scm-chunk>
 
   <\scm-chunk|tests/goldfish/liii/list-test.scm|true|false>
+    (check-report)
+
+    \;
+  </scm-chunk>
+
+  \;
+
+  <chapter|(liii bitwise)><label|chapter:liii_bitwise>
+
+  <section|许可证>
+
+  <\scm-chunk|goldfish/liii/bitwise.scm|false|true>
+    ;
+
+    ; Copyright (C) 2024 The Goldfish Scheme Authors
+
+    ;
+
+    ; Licensed under the Apache License, Version 2.0 (the "License");
+
+    ; you may not use this file except in compliance with the License.
+
+    ; You may obtain a copy of the License at
+
+    ;
+
+    ; http://www.apache.org/licenses/LICENSE-2.0
+
+    ;
+
+    ; Unless required by applicable law or agreed to in writing, software
+
+    ; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+
+    ; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+
+    ; License for the specific language governing permissions and limitations
+
+    ; under the License.
+
+    ;
+
+    \;
+  </scm-chunk>
+
+  <\scm-chunk|goldfish/srfi/srfi-151.scm|false|true>
+    ;
+
+    ; Copyright (C) 2024 The Goldfish Scheme Authors
+
+    ;
+
+    ; Licensed under the Apache License, Version 2.0 (the "License");
+
+    ; you may not use this file except in compliance with the License.
+
+    ; You may obtain a copy of the License at
+
+    ;
+
+    ; http://www.apache.org/licenses/LICENSE-2.0
+
+    ;
+
+    ; Unless required by applicable law or agreed to in writing, software
+
+    ; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+
+    ; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+
+    ; License for the specific language governing permissions and limitations
+
+    ; under the License.
+
+    ;
+
+    \;
+  </scm-chunk>
+
+  <\scm-chunk|tests/goldfish/liii/bitwise-test.scm|false|true>
+    ;
+
+    ; Copyright (C) 2024 The Goldfish Scheme Authors
+
+    ;
+
+    ; Licensed under the Apache License, Version 2.0 (the "License");
+
+    ; you may not use this file except in compliance with the License.
+
+    ; You may obtain a copy of the License at
+
+    ;
+
+    ; http://www.apache.org/licenses/LICENSE-2.0
+
+    ;
+
+    ; Unless required by applicable law or agreed to in writing, software
+
+    ; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+
+    ; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+
+    ; License for the specific language governing permissions and limitations
+
+    ; under the License.
+
+    ;
+
+    \;
+  </scm-chunk>
+
+  <section|接口>
+
+  <\scm-chunk|goldfish/liii/bitwise.scm|true|false>
+    (define-library (liii bitwise)
+
+    (import (srfi srfi-151)
+
+    \ \ \ \ \ \ \ \ (liii error))
+
+    (export
+
+    \ \ ; S7 built-in
+
+    \ 
+
+    \ \ ; from (scheme base)
+
+    \ 
+
+    \ \ ; from (srfi srfi-151)
+
+    \ \ bitwise-and\ 
+
+    \ \ bitwise-or
+
+    )
+
+    (begin
+
+    ) ; end of begin
+
+    ) ; end of library
+
+    \;
+  </scm-chunk>
+
+  <\scm-chunk|goldfish/srfi/srfi-151.scm|true|true>
+    (define-library (srfi srfi-151)
+
+    (export bitwise-and bitwise-or)
+
+    (begin
+
+    \;
+  </scm-chunk>
+
+  <section|测试>
+
+  <\scm-chunk|tests/goldfish/liii/bitwise-test.scm|true|true>
+    (import (liii check)
+
+    \ \ \ \ \ \ \ \ (liii bitwise))
+
+    \;
+
+    (check-set-mode! 'report-failed)
+
+    \;
+  </scm-chunk>
+
+  <section|位逻辑运算>
+
+  \;
+
+  <label|srfi><paragraph|bitwise-and><index|bitwise-and>
+
+  使用S7内置的<with|font-family|tt|logand>实现。此函数应用<with|font-family|tt|and>运算在整数的二进制表示上。
+
+  <\scm-chunk|goldfish/srfi/srfi-151.scm|true|true>
+    (define bitwise-and logand)
+
+    \;
+  </scm-chunk>
+
+  <subparagraph|测试>
+
+  <\scm-chunk|tests/goldfish/liii/bitwise-test.scm|true|true>
+    (check (bitwise-and 5 3) =\<gtr\> 1) \ ; 5 (101) AND 3 (011) = 1 (001)
+
+    (check (bitwise-and 8 4) =\<gtr\> 0) \ ; 8 (1000) AND 4 (0100) = 0 (0000)
+
+    (check (bitwise-and #b101 #b011) =\<gtr\> 1) \ ; 5 (101) AND 3 (011) = 1 (001) \ 
+
+    (check (bitwise-and #b1000 #b0100) =\<gtr\> 0) ; 8 (1000) AND 4 (0100) = 0 (0000)
+
+    (check (bitwise-and #b1100 #b1010) =\<gtr\> 8)\ 
+
+    \;
+  </scm-chunk>
+
+  \;
+
+  <label|srfi><paragraph|bitwise-or><index|bitwise-or>
+
+  使用S7内置的<with|font-family|tt|logior>实现。此函数应用<with|font-family|tt|or>运算在整数的二进制表示上。
+
+  <\scm-chunk|goldfish/srfi/srfi-151.scm|true|true>
+    (define bitwise-or logior)
+
+    \;
+  </scm-chunk>
+
+  <subparagraph|测试>
+
+  <\scm-chunk|tests/goldfish/liii/bitwise-test.scm|true|true>
+    (check (bitwise-or 5 3) =\<gtr\> 7) \ ; 5 (101) OR 3 (011) = 7 (111)
+
+    (check (bitwise-or 8 4) =\<gtr\> 12) ; 8 (1000) OR 4 (0100) = 12 (1100)
+
+    (check (bitwise-or #b101 #b011) =\<gtr\> 7) \ ; 5 (101) AND 3 (011) = 1 (001) \ 
+
+    (check (bitwise-or #b1000 #b0100) =\<gtr\> 12) ; 8 (1000) AND 4 (0100) = 0 (0000)
+
+    (check (bitwise-or #b1100 #b0001) =\<gtr\> 13)
+
+    \;
+  </scm-chunk>
+
+  <section|结束>
+
+  <paragraph|SRFI-151 End>
+
+  <\scm-chunk|goldfish/srfi/srfi-151.scm|true|false>
+    ) ; end of begin
+
+    ) ; end of define-library
+
+    \;
+  </scm-chunk>
+
+  <paragraph|Report Test Result>
+
+  <\scm-chunk|tests/goldfish/liii/bitwise-test.scm|true|false>
     (check-report)
 
     \;

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Just like S7 Scheme, [src/goldfish.hpp](src/goldfish.hpp) and [src/goldfish.cpp]
 | `(srfi srfi-78)`  | Part | Lightweigted Test Framework |
 | `(srfi srfi-125)` | Part | Hash Table |
 | `(srfi srfi-133)` | Part | Vector |
+| `(srfi srfi-151)` | Part | Bitwise Operations |
 | `(srfi srfi-216)` | Part | SICP |
 
 ### R7RS Standard Libraries

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -43,6 +43,7 @@
 | `(srfi srfi-78)` | 部分 | 轻量级测试框架 |
 | `(srfi srfi-125)` | 部分 | 哈希表 |
 | `(srfi srfi-133)` | 部分 | 向量 |
+| `(srfi srfi-151)` | 部分 | 位运算 |
 | `(srfi srfi-216)` | 部分 | SICP |
 
 

--- a/goldfish/liii/bitwise.scm
+++ b/goldfish/liii/bitwise.scm
@@ -1,0 +1,32 @@
+;
+; Copyright (C) 2024 The Goldfish Scheme Authors
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+; http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+
+(define-library (liii bitwise)
+(import (srfi srfi-151)
+        (liii error))
+(export
+  ; S7 built-in
+ 
+  ; from (scheme base)
+ 
+  ; from (srfi srfi-151)
+  bitwise-and 
+  bitwise-or
+)
+(begin
+) ; end of begin
+) ; end of library
+

--- a/goldfish/srfi/srfi-151.scm
+++ b/goldfish/srfi/srfi-151.scm
@@ -1,0 +1,27 @@
+;
+; Copyright (C) 2024 The Goldfish Scheme Authors
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+; http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+
+(define-library (srfi srfi-151)
+(export bitwise-and bitwise-or)
+(begin
+
+(define bitwise-and logand)
+
+(define bitwise-or logior)
+
+) ; end of begin
+) ; end of define-library
+

--- a/tests/goldfish/liii/bitwise-test.scm
+++ b/tests/goldfish/liii/bitwise-test.scm
@@ -1,0 +1,35 @@
+;
+; Copyright (C) 2024 The Goldfish Scheme Authors
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+; http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+
+(import (liii check)
+        (liii bitwise))
+
+(check-set-mode! 'report-failed)
+
+(check (bitwise-and 5 3) => 1)  ; 5 (101) AND 3 (011) = 1 (001)
+(check (bitwise-and 8 4) => 0)  ; 8 (1000) AND 4 (0100) = 0 (0000)
+(check (bitwise-and #b101 #b011) => 1)  ; 5 (101) AND 3 (011) = 1 (001)  
+(check (bitwise-and #b1000 #b0100) => 0) ; 8 (1000) AND 4 (0100) = 0 (0000)
+(check (bitwise-and #b1100 #b1010) => 8) 
+
+(check (bitwise-or 5 3) => 7)  ; 5 (101) OR 3 (011) = 7 (111)
+(check (bitwise-or 8 4) => 12) ; 8 (1000) OR 4 (0100) = 12 (1100)
+(check (bitwise-or #b101 #b011) => 7)  ; 5 (101) AND 3 (011) = 1 (001)  
+(check (bitwise-or #b1000 #b0100) => 12) ; 8 (1000) AND 4 (0100) = 0 (0000)
+(check (bitwise-or #b1100 #b0001) => 13)
+
+(check-report)
+


### PR DESCRIPTION
1. added a new chapter/libary `(liii bitwise)`.
2. implemented `bitwise-and` and `bitwise-or` mentioned in [srfi-151.](https://srfi.schemers.org/srfi-151/srfi-151.html#Bitsconversion)