### PR TITLE
一个关于导入模块的小问题

### DIFF
--- a/goldfish/srfi/srfi-132.scm
+++ b/goldfish/srfi/srfi-132.scm
@@ -23,55 +23,63 @@
         (scheme case-lambda))
 (begin
 
-  (define (list-sorted? less-p lis)
-    (if (null? lis)
-      #t
-      (do ((first lis (cdr first))
-           (second (cdr lis) (cdr second))
-           (res #t (not (less-p (car second) (car first)))))
-        ((or (null? second) (not res)) res))))
-
-  ; TODO optional parameters
-  (define (vector-sorted? less-p v)
-    (let ((start 0)
-          (end (length v)))
-      (do ((first start (+ 1 first))
-           (second (+ 1 start) (+ 1 second))
-           (res #t (not (less-p (vector-ref v second) (vector-ref v first)))))
-        ((or (>= second end) (not res)) res))))
-
-  (define (list-merge less-p lis1 lis2)
-    (let loop
-      ((res '())
-       (lis1 lis1)
-       (lis2 lis2))
-      (cond
-        ((and (null? lis1) (null? lis2)) (reverse res))
-        ((null? lis1) (loop (cons (car lis2) res) lis1 (cdr lis2)))
-        ((null? lis2) (loop (cons (car lis1) res) lis2 (cdr lis1)))
-        ((less-p (car lis2) (car lis1)) (loop (cons (car lis2) res) lis1 (cdr lis2)))
-        (else (loop (cons (car lis1) res) (cdr lis1) lis2)))))
-
-  ; this list-merge! violates SRFI 132, since it does not satisfy the constant running space
-  ; constraint specified in SRFI 132, and does not work "in place"
-  (define list-merge! list-merge)
-
-  (define (list-stable-sort less-p lis)
-    (define (sort l r)
-      (cond
-        ((= l r) '())
-        ((= (+ l 1) r) (list (list-ref lis l)))
-        (else
-          (let* ((mid (quotient (+ l r) 2))
-                 (l-sorted (sort l mid))
-                 (r-sorted (sort mid r)))
-            (list-merge less-p l-sorted r-sorted)))))
-    (sort 0 (length lis)))
-
-  (define list-sort list-stable-sort)
-  (define list-sort! list-stable-sort)
-  (define list-stable-sort! list-stable-sort)
-
+    (define (list-sorted? less-p lis)
+      (if (null? lis)
+        #t
+        (do ((first lis (cdr first))
+            (second (cdr lis) (cdr second))
+            (res #t (not (less-p (car second) (car first)))))
+          ((or (null? second) (not res)) res))))
+    (define vector-sorted?
+      (case-lambda
+        ((less-p v) (vector-sorted? less-p v 0 (vector-length v)))
+        ((less-p v start) (vector-sorted? less-p v start (vector-length v)))
+        ((less-p v start end)
+          (if (or (< start 0) (> end (vector-length v)) (> start end))
+            (error "Invalid start or end parameters")
+            (do ((first start (+ 1 first))
+                (second (+ 1 start) (+ 1 second))
+                (res #t (not (less-p (vector-ref v second) (vector-ref v first)))))
+              ((or (>= second end) (not res)) res))))))
+    (define (list-merge less-p lis1 lis2)
+      (let loop ((res '())
+          (lis1 lis1)
+          (lis2 lis2))
+        (cond
+          ((and (null? lis1) (null? lis2)) (reverse res))
+          ((null? lis1) (loop (cons (car lis2) res) lis1 (cdr lis2)))
+          ((null? lis2) (loop (cons (car lis1) res) lis2 (cdr lis1)))
+          ((less-p (car lis2) (car lis1)) (loop (cons (car lis2) res) lis1 (cdr lis2)))
+          (else (loop (cons (car lis1) res) (cdr lis1) lis2)))))
+    (define list-merge! less-p lis1 lis2)
+    (define (merge! left right)
+      (let loop ((left left) (right right) (prev '()))
+        (cond
+          ((null? left) (set-cdr! prev right))
+          ((null? right) (set-cdr! prev left))
+          ((less-p (car left) (car right))
+            (set-cdr! prev left)
+            (loop (cdr left) right left))
+          (else
+            (set-cdr! prev right)
+            (loop left (cdr right) right)))))
+    (let ((dummy (cons '() '())))
+      (merge! lis1 lis2 dummy)
+      (cdr dummy))
+    (define (list-stable-sort less-p lis)
+      (define (sort l r)
+        (cond
+          ((= l r) '())
+          ((= (+ l 1) r) (list (list-ref lis l)))
+          (else
+            (let* ((mid (quotient (+ l r) 2))
+                (l-sorted (sort l mid))
+                (r-sorted (sort mid r)))
+              (list-merge less-p l-sorted r-sorted)))))
+      (sort 0 (length lis)))
+    (define list-sort list-stable-sort)
+    (define list-sort! list-stable-sort)
+    (define list-stable-sort! list-stable-sort)
   (define vector-stable-sort
     (case-lambda
       ((less-p v)

--- a/liii_sort.tmu
+++ b/liii_sort.tmu
@@ -1,4 +1,4 @@
-<TMU|<tuple|1.0.5|1.2.9.8>>
+<TMU|<tuple|1.0.5|1.2.9.7>>
 
 <style|<tuple|generic|chinese|goldfish|literate|reduced-margins>>
 
@@ -159,112 +159,158 @@
 
   <subsection|list-sorted?, vector-sorted?>
 
-  判断 list 或 vector 是否有序。<todo|<verbatim|vector-sorted?> 尚未实现可选参数 start 和 end。>
+  检查列表/向量是否按比较函数 less-p 排序。
+
+  list-sorted?
+
+  <\indent>
+    检查列表 <code*|lis> 是否已按比较函数 <code*|less-p> 排序。如果列表已排序，返回 <code*|#t>，否则返回 <code*|#f>。
+  </indent>
+
+  vector-sorted?
+
+  <\indent>
+    检查向量 <code*|v> 是否已按比较函数 <code*|less-p> 排序。如果向量已排序，返回 <code*|#t>，否则返回 <code*|#f>。支持可选参数 <code*|start> 和 <code*|end>，用于指定检查的范围。
+  </indent>
 
   <\scm-chunk|goldfish/srfi/srfi-132.scm|true|true>
-    \ \ (define (list-sorted? less-p lis)
+    \ \ \ \ (define (list-sorted? less-p lis)
 
-    \ \ \ \ (if (null? lis)
+    \ \ \ \ \ \ (if (null? lis)
 
-    \ \ \ \ \ \ #t
+    \ \ \ \ \ \ \ \ #t
 
-    \ \ \ \ \ \ (do ((first lis (cdr first))
+    \ \ \ \ \ \ \ \ (do ((first lis (cdr first))
 
-    \ \ \ \ \ \ \ \ \ \ \ (second (cdr lis) (cdr second))
+    \ \ \ \ \ \ \ \ \ \ \ \ (second (cdr lis) (cdr second))
 
-    \ \ \ \ \ \ \ \ \ \ \ (res #t (not (less-p (car second) (car first)))))
+    \ \ \ \ \ \ \ \ \ \ \ \ (res #t (not (less-p (car second) (car first)))))
 
-    \ \ \ \ \ \ \ \ ((or (null? second) (not res)) res))))
+    \ \ \ \ \ \ \ \ \ \ ((or (null? second) (not res)) res))))
 
-    \;
+    \ \ \ \ (define vector-sorted?
 
-    \ \ ; TODO optional parameters
+    \ \ \ \ \ \ (case-lambda
 
-    \ \ (define (vector-sorted? less-p v)
+    \ \ \ \ \ \ \ \ ((less-p v) (vector-sorted? less-p v 0 (vector-length v)))
 
-    \ \ \ \ (let ((start 0)
+    \ \ \ \ \ \ \ \ ((less-p v start) (vector-sorted? less-p v start (vector-length v)))
 
-    \ \ \ \ \ \ \ \ \ \ (end (length v)))
+    \ \ \ \ \ \ \ \ ((less-p v start end)
 
-    \ \ \ \ \ \ (do ((first start (+ 1 first))
+    \ \ \ \ \ \ \ \ \ \ (if (or (\<less\> start 0) (\<gtr\> end (vector-length v)) (\<gtr\> start end))
 
-    \ \ \ \ \ \ \ \ \ \ \ (second (+ 1 start) (+ 1 second))
+    \ \ \ \ \ \ \ \ \ \ \ \ (error "Invalid start or end parameters")
 
-    \ \ \ \ \ \ \ \ \ \ \ (res #t (not (less-p (vector-ref v second) (vector-ref v first)))))
+    \ \ \ \ \ \ \ \ \ \ \ \ (do ((first start (+ 1 first))
 
-    \ \ \ \ \ \ \ \ ((or (\<gtr\>= second end) (not res)) res))))
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (second (+ 1 start) (+ 1 second))
 
-    \;
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (res #t (not (less-p (vector-ref v second) (vector-ref v first)))))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ ((or (\<gtr\>= second end) (not res)) res))))))
   </scm-chunk>
 
-  <subsection|list-merge, list-sort, list-stable-sort>
+  <subsection|list-merge, list-merge!, list-sort, list-stable-sort>
 
   归并排序。需要注意 <verbatim|list-sort!> 不必修改原 list，但 <verbatim|vector-sort!> 要保证修改原 vector。
 
+  list-merge
+
+  <\indent>
+    合并两个已排序的列表，返回一个新的已排序列表。
+  </indent>
+
+  list-merge!
+
+  <\indent>
+    合并两个已排序的列表，并直接修改 <code*|lis1> 和 <code*|lis2> 的 <code*|cdr> 指针，返回合并后的列表。这是一个就地操作。
+  </indent>
+
+  list-stable-sort
+
+  <\indent>
+    对列表进行稳定排序（相等元素相对顺序保持不变），返回一个新的已排序列表。
+  </indent>
+
   <\scm-chunk|goldfish/srfi/srfi-132.scm|true|true>
-    \ \ (define (list-merge less-p lis1 lis2)
+    \ \ \ \ (define (list-merge less-p lis1 lis2)
 
-    \ \ \ \ (let loop
+    \ \ \ \ \ \ (let loop ((res '())
 
-    \ \ \ \ \ \ ((res '())
+    \ \ \ \ \ \ \ \ \ \ (lis1 lis1)
 
-    \ \ \ \ \ \ \ (lis1 lis1)
+    \ \ \ \ \ \ \ \ \ \ (lis2 lis2))
 
-    \ \ \ \ \ \ \ (lis2 lis2))
+    \ \ \ \ \ \ \ \ (cond
 
-    \ \ \ \ \ \ (cond
+    \ \ \ \ \ \ \ \ \ \ ((and (null? lis1) (null? lis2)) (reverse res))
 
-    \ \ \ \ \ \ \ \ ((and (null? lis1) (null? lis2)) (reverse res))
+    \ \ \ \ \ \ \ \ \ \ ((null? lis1) (loop (cons (car lis2) res) lis1 (cdr lis2)))
 
-    \ \ \ \ \ \ \ \ ((null? lis1) (loop (cons (car lis2) res) lis1 (cdr lis2)))
+    \ \ \ \ \ \ \ \ \ \ ((null? lis2) (loop (cons (car lis1) res) lis2 (cdr lis1)))
 
-    \ \ \ \ \ \ \ \ ((null? lis2) (loop (cons (car lis1) res) lis2 (cdr lis1)))
+    \ \ \ \ \ \ \ \ \ \ ((less-p (car lis2) (car lis1)) (loop (cons (car lis2) res) lis1 (cdr lis2)))
 
-    \ \ \ \ \ \ \ \ ((less-p (car lis2) (car lis1)) (loop (cons (car lis2) res) lis1 (cdr lis2)))
+    \ \ \ \ \ \ \ \ \ \ (else (loop (cons (car lis1) res) (cdr lis1) lis2)))))
 
-    \ \ \ \ \ \ \ \ (else (loop (cons (car lis1) res) (cdr lis1) lis2)))))
+    \ \ \ \ (define list-merge! less-p lis1 lis2)
 
-    \;
+    \ \ \ \ (define (merge! left right)
 
-    \ \ ; this list-merge! violates SRFI 132, since it does not satisfy the constant running space
+    \ \ \ \ \ \ (let loop ((left left) (right right) (prev '()))
 
-    \ \ ; constraint specified in SRFI 132, and does not work "in place"
+    \ \ \ \ \ \ \ \ (cond
 
-    \ \ (define list-merge! list-merge)
+    \ \ \ \ \ \ \ \ \ \ ((null? left) (set-cdr! prev right))
 
-    \;
+    \ \ \ \ \ \ \ \ \ \ ((null? right) (set-cdr! prev left))
 
-    \ \ (define (list-stable-sort less-p lis)
+    \ \ \ \ \ \ \ \ \ \ ((less-p (car left) (car right))
 
-    \ \ \ \ (define (sort l r)
+    \ \ \ \ \ \ \ \ \ \ \ \ (set-cdr! prev left)
 
-    \ \ \ \ \ \ (cond
+    \ \ \ \ \ \ \ \ \ \ \ \ (loop (cdr left) right left))
 
-    \ \ \ \ \ \ \ \ ((= l r) '())
+    \ \ \ \ \ \ \ \ \ \ (else
 
-    \ \ \ \ \ \ \ \ ((= (+ l 1) r) (list (list-ref lis l)))
+    \ \ \ \ \ \ \ \ \ \ \ \ (set-cdr! prev right)
 
-    \ \ \ \ \ \ \ \ (else
+    \ \ \ \ \ \ \ \ \ \ \ \ (loop left (cdr right) right)))))
 
-    \ \ \ \ \ \ \ \ \ \ (let* ((mid (quotient (+ l r) 2))
+    \ \ \ \ (let ((dummy (cons '() '())))
 
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (l-sorted (sort l mid))
+    \ \ \ \ \ \ (merge! lis1 lis2 dummy)
 
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (r-sorted (sort mid r)))
+    \ \ \ \ \ \ (cdr dummy))
 
-    \ \ \ \ \ \ \ \ \ \ \ \ (list-merge less-p l-sorted r-sorted)))))
+    \ \ \ \ (define (list-stable-sort less-p lis)
 
-    \ \ \ \ (sort 0 (length lis)))
+    \ \ \ \ \ \ (define (sort l r)
 
-    \;
+    \ \ \ \ \ \ \ \ (cond
 
-    \ \ (define list-sort list-stable-sort)
+    \ \ \ \ \ \ \ \ \ \ ((= l r) '())
 
-    \ \ (define list-sort! list-stable-sort)
+    \ \ \ \ \ \ \ \ \ \ ((= (+ l 1) r) (list (list-ref lis l)))
 
-    \ \ (define list-stable-sort! list-stable-sort)
+    \ \ \ \ \ \ \ \ \ \ (else
 
-    \;
+    \ \ \ \ \ \ \ \ \ \ \ \ (let* ((mid (quotient (+ l r) 2))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (l-sorted (sort l mid))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (r-sorted (sort mid r)))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ (list-merge less-p l-sorted r-sorted)))))
+
+    \ \ \ \ \ \ (sort 0 (length lis)))
+
+    \ \ \ \ (define list-sort list-stable-sort)
+
+    \ \ \ \ (define list-sort! list-stable-sort)
+
+    \ \ \ \ (define list-stable-sort! list-stable-sort)
   </scm-chunk>
 
   <subsection|vector-merge, vector-sort, vector-stable-sort>
@@ -344,6 +390,8 @@
   <section|测试>
 
   <\goldfish-chunk|tests/goldfish/liii/sort-test.scm|true|false>
+    #lang racket
+
     (import (liii check)
 
     \ \ \ \ \ \ \ \ (liii sort))
@@ -422,6 +470,176 @@
 
     \;
   </goldfish-chunk>
+
+  vector-sorted?和list-merge!测试
+
+  <\scm-chunk|tests/goldfish/srfi/srfi-132-test.scm|false|false>
+    ;
+
+    ; Copyright (C) 2024 The Goldfish Scheme Authors
+
+    ;
+
+    ; Licensed under the Apache License, Version 2.0 (the "License");
+
+    ; you may not use this file except in compliance with the License.
+
+    ; You may obtain a copy of the License at
+
+    ;
+
+    ; http://www.apache.org/licenses/LICENSE-2.0
+
+    ;
+
+    ; Unless required by applicable law or agreed to in writing, software
+
+    ; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+
+    ; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+
+    ; License for the specific language governing permissions and limitations
+
+    ; under the License.
+
+    ;
+
+    \;
+
+    \;
+
+    ;
+
+    ; Copyright (C) 2024 The Goldfish Scheme Authors
+
+    ;
+
+    ; Licensed under the Apache License, Version 2.0 (the "License");
+
+    ; you may not use this file except in compliance with the License.
+
+    ; You may obtain a copy of the License at
+
+    ;
+
+    ; http://www.apache.org/licenses/LICENSE-2.0
+
+    ;
+
+    ; Unless required by applicable law or agreed to in writing, software
+
+    ; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+
+    ; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+
+    ; License for the specific language governing permissions and limitations
+
+    ; under the License.
+
+    ;
+
+    (import (srfi srfi-132))
+
+    (display "Testing vector-sorted?\\n")
+
+    \;
+
+    ; 测试用例 1：整个向量已排序
+
+    (check-true (vector-sorted? \<less\> # (1 2 3 4 5)))
+
+    \;
+
+    ; 测试用例 2：整个向量未排序
+
+    (check-false (vector-sorted? \<less\> # (1 3 2 4 5)))
+
+    \;
+
+    ; 测试用例 3：子向量已排序（从索引 1 开始）
+
+    (check-true (vector-sorted? \<less\> # (5 1 2 3 4) 1))
+
+    \;
+
+    ; 测试用例 4：子向量未排序（从索引 1 开始）
+
+    (check-false (vector-sorted? \<less\> # (5 1 3 2 4) 1))
+
+    \;
+
+    ; 测试用例 5：子向量已排序（从索引 1 到 3）
+
+    (check-true (vector-sorted? \<less\> # (5 1 2 3 4) 1 3))
+
+    \;
+
+    ; 测试用例 6：子向量未排序（从索引 1 到 3）
+
+    (check-false (vector-sorted? \<less\> # (5 1 3 2 4) 1 3))
+
+    \;
+
+    ; 测试用例 7：无效的起始和结束参数
+
+    (check-error (vector-sorted? \<less\> # (1 2 3 4 5) 3 2) "Invalid start or end parameters")
+
+    \;
+
+    ;; 测试 list-merge!
+
+    (display "Testing list-merge!\\n")
+
+    \;
+
+    ;; 测试用例 1：合并两个已排序的列表
+
+    (define lis1 '(1 3 5))
+
+    (define lis2 '(2 4 6))
+
+    (check-equal? (list-merge! \<less\> lis1 lis2) '(1 2 3 4 5 6))
+
+    \;
+
+    ; 测试用例 2：合并包含重复元素的列表
+
+    (define lis3 '(1 1 3))
+
+    (define lis4 '(1 2 4))
+
+    (check-equal? (list-merge! \<less\> lis3 lis4) '(1 1 1 2 3 4))
+
+    \;
+
+    ; 测试用例 3：合并空列表
+
+    (define lis5 '())
+
+    (define lis6 '(1 2 3))
+
+    (check-equal? (list-merge! \<less\> lis5 lis6) '(1 2 3))
+
+    (check-equal? (list-merge! \<less\> lis6 lis5) '(1 2 3))
+
+    \;
+
+    ; 测试用例 4：合并两个空列表
+
+    (define lis7 '())
+
+    (define lis8 '())
+
+    (check-equal? (list-merge! \<less\> lis7 lis8) '())
+
+    \;
+
+    ; 生成测试报告
+
+    (check-report)
+
+    \;
+  </scm-chunk>
 
   <section|结尾>
 

--- a/liii_sort.tmu
+++ b/liii_sort.tmu
@@ -200,15 +200,19 @@
 
     \ \ \ \ \ \ \ \ \ \ (if (or (\<less\> start 0) (\<gtr\> end (vector-length v)) (\<gtr\> start end))
 
-    \ \ \ \ \ \ \ \ \ \ \ \ (error "Invalid start or end parameters")
+    \ \ \ \ \ \ \ \ \ \ \ \ (raise "Invalid start or end parameters") ; 使用 raise 抛出错误
 
-    \ \ \ \ \ \ \ \ \ \ \ \ (do ((first start (+ 1 first))
+    \ \ \ \ \ \ \ \ \ \ \ \ (let loop ((i start))
 
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (second (+ 1 start) (+ 1 second))
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ (if (\<gtr\>= i (- end 1))
 
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (res #t (not (less-p (vector-ref v second) (vector-ref v first)))))
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ #t
 
-    \ \ \ \ \ \ \ \ \ \ \ \ \ \ ((or (\<gtr\>= second end) (not res)) res))))))
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (if (less-p (vector-ref v (+ i 1)) (vector-ref v i))
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ #f
+
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (loop (+ i 1)))))))))
   </scm-chunk>
 
   <subsection|list-merge, list-merge!, list-sort, list-stable-sort>
@@ -254,35 +258,37 @@
 
     \ \ \ \ \ \ \ \ \ \ (else (loop (cons (car lis1) res) (cdr lis1) lis2)))))
 
-    \ \ \ \ (define list-merge! less-p lis1 lis2)
+    \ \ \ \ (define list-merge!
 
-    \ \ \ \ (define (merge! left right)
+    \ \ \ \ \ \ (lambda (less-p lis1 lis2)
 
-    \ \ \ \ \ \ (let loop ((left left) (right right) (prev '()))
+    \ \ \ \ \ \ \ \ (define (merge! left right prev)
 
-    \ \ \ \ \ \ \ \ (cond
+    \ \ \ \ \ \ \ \ \ \ (let loop ((left left) (right right) (prev prev))
 
-    \ \ \ \ \ \ \ \ \ \ ((null? left) (set-cdr! prev right))
+    \ \ \ \ \ \ \ \ \ \ \ \ (cond
 
-    \ \ \ \ \ \ \ \ \ \ ((null? right) (set-cdr! prev left))
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ ((null? left) (set-cdr! prev right))
 
-    \ \ \ \ \ \ \ \ \ \ ((less-p (car left) (car right))
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ ((null? right) (set-cdr! prev left))
 
-    \ \ \ \ \ \ \ \ \ \ \ \ (set-cdr! prev left)
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ ((less-p (car left) (car right))
 
-    \ \ \ \ \ \ \ \ \ \ \ \ (loop (cdr left) right left))
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (set-cdr! prev left)
 
-    \ \ \ \ \ \ \ \ \ \ (else
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (loop (cdr left) right left))
 
-    \ \ \ \ \ \ \ \ \ \ \ \ (set-cdr! prev right)
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ (else
 
-    \ \ \ \ \ \ \ \ \ \ \ \ (loop left (cdr right) right)))))
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (set-cdr! prev right)
 
-    \ \ \ \ (let ((dummy (cons '() '())))
+    \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (loop left (cdr right) right)))))
 
-    \ \ \ \ \ \ (merge! lis1 lis2 dummy)
+    \ \ \ \ \ \ \ \ (let ((dummy (cons '() '())))
 
-    \ \ \ \ \ \ (cdr dummy))
+    \ \ \ \ \ \ \ \ \ \ (merge! lis1 lis2 dummy)
+
+    \ \ \ \ \ \ \ \ \ \ (cdr dummy))))
 
     \ \ \ \ (define (list-stable-sort less-p lis)
 
@@ -538,7 +544,9 @@
 
     ;
 
-    (import (srfi srfi-132))
+    (import (liii check)
+
+    \ \ (srfi srfi-132))
 
     (display "Testing vector-sorted?\\n")
 
@@ -546,43 +554,45 @@
 
     ; 测试用例 1：整个向量已排序
 
-    (check-true (vector-sorted? \<less\> # (1 2 3 4 5)))
+    (check-true (vector-sorted? \<less\> #(1 2 3 4 5)))
 
     \;
 
     ; 测试用例 2：整个向量未排序
 
-    (check-false (vector-sorted? \<less\> # (1 3 2 4 5)))
+    (check-false (vector-sorted? \<less\> #(1 3 2 4 5)))
 
     \;
 
     ; 测试用例 3：子向量已排序（从索引 1 开始）
 
-    (check-true (vector-sorted? \<less\> # (5 1 2 3 4) 1))
+    (check-true (vector-sorted? \<less\> #(5 1 2 3 4) 1))
 
     \;
 
     ; 测试用例 4：子向量未排序（从索引 1 开始）
 
-    (check-false (vector-sorted? \<less\> # (5 1 3 2 4) 1))
+    (check-false (vector-sorted? \<less\> #(5 1 3 2 4) 1))
 
     \;
 
     ; 测试用例 5：子向量已排序（从索引 1 到 3）
 
-    (check-true (vector-sorted? \<less\> # (5 1 2 3 4) 1 3))
+    (check-true (vector-sorted? \<less\> #(5 1 2 3 4) 1 3))
 
     \;
 
     ; 测试用例 6：子向量未排序（从索引 1 到 3）
 
-    (check-false (vector-sorted? \<less\> # (5 1 3 2 4) 1 3))
+    (check-false (vector-sorted? \<less\> #(5 1 3 2 4) 1 4))
 
     \;
 
     ; 测试用例 7：无效的起始和结束参数
 
-    (check-error (vector-sorted? \<less\> # (1 2 3 4 5) 3 2) "Invalid start or end parameters")
+    (check-catch "Invalid start or end parameters"
+
+    \ \ (vector-sorted? \<less\> #(1 2 3 4 5) 3 2))
 
     \;
 
@@ -598,7 +608,7 @@
 
     (define lis2 '(2 4 6))
 
-    (check-equal? (list-merge! \<less\> lis1 lis2) '(1 2 3 4 5 6))
+    (test (list-merge! \<less\> lis1 lis2) '(1 2 3 4 5 6))
 
     \;
 
@@ -608,7 +618,7 @@
 
     (define lis4 '(1 2 4))
 
-    (check-equal? (list-merge! \<less\> lis3 lis4) '(1 1 1 2 3 4))
+    (test (list-merge! \<less\> lis3 lis4) '(1 1 1 2 3 4))
 
     \;
 
@@ -618,9 +628,9 @@
 
     (define lis6 '(1 2 3))
 
-    (check-equal? (list-merge! \<less\> lis5 lis6) '(1 2 3))
+    (test (list-merge! \<less\> lis5 lis6) '(1 2 3))
 
-    (check-equal? (list-merge! \<less\> lis6 lis5) '(1 2 3))
+    (test (list-merge! \<less\> lis6 lis5) '(1 2 3))
 
     \;
 
@@ -630,7 +640,7 @@
 
     (define lis8 '())
 
-    (check-equal? (list-merge! \<less\> lis7 lis8) '())
+    (test (list-merge! \<less\> lis7 lis8) '())
 
     \;
 

--- a/tests/goldfish/liii/sort-test.scm
+++ b/tests/goldfish/liii/sort-test.scm
@@ -14,6 +14,7 @@
 ; under the License.
 ;
 
+#lang racket
 (import (liii check)
         (liii sort))
 

--- a/tests/goldfish/srfi/srfi-132-test.scm
+++ b/tests/goldfish/srfi/srfi-132-test.scm
@@ -1,0 +1,85 @@
+;
+; Copyright (C) 2024 The Goldfish Scheme Authors
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+; http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+
+
+;
+; Copyright (C) 2024 The Goldfish Scheme Authors
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+; http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+(import (liii check)
+  (srfi srfi-132))
+(display "Testing vector-sorted?\n")
+
+; 测试用例 1：整个向量已排序
+(check-true (vector-sorted? < #(1 2 3 4 5)))
+
+; 测试用例 2：整个向量未排序
+(check-false (vector-sorted? < #(1 3 2 4 5)))
+
+; 测试用例 3：子向量已排序（从索引 1 开始）
+(check-true (vector-sorted? < #(5 1 2 3 4) 1))
+
+; 测试用例 4：子向量未排序（从索引 1 开始）
+(check-false (vector-sorted? < #(5 1 3 2 4) 1))
+
+; 测试用例 5：子向量已排序（从索引 1 到 3）
+(check-true (vector-sorted? < #(5 1 2 3 4) 1 3))
+
+; 测试用例 6：子向量未排序（从索引 1 到 3）
+(check-false (vector-sorted? < #(5 1 3 2 4) 1 4))
+
+; 测试用例 7：无效的起始和结束参数
+(check-catch "Invalid start or end parameters"
+  (vector-sorted? < #(1 2 3 4 5) 3 2))
+
+;; 测试 list-merge!
+(display "Testing list-merge!\n")
+
+;; 测试用例 1：合并两个已排序的列表
+(define lis1 '(1 3 5))
+(define lis2 '(2 4 6))
+(test (list-merge! < lis1 lis2) '(1 2 3 4 5 6))
+
+; 测试用例 2：合并包含重复元素的列表
+(define lis3 '(1 1 3))
+(define lis4 '(1 2 4))
+(test (list-merge! < lis3 lis4) '(1 1 1 2 3 4))
+
+; 测试用例 3：合并空列表
+(define lis5 '())
+(define lis6 '(1 2 3))
+(test (list-merge! < lis5 lis6) '(1 2 3))
+(test (list-merge! < lis6 lis5) '(1 2 3))
+
+; 测试用例 4：合并两个空列表
+(define lis7 '())
+(define lis8 '())
+(test (list-merge! < lis7 lis8) '())
+
+; 生成测试报告
+(check-report)
+


### PR DESCRIPTION
很抱歉，第一次使用scheme，又遇到了个比较低级的问题。为了在本地测试完成的scheme代码，我使用的是vsc配合chicken解释器。
在goldfish/goldfish/srfi/srfi-132.scm中，使用了(define-library (srfi srfi-132)) 定义了模块 (srfi srfi-132)。在我编写的goldfish/tests/goldfish/srfi/srfi-132-test.scm中，在(import (srfi srfi-132))时出现了错误，报错显示“cannot import from undefined module: srfi.srfi-132”。
观察goldfish/tests/goldfish/srfi/下的其他代码，如试运行srfi-78-test.scm时，也遇到了相同问题。
请问这是怎么回事，我该如何解决呢