### PR TITLE
Add setter for case class

### DIFF
--- a/GoldfishLang.tmu
+++ b/GoldfishLang.tmu
@@ -1,4 +1,4 @@
-<TMU|<tuple|1.1.0|2025.0.4>>
+<TMU|<tuple|1.0.5|1.2.9.8>>
 
 <style|<tuple|book|goldfish|literate|reduced-margins|python|padded-paragraphs|chinese>>
 
@@ -494,7 +494,11 @@
 
     \;
 
-    \ \ (instance-dispatcher)
+    \ \ ,(if (in? '%setter instance-method-symbols)
+
+    \ \ \ \ \ '(dilambda (instance-dispatcher) %setter)
+
+    \ \ \ \ \ '(instance-dispatcher))
 
     ) ; end of the internal typed define
 
@@ -2013,6 +2017,26 @@
     \;
   </goldfish-chunk>
 
+  <paragraph|rich-string%setter>
+
+  <\goldfish-chunk|goldfish/liii/lang.scm|true|true>
+    (define (%setter n v)
+
+    \ \ (set! (data n) v))
+
+    \;
+  </goldfish-chunk>
+
+  <\goldfish-chunk|tests/goldfish/liii/lang-test.scm|true|true>
+    (let ((str ($ "hello")))
+
+    \ \ \ \ \ \ \ (set! (str 0) #\\H)
+
+    \ \ \ \ \ \ \ (check str =\<gtr\> ($ "Hello")))
+
+    \;
+  </goldfish-chunk>
+
   <subsection|谓词>
 
   <paragraph|rich-string%equals>
@@ -2837,7 +2861,27 @@
     \;
   </goldfish-chunk>
 
+  <paragraph|rich-list%setter>
+
+  <\scm-chunk|goldfish/liii/lang.scm|true|true>
+    (define (%setter n v)
+
+    \ \ (set! (data n) v))
+
+    \;
+  </scm-chunk>
+
   \;
+
+  <\goldfish-chunk|tests/goldfish/liii/lang-test.scm|true|true>
+    (let ((lst ($ '(2 3 4))))
+
+    \ \ \ \ \ \ \ (set! (lst 2) 3)
+
+    \ \ \ \ \ \ \ (check lst =\<gtr\> ($ '(2 3 3))))
+
+    \;
+  </goldfish-chunk>
 
   <subsection|谓词>
 
@@ -3703,6 +3747,26 @@
     (check ($ (vector 1 2 3) :last-option) =\> (option 3))
 
     (check (rich-vector :empty :last-option) =\> (none))
+
+    \;
+  </scm-chunk>
+
+  <paragraph|rich-vector%setter>
+
+  <\scm-chunk|goldfish/liii/lang.scm|true|true>
+    (define (%setter n v)
+
+    \ \ (set! (data n) v))
+
+    \;
+  </scm-chunk>
+
+  <\scm-chunk|tests/goldfish/liii/lang-test.scm|true|true>
+    (let ((vec ($ (vector 2 3 4))))
+
+    \ \ \ \ \ \ \ (set! (vec 2) 3)
+
+    \ \ \ \ \ \ \ (check vec =\<gtr\> ($ (vector 2 3 3))))
 
     \;
   </scm-chunk>

--- a/goldfish/liii/lang.scm
+++ b/goldfish/liii/lang.scm
@@ -144,7 +144,9 @@
 
         (else (apply %apply (cons msg args))))))
 
-  (instance-dispatcher)
+  ,(if (in? '%setter instance-method-symbols)
+     '(dilambda (instance-dispatcher) %setter)
+     '(instance-dispatcher))
 ) ; end of the internal typed define
 
 (if (in? msg (list ,@static-messages))
@@ -422,6 +424,9 @@
 (typed-define (%apply (i integer?))
   (%char-at i))
 
+(define (%setter n v)
+  (set! (data n) v))
+
 (define (%empty?)
   (string-null? data))
 
@@ -604,6 +609,9 @@
       (none)
       (option (car data))))
 
+
+(define (%setter n v)
+  (set! (data n) v))
 
 (define (%empty?)
   (null? data))
@@ -802,6 +810,9 @@
     (if (> len 0)
       (option (vector-ref data (- len 1)))
       (none))))
+
+(define (%setter n v)
+  (set! (data n) v))
 
 (define (%empty?)
   (= (length data) 0))

--- a/tests/goldfish/liii/lang-test.scm
+++ b/tests/goldfish/liii/lang-test.scm
@@ -293,6 +293,10 @@
    (check (str 0) => ($ #\H))
    (check (str 7) => (rich-char "界")))
 
+(let ((str ($ "hello")))
+       (set! (str 0) #\H)
+       (check str => ($ "Hello")))
+
 (check ($ "42") => ($ "42"))
 (check-false ($ "41" :equals ($ "42")))
 
@@ -427,6 +431,10 @@
 (check ($ (list 1 2 3) :head-option) => (option 1))
 (check (rich-list :empty :head-option) => (none))
 
+(let ((lst ($ '(2 3 4))))
+       (set! (lst 2) 3)
+       (check lst => ($ '(2 3 3))))
+
 (check-true ($ (list) :empty?))
 (check-false ($ '(1 2 3) :empty?))
 
@@ -560,6 +568,10 @@
 (check-catch 'out-of-range (rich-vector :empty :last))
 (check ($ (vector 1 2 3) :last-option) => (option 3))
 (check (rich-vector :empty :last-option) => (none))
+
+(let ((vec ($ (vector 2 3 4))))
+       (set! (vec 2) 3)
+       (check vec => ($ (vector 2 3 3))))
 
 (check-true ($ (vector) :empty?))
 (check-false ($ #(1 2 3) :empty?))


### PR DESCRIPTION
Implemented `rich-list%setter`, `rich-vector%setter` and `rich-string%setter`. Now it supports grammar like
```
(define vec ($ (vector 1 2 3)))
(set! (vec 0) 2)
```
Using s7 scheme [`setter`](https://ccrma.stanford.edu/software/snd/snd/s7.html#pws) and `dilambda`. Modified define-case-class so that `%setter` is a special function for setter grammar.