### PR TITLE
ci(xmake): update version to v2.9.9

### DIFF
--- a/.github/workflows/ci-debian.yml
+++ b/.github/workflows/ci-debian.yml
@@ -51,7 +51,7 @@ jobs:
 
       - uses: xmake-io/github-action-setup-xmake@v1
         with:
-          xmake-version: v2.8.7
+          xmake-version: v2.9.9
           actions-cache-folder: '.xmake-cache'
 
       - name: xmake repo --update

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: xmake-io/github-action-setup-xmake@v1
         with:
-          xmake-version: v2.8.7
+          xmake-version: v2.9.9
           actions-cache-folder: '.xmake-cache'
 
       - name: xmake repo --update

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: xmake-io/github-action-setup-xmake@v1
         with:
-          xmake-version: v2.8.9
+          xmake-version: v2.9.9
       - name: update repo
         run: xmake repo -u
       - name: git crlf


### PR DESCRIPTION
Prerequisites for #359.

将 xmake 从 v2.8.7/9 更新至 v2.9.9（v2 的最后版本）。

#359 引入的依赖 CPR 使用 cmake 构建，至少需求 https://github.com/xmake-io/xmake/pull/5155 合并后的 v2.9.3 版本。