### PR TITLE
bitwise-or as an alias of bitwise-ior in (liii bitwise)

### DIFF
--- a/Goldfish.tmu
+++ b/Goldfish.tmu
@@ -7117,7 +7117,7 @@
 
   <section|接口>
 
-  <\scm-chunk|goldfish/liii/bitwise.scm|true|false>
+  <\scm-chunk|goldfish/liii/bitwise.scm|true|true>
     (define-library (liii bitwise)
 
     (import (srfi srfi-151)
@@ -7128,7 +7128,7 @@
 
     \ \ ; from (srfi srfi-151)
 
-    \ \ bitwise-not bitwise-and bitwise-ior bitwise-xor bitwise-nor bitwise-nand
+    \ \ bitwise-not bitwise-and bitwise-ior bitwise-xor bitwise-or bitwise-nor bitwise-nand
 
     \ \ arithmetic-shift
 
@@ -7141,10 +7141,6 @@
     )
 
     (begin
-
-    ) ; end of begin
-
-    ) ; end of library
 
     \;
   </scm-chunk>
@@ -7251,10 +7247,18 @@
     \;
   </scm-chunk>
 
+  <\scm-chunk|goldfish/liii/bitwise.scm|true|true>
+    (define bitwise-or bitwise-ior)
+
+    \;
+  </scm-chunk>
+
   <subparagraph|测试>
 
   <\scm-chunk|tests/goldfish/liii/bitwise-test.scm|true|true>
     (check (bitwise-ior 5 3) =\<gtr\> 7) \ ; 5 (101) OR 3 (011) = 7 (111)
+
+    (check (bitwise-or 5 3) =\<gtr\> 7)
 
     (check (bitwise-ior 8 4) =\<gtr\> 12) ; 8 (1000) OR 4 (0100) = 12 (1100)
 
@@ -7415,6 +7419,14 @@
     ) ; end of begin
 
     ) ; end of define-library
+
+    \;
+  </scm-chunk>
+
+  <\scm-chunk|goldfish/liii/bitwise.scm|true|false>
+    ) ; end of begin
+
+    ) ; end of library
 
     \;
   </scm-chunk>

--- a/goldfish/liii/bitwise.scm
+++ b/goldfish/liii/bitwise.scm
@@ -19,13 +19,16 @@
         (liii error))
 (export
   ; from (srfi srfi-151)
-  bitwise-not bitwise-and bitwise-ior bitwise-xor bitwise-nor bitwise-nand
+  bitwise-not bitwise-and bitwise-ior bitwise-xor bitwise-or bitwise-nor bitwise-nand
   arithmetic-shift
   ; S7 built-in
   lognot logand logior logxor
   ash
 )
 (begin
+
+(define bitwise-or bitwise-ior)
+
 ) ; end of begin
 ) ; end of library
 

--- a/tests/goldfish/liii/bitwise-test.scm
+++ b/tests/goldfish/liii/bitwise-test.scm
@@ -31,6 +31,7 @@
 (check (bitwise-and #b1100 #b1010) => 8) 
 
 (check (bitwise-ior 5 3) => 7)  ; 5 (101) OR 3 (011) = 7 (111)
+(check (bitwise-or 5 3) => 7)
 (check (bitwise-ior 8 4) => 12) ; 8 (1000) OR 4 (0100) = 12 (1100)
 (check (bitwise-ior #b101 #b011) => 7)  ; 5 (101) AND 3 (011) = 1 (001)  
 (check (bitwise-ior #b1000 #b0100) => 12) ; 8 (1000) AND 4 (0100) = 0 (0000)


### PR DESCRIPTION
## What
as title

## Why
bitwise-or is much more natural than bitwise-ior defined in SRFI 151.