### PR TITLE
[200_37] 将 goldfish 生成的命令名从 goldfish 改为 gf

### DIFF
--- a/.github/workflows/ci-debian.yml
+++ b/.github/workflows/ci-debian.yml
@@ -69,5 +69,5 @@ jobs:
       - name: build
         run: xmake build --yes -vD goldfish
       - name: run tests
-        run: bin/goldfish tests/test_all.scm
+        run: bin/gf tests/test_all.scm
 

--- a/.github/workflows/ci-fedora.yml
+++ b/.github/workflows/ci-fedora.yml
@@ -65,5 +65,5 @@ jobs:
         run: xmake build --yes -vD goldfish
 
       - name: run tests
-        run: bin/goldfish tests/test_all.scm
+        run: bin/gf tests/test_all.scm
 

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -63,5 +63,5 @@ jobs:
         run: xmake build --yes -vD goldfish
 
       - name: run tests
-        run: bin/goldfish tests/test_all.scm
+        run: bin/gf tests/test_all.scm
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -45,5 +45,5 @@ jobs:
       - name: build
         run: xmake build --yes -vD goldfish
       - name: test
-        run: bin/goldfish tests/test_all.scm
+        run: bin/gf tests/test_all.scm
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
 # Claude Code 工作规则
 
 ## Adhoc测试规则
-在做adhoc测试时，不使用echo命令，也不使用 bin/goldfish -e，而是：
+在做adhoc测试时，不使用echo命令，也不使用 bin/gf -e，而是：
 1. **唯一方法**：直接在 `tests` 目录下的现有测试用例文件中新增测试代码
 2. **禁止**：在 /tmp 目录下新建临时文件来测试
-3. 使用 bin/goldfish tests/... 的方式执行测试
+3. 使用 bin/gf tests/... 的方式执行测试
 
 **重要**：所有测试代码都必须保存在版本控制的测试文件中，便于后续的回归测试和代码审查。
 
@@ -18,13 +18,13 @@ Goldfish 内置了代码格式化工具 `goldfish --fix`，用于自动格式化
 ### 基本用法
 ```bash
 # 格式化单个文件（原地修改）
-bin/goldfish --fix goldfish/liii/os.scm
+bin/gf --fix goldfish/liii/os.scm
 
 # 格式化整个目录（原地修改）
-bin/goldfish --fix goldfish/
+bin/gf --fix goldfish/
 
 # 仅查看格式化结果（不修改文件）
-bin/goldfish --fix-dry-run goldfish/liii/os.scm
+bin/gf --fix-dry-run goldfish/liii/os.scm
 ```
 
 ### 测试步骤中的格式化检查
@@ -34,11 +34,11 @@ bin/goldfish --fix-dry-run goldfish/liii/os.scm
 xmake b goldfish
 
 # 2. 格式化代码
-bin/goldfish --fix goldfish/liii/xxx.scm
-bin/goldfish --fix tests/goldfish/liii/xxx-test.scm
+bin/gf --fix goldfish/liii/xxx.scm
+bin/gf --fix tests/goldfish/liii/xxx-test.scm
 
 # 3. 运行测试
-bin/goldfish tests/goldfish/liii/xxx-test.scm
+bin/gf tests/goldfish/liii/xxx-test.scm
 ```
 
 ## 创建代码合并请求的方法

--- a/tests/goldfish/liii/sys-test.scm
+++ b/tests/goldfish/liii/sys-test.scm
@@ -18,8 +18,8 @@ argv
 -----
 list
 例如：
-> bin/goldfish demo/demo_argv.scm 
-("bin/goldfish" "demo/demo_argv.scm")
+> bin/gf demo/demo_argv.scm
+("bin/gf" "demo/demo_argv.scm")
 返回一个列表，第一个表示的是命令行的命令名；第二个表示的是命令行第一个参数
 
 功能

--- a/tests/test_all.scm
+++ b/tests/test_all.scm
@@ -72,8 +72,8 @@
 
 (define (goldfish-cmd)
   (if (os-windows?)
-    "bin\\goldfish -m r7rs "
-    "bin/goldfish -m r7rs "
+    "bin\\gf -m r7rs "
+    "bin/gf -m r7rs "
   ) ;if
 ) ;define
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -101,6 +101,7 @@ local JSON_SCHEMA_VALIDATOR_VERSION = "2.4.0"
 target ("goldfish") do
     set_languages("c++17")
     set_targetdir("$(projectdir)/bin/")
+    set_basename("gf")
     if is_plat("linux") then
         add_syslinks("stdc++")
     end


### PR DESCRIPTION
在 xmake.lua 中添加 set_basename(\"gf\")，保持 target 名称为 goldfish， 但生成的可执行文件名为 gf（Windows 上为 gf.exe）。