### PR TITLE
Impl vector= in srfi 133

### DIFF
--- a/Goldfish.tmu
+++ b/Goldfish.tmu
@@ -9899,6 +9899,8 @@
 
   <paragraph|vector=>
 
+  使用给定的元素比较器 (elt) 在传入的待比较向量参数列表上进行比较。如果参数列表实际上不足两个，默认返回 true。如果在给定的元素比较器上，参数列表中有任意向量的某个元素不相等，返回 false。
+
   <\scm-chunk|goldfish/srfi/srfi-133.scm|true|true>
     ; (vector= elt=? vec ...) -\> boolean, srfi-133 support.\ 
 
@@ -9967,6 +9969,10 @@
     (check-false (vector= = '#(1 2 3 4 5) '#(1 2 3 4)))
 
     (check-true (vector= = '#(1 2 3 4) '#(1 2 3 4)))
+
+    (check-true (vector= equal? '#(1 2 3) '#(1 2 3) '#(1 2 3)))
+
+    (check-false (vector= equal? '#(1 2 3) '#(1 2 3) '#(1 2 3 4)))
 
     ; error cases
 

--- a/Goldfish.tmu
+++ b/Goldfish.tmu
@@ -9606,7 +9606,9 @@
 
     \ \ vector-index vector-index-right vector-partition
 
-    \ \ vector-swap! vector-cumulate reverse-list-\<gtr\>vector)
+    \ \ vector-swap! vector-cumulate reverse-list-\<gtr\>vector
+
+    \ \ vector=)
 
     (begin
 
@@ -9642,7 +9644,9 @@
 
     \ \ vector-index vector-index-right vector-partition
 
-    \ \ vector-swap! vector-cumulate reverse-list-\<gtr\>vector)
+    \ \ vector-swap! vector-cumulate reverse-list-\<gtr\>vector
+
+    \ \ vector=)
 
     (begin
 
@@ -9678,7 +9682,9 @@
 
     \ \ \ vector-index vector-index-right vector-partition
 
-    \ \ \ vector-swap! vector-cumulate reverse-list-\<gtr\>vector))
+    \ \ \ vector-swap! vector-cumulate reverse-list-\<gtr\>vector
+
+    \ \ \ vector=))
 
     \;
   </scm-chunk>
@@ -9893,7 +9899,87 @@
 
   <paragraph|vector=>
 
-  <todo|TODO>
+  <\scm-chunk|goldfish/srfi/srfi-133.scm|true|true>
+    ; (vector= elt=? vec ...) -\> boolean, srfi-133 support.\ 
+
+    ; Use the given element comparators to compare the input vectors.
+
+    ; When the input is null or just one vector, return #t.
+
+    ; Else, it will compare the vectors in the argument list one by one.
+
+    ; \ \ \ \ If all the vectors are equal under the elt's comparison, return #t, else #f.
+
+    (define (vector= elt . rest)
+
+    \ \ ; The inner method provides type-check and two vectors comparison.
+
+    \ \ (define compare2vecs
+
+    \ \ \ \ (typed-lambda ((cmp procedure?) (vec1 vector?) (vec2 vector?))
+
+    \ \ \ \ \ \ (let* \ ((len1 (vector-length vec1))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ (len2 (vector-length vec2)))
+
+    \ \ \ \ \ \ \ \ (if (not (= len1 len2)) #f
+
+    \ \ \ \ \ \ \ \ \ \ \ \ (let loop ((ilhs 0) (irhs 0) (imax len1))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (if (= ilhs imax) #t
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (if (not (cmp (vec1 ilhs) (vec2 irhs))) #f
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (loop (+ 1 ilhs) (+ 1 irhs) imax))))))))
+
+    \ \ (if (not (procedure? elt)) (error 'type-error "elt should be a procedure")
+
+    \ \ \ \ \ \ (if (or(null? rest) (= 1 (length rest))) #t
+
+    \ \ \ \ \ \ \ \ \ \ (let loop ((vec1 (car rest))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (vec2 (car (cdr rest)))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (vrest (cdr (cdr rest))))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (if (compare2vecs elt vec1 vec2)
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (if (null? vrest) #t
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (loop vec2 (car vrest) (cdr vrest)))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ #f)))))
+  </scm-chunk>
+
+  <\scm-chunk|tests/goldfish/liii/vector-test.scm|true|true>
+    ; trivial cases
+
+    (check-true (vector= eq?))
+
+    (check-true (vector= eq? '#(a)))
+
+    ; basic cases
+
+    (check-true (vector= eq? '#(a b c d) '#(a b c d)))
+
+    (check-false (vector= eq? '#(a b c d) '#(a b d c)))
+
+    (check-false (vector= = '#(1 2 3 4 5) '#(1 2 3 4)))
+
+    (check-true (vector= = '#(1 2 3 4) '#(1 2 3 4)))
+
+    ; error cases
+
+    (check-catch 'type-error (vector= 1 (vector (vector 'a)) (vector (vector 'a))))
+
+    ; complex cases in srfi-133
+
+    (check-true (vector= equal? (vector (vector 'a)) (vector (vector 'a))))
+
+    (check-false (vector= eq? (vector (vector 'a)) (vector (vector 'a))))
+  </scm-chunk>
+
+  \;
 
   <subsection|选择器>
 

--- a/Goldfish.tmu
+++ b/Goldfish.tmu
@@ -9899,58 +9899,48 @@
 
   <paragraph|vector=>
 
-  使用给定的元素比较器 (elt) 在传入的待比较向量参数列表上进行比较。如果参数列表实际上不足两个，默认返回 true。如果在给定的元素比较器上，参数列表中有任意向量的某个元素不相等，返回 false。
+  使用一个元素比较器 (elt=?) 来比较传入的一组向量是否相等。当传入的向量不足两个的时候默认返回相等。元素比较器 elt=? 以及内置的比较器运算的结果都是 boolean，否则都会抛出类型错误。
+
+  因为比较一组向量是否全部相等，可以通过不断比较相邻两个来实现。所以这里的具体实现中，定义了一个名为 compare2vecs 的 内部 procedure ，它可以使用 elt=? 进行向量的两两比较。
 
   <\scm-chunk|goldfish/srfi/srfi-133.scm|true|true>
-    ; (vector= elt=? vec ...) -\> boolean, srfi-133 support.\ 
-
-    ; Use the given element comparators to compare the input vectors.
-
-    ; When the input is null or just one vector, return #t.
-
-    ; Else, it will compare the vectors in the argument list one by one.
-
-    ; \ \ \ \ If all the vectors are equal under the elt's comparison, return #t, else #f.
-
-    (define (vector= elt . rest)
-
-    \ \ ; The inner method provides type-check and two vectors comparison.
+    (define (vector= elt=? . rest)
 
     \ \ (define compare2vecs
 
     \ \ \ \ (typed-lambda ((cmp procedure?) (vec1 vector?) (vec2 vector?))
 
-    \ \ \ \ \ \ (let* \ ((len1 (vector-length vec1))
+    \ \ \ \ \ \ \ (let* \ ((len1 (vector-length vec1))
 
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ (len2 (vector-length vec2)))
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (len2 (vector-length vec2)))
 
-    \ \ \ \ \ \ \ \ (if (not (= len1 len2)) #f
+    \ \ \ \ \ \ \ \ \ (if (not (= len1 len2)) #f
 
-    \ \ \ \ \ \ \ \ \ \ \ \ (let loop ((ilhs 0) (irhs 0) (imax len1))
+    \ \ \ \ \ \ \ \ \ \ \ \ \ (let loop ((ilhs 0) (irhs 0) (len len1))
 
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (if (= ilhs imax) #t
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (if (= ilhs len) #t
 
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (if (not (cmp (vec1 ilhs) (vec2 irhs))) #f
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (if (not (cmp (vec1 ilhs) (vec2 irhs))) #f\ 
 
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (loop (+ 1 ilhs) (+ 1 irhs) imax))))))))
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (loop (+ 1 ilhs) (+ 1 irhs) len))))))))
 
-    \ \ (if (not (procedure? elt)) (error 'type-error "elt should be a procedure")
+    \ \ (when (not (procedure? elt=?)) (error 'type-error "elt=? should be a procedure"))
 
-    \ \ \ \ \ \ (if (or(null? rest) (= 1 (length rest))) #t
+    \ \ (if (or(null? rest) (= 1 (length rest))) #t
 
-    \ \ \ \ \ \ \ \ \ \ (let loop ((vec1 (car rest))
+    \ \ \ \ \ \ (let loop ((vec1 (car rest)) (vec2 (car (cdr rest))) (vrest (cdr (cdr rest))))
 
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (vec2 (car (cdr rest)))
+    \ \ \ \ \ \ \ \ (let1 rst (compare2vecs elt=? vec1 vec2)
 
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (vrest (cdr (cdr rest))))
+    \ \ \ \ \ \ \ \ \ \ \ (when (not (boolean? rst)) (error 'type-error "elt=\<gtr\> should return bool"))
 
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (if (compare2vecs elt vec1 vec2)
+    \ \ \ \ \ \ \ \ \ \ \ (if (compare2vecs elt=? vec1 vec2)
 
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (if (null? vrest) #t
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (if (null? vrest) #t
 
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (loop vec2 (car vrest) (cdr vrest)))
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (loop vec2 (car vrest) (cdr vrest)))
 
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ #f)))))
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ #f)))))
   </scm-chunk>
 
   <\scm-chunk|tests/goldfish/liii/vector-test.scm|true|true>

--- a/goldfish/liii/vector.scm
+++ b/goldfish/liii/vector.scm
@@ -28,7 +28,8 @@
   vector-count
   vector-any vector-every vector-copy vector-copy!
   vector-index vector-index-right vector-partition
-  vector-swap! vector-cumulate reverse-list->vector)
+  vector-swap! vector-cumulate reverse-list->vector
+  vector=)
 (begin
 
 ) ; end of begin

--- a/goldfish/srfi/srfi-133.scm
+++ b/goldfish/srfi/srfi-133.scm
@@ -30,31 +30,25 @@
     (error 'type-error "v is not a vector"))
   (zero? (vector-length v)))
 
-; (vector= elt=? vec ...) -> boolean, srfi-133 support. 
-; Use the given element comparators to compare the input vectors.
-; When the input is null or just one vector, return #t.
-; Else, it will compare the vectors in the argument list one by one.
-;     If all the vectors are equal under the elt's comparison, return #t, else #f.
-(define (vector= elt . rest)
-  ; The inner method provides type-check and two vectors comparison.
+(define (vector= elt=? . rest)
   (define compare2vecs
     (typed-lambda ((cmp procedure?) (vec1 vector?) (vec2 vector?))
-      (let*  ((len1 (vector-length vec1))
-              (len2 (vector-length vec2)))
-        (if (not (= len1 len2)) #f
-            (let loop ((ilhs 0) (irhs 0) (imax len1))
-                 (if (= ilhs imax) #t
-                     (if (not (cmp (vec1 ilhs) (vec2 irhs))) #f
-                         (loop (+ 1 ilhs) (+ 1 irhs) imax))))))))
-  (if (not (procedure? elt)) (error 'type-error "elt should be a procedure")
-      (if (or(null? rest) (= 1 (length rest))) #t
-          (let loop ((vec1 (car rest))
-                     (vec2 (car (cdr rest)))
-                     (vrest (cdr (cdr rest))))
-               (if (compare2vecs elt vec1 vec2)
-                   (if (null? vrest) #t
-                       (loop vec2 (car vrest) (cdr vrest)))
-                   #f)))))
+       (let*  ((len1 (vector-length vec1))
+               (len2 (vector-length vec2)))
+         (if (not (= len1 len2)) #f
+             (let loop ((ilhs 0) (irhs 0) (len len1))
+                  (if (= ilhs len) #t
+                      (if (not (cmp (vec1 ilhs) (vec2 irhs))) #f 
+                          (loop (+ 1 ilhs) (+ 1 irhs) len))))))))
+  (when (not (procedure? elt=?)) (error 'type-error "elt=? should be a procedure"))
+  (if (or(null? rest) (= 1 (length rest))) #t
+      (let loop ((vec1 (car rest)) (vec2 (car (cdr rest))) (vrest (cdr (cdr rest))))
+        (let1 rst (compare2vecs elt=? vec1 vec2)
+           (when (not (boolean? rst)) (error 'type-error "elt=> should return bool"))
+           (if (compare2vecs elt=? vec1 vec2)
+               (if (null? vrest) #t
+                   (loop vec2 (car vrest) (cdr vrest)))
+               #f)))))
 ; TODO optional parameters
 (define (vector-count pred v)
   (let loop ((i 0) (count 0))

--- a/goldfish/srfi/srfi-133.scm
+++ b/goldfish/srfi/srfi-133.scm
@@ -21,7 +21,8 @@
   vector-count
   vector-any vector-every vector-copy vector-copy!
   vector-index vector-index-right vector-partition
-  vector-swap! vector-cumulate reverse-list->vector)
+  vector-swap! vector-cumulate reverse-list->vector
+  vector=)
 (begin
 
 (define (vector-empty? v)
@@ -29,6 +30,31 @@
     (error 'type-error "v is not a vector"))
   (zero? (vector-length v)))
 
+; (vector= elt=? vec ...) -> boolean, srfi-133 support. 
+; Use the given element comparators to compare the input vectors.
+; When the input is null or just one vector, return #t.
+; Else, it will compare the vectors in the argument list one by one.
+;     If all the vectors are equal under the elt's comparison, return #t, else #f.
+(define (vector= elt . rest)
+  ; The inner method provides type-check and two vectors comparison.
+  (define compare2vecs
+    (typed-lambda ((cmp procedure?) (vec1 vector?) (vec2 vector?))
+      (let*  ((len1 (vector-length vec1))
+              (len2 (vector-length vec2)))
+        (if (not (= len1 len2)) #f
+            (let loop ((ilhs 0) (irhs 0) (imax len1))
+                 (if (= ilhs imax) #t
+                     (if (not (cmp (vec1 ilhs) (vec2 irhs))) #f
+                         (loop (+ 1 ilhs) (+ 1 irhs) imax))))))))
+  (if (not (procedure? elt)) (error 'type-error "elt should be a procedure")
+      (if (or(null? rest) (= 1 (length rest))) #t
+          (let loop ((vec1 (car rest))
+                     (vec2 (car (cdr rest)))
+                     (vrest (cdr (cdr rest))))
+               (if (compare2vecs elt vec1 vec2)
+                   (if (null? vrest) #t
+                       (loop vec2 (car vrest) (cdr vrest)))
+                   #f)))))
 ; TODO optional parameters
 (define (vector-count pred v)
   (let loop ((i 0) (count 0))

--- a/tests/goldfish/liii/vector-test.scm
+++ b/tests/goldfish/liii/vector-test.scm
@@ -71,6 +71,8 @@
 (check-false (vector= eq? '#(a b c d) '#(a b d c)))
 (check-false (vector= = '#(1 2 3 4 5) '#(1 2 3 4)))
 (check-true (vector= = '#(1 2 3 4) '#(1 2 3 4)))
+(check-true (vector= equal? '#(1 2 3) '#(1 2 3) '#(1 2 3)))
+(check-false (vector= equal? '#(1 2 3) '#(1 2 3) '#(1 2 3 4)))
 ; error cases
 (check-catch 'type-error (vector= 1 (vector (vector 'a)) (vector (vector 'a))))
 ; complex cases in srfi-133

--- a/tests/goldfish/liii/vector-test.scm
+++ b/tests/goldfish/liii/vector-test.scm
@@ -27,7 +27,8 @@
    vector-count
    vector-any vector-every vector-copy vector-copy!
    vector-index vector-index-right vector-partition
-   vector-swap! vector-cumulate reverse-list->vector))
+   vector-swap! vector-cumulate reverse-list->vector
+   vector=))
 
 (check-true (vector? (int-vector 1 2 3)))
 (check-catch 'wrong-type-arg (int-vector 1 2 'a))
@@ -62,6 +63,19 @@
 (check-false (vector-empty? (vector 1)))
 (check-catch 'type-error (vector-empty? 1))
 
+; trivial cases
+(check-true (vector= eq?))
+(check-true (vector= eq? '#(a)))
+; basic cases
+(check-true (vector= eq? '#(a b c d) '#(a b c d)))
+(check-false (vector= eq? '#(a b c d) '#(a b d c)))
+(check-false (vector= = '#(1 2 3 4 5) '#(1 2 3 4)))
+(check-true (vector= = '#(1 2 3 4) '#(1 2 3 4)))
+; error cases
+(check-catch 'type-error (vector= 1 (vector (vector 'a)) (vector (vector 'a))))
+; complex cases in srfi-133
+(check-true (vector= equal? (vector (vector 'a)) (vector (vector 'a))))
+(check-false (vector= eq? (vector (vector 'a)) (vector (vector 'a))))
 (check
   (let ((lst (make-list 5)))
     (vector-for-each


### PR DESCRIPTION
I implement the vector= elt in srfi-133 (https://srfi.schemers.org/srfi-133/srfi-133.html#vector-eq).

The implement uses a inner compare two vectors method, and checks the type of DotList input.

When the input has a length less than 2 vectors, it return #t.

Otherwise, it compare the vectors use the compare2vec method one by one.