### PR TITLE
Fix: Bug: SRFI 1 fold and fold-right #190

### DIFF
--- a/goldfish/srfi/srfi-1.scm
+++ b/goldfish/srfi/srfi-1.scm
@@ -141,22 +141,32 @@
     (if (null-list? lis) i
         (lp (cdr lis) (if (pred (car lis)) (+ i 1) i)))))
 
-(define (fold f initial l)
-  (when (not (procedure? f))
-    (error 'type-error "The first param must be a procedure"))
-  (if (null? l)
-      initial
-      (fold f
-            (f (car l) initial)
-            (cdr l))))
+(define (fold f accum . lsts)
+  (if (eq? 1 (length lsts))
+    (let loop ((op f) (acc accum) (lst (car lsts)))
+      (if (null? lst) acc
+        (loop f 
+          (f (car lst) acc) 
+          (cdr lst))))
+    (if (any null? lsts)
+      accum
+      (let* ((heads (map car lsts))
+             (lsts' (map cdr lsts))
+             (accum' (apply f (list (apply f heads) accum))))
+        (apply fold f accum' lsts')))))
 
-(define (fold-right f initial l)
-  (if (null? l)
-    initial
-    (f (car l)
-        (fold-right f
-                    initial
-                    (cdr l)))))
+(define (fold-right f accum . lsts)
+  (if (eq? 1 (length lsts))
+    (let loop ((op f) (acc accum) (lst (car lsts)))
+      (if (null? lst) acc
+        (f (car lst) 
+          (loop f accum (cdr lst)))))
+    (if (any null? lsts)
+      accum
+      (let* ((heads (map car lsts))
+             (lsts' (map cdr lsts))
+             (accum' (apply f heads)))
+        (apply f (list accum' (apply fold-right f accum lsts')))))))
 
 (define (reduce f initial l)
   (if (null-list? l) initial

--- a/tests/goldfish/liii/list-test.scm
+++ b/tests/goldfish/liii/list-test.scm
@@ -170,9 +170,11 @@
 (check (fold + 0 '(1 2 3 4)) => 10)
 (check (fold + 0 '()) => 0)
 
-(check-catch 'type-error (fold 0 + '(1 2 3 4)))
+(check-catch 'syntax-error (fold 0 + '(1 2 3 4)))
 
-(check (fold cons () '(1 2 3 4)) => '(4 3 2 1))
+(check (fold cons '() '(1 2 3 4)) => '(4 3 2 1))
+
+(check (fold cons '() '(1 2 3 4) '(a b c)) => '((3 . c) (2 . b) (1 . a)))
 
 (check
   (fold (lambda (x count) (if (symbol? x) (+ count 1) count))
@@ -181,6 +183,8 @@
   => 2)
 
 (check (fold-right + 0 '(1 2 3 4)) => 10)
+
+(check (fold-right cons '() '(a b c) '(1 2 3 4 5)) => '((a . 1) (b . 2) (c . 3)))
 
 (check (fold-right + 0 '()) => 0)
 


### PR DESCRIPTION
I implement the fold, fold-right for variant parameters. I added two simple cases provided by the srfi-1 about the cons. As I didn't find an "unpack", I use "apply" to represent. As I'm not very familiar with variant parameters, please check them.
@Ancker-0 @da-liii 