### PR TITLE
[210_31] string-replace 空pattern行为与Python兼容，补充corner case测试

### DIFF
--- a/devel/210_31.md
+++ b/devel/210_31.md
@@ -171,4 +171,32 @@ bin/gf eval '(begin
 7. Unicode 字符串替换
 8. 类型错误与参数个数错误
 
+## 2026-03-29 补充 string-split 与 Python 兼容的测试用例
+
+### What
+为 `string-split` 新增与 Python `str.split()` 行为一致的测试用例，确保 Goldfish 的实现细节与 Python 保持统一。
+
+Python 测试文件: `tests/python_split_test.py`
+
+新增测试覆盖以下场景:
+
+1. **单字符字符串** - `"a".split(",")` => `["a"]`
+2. **多字符分隔符边界情况** - `"abc".split("bc")` => `["a", ""]`
+3. **更多连续分隔符场景** - `"a,,,b".split(",")` => `["a", "", "", "b"]`
+4. **分隔符重复出现（重叠匹配）** - Python 不会重叠匹配，如 `"aaaa".split("aa")` => `["", "", ""]`
+5. **更多特殊字符场景** - 制表符、换行符等
+6. **路径/URL 场景** - `/usr/local/bin`.split("/") => `["", "usr", "local", "bin"]`
+
+### Why
+Python 的 `str.split()` 是业界最广泛使用的字符串分割语义，确保 Goldfish 的 `string-split` 与之保持一致可以减少开发者的认知负担。
+
+### How
+1. 编写 `tests/python_split_test.py` 全面测试 Python 的 `str.split()` 行为
+2. 验证所有测试用例在 Python 中的输出
+3. 将对应的测试用例添加到 `tests/goldfish/liii/string-test.scm`
+4. 运行 Goldfish 测试确认所有用例通过
+
+### Python 与 Goldfish 的行为差异
+- **空分隔符**: Python 的 `str.split("")` 会抛出 `ValueError`，而 Goldfish 的 `string-split` 将空分隔符视为按字符拆分（`"abc".split("")` => `["a", "b", "c"]`）。这是 Goldfish 的扩展功能，不是缺陷。
+
 ## 2026/03/25 新增 `string-contains?`

--- a/goldfish/liii/string.scm
+++ b/goldfish/liii/string.scm
@@ -112,7 +112,17 @@
         (let ((str-len (string-length str))
               (old-len (string-length old)))
           (if (zero? old-len)
-              (string-copy str)
+              ; Python 兼容行为: 空 pattern 时在每个字符之间插入 new
+              (if (zero? str-len)
+                  new  ; 空字符串 + 空 pattern = new
+                  (let loop ((i 0)
+                             (acc (list new)))
+                    (if (= i str-len)
+                        (apply string-append (reverse acc))
+                        (loop (+ i 1)
+                              (cons new
+                                    (cons (substring str i (+ i 1))
+                                          acc))))))
               (let loop ((search-start 0)
                          (parts '()))
                 (let ((next-pos (string-position old str search-start)))

--- a/tests/goldfish/liii/string-test.scm
+++ b/tests/goldfish/liii/string-test.scm
@@ -3008,6 +3008,40 @@ wrong-number-of-args 当参数数量不正确时
 (check (string-split "你好，世界，Goldfish" "，") => '("你好" "世界" "Goldfish"))
 (check (string-split "name=goldfish&lang=scheme" "&") => '("name=goldfish" "lang=scheme"))
 
+; === 以下测试用例与 Python str.split() 保持一致 ===
+
+; 单字符字符串
+(check (string-split "a" ",") => '("a"))
+(check (string-split "x" "x") => '("" ""))
+
+; 多字符分隔符边界情况
+(check (string-split "abc" "bc") => '("a" ""))
+(check (string-split "abc" "abc") => '("" ""))
+(check (string-split "hello world" " world") => '("hello" ""))
+(check (string-split "a--b--c" "--") => '("a" "b" "c"))
+
+; 更多连续分隔符场景
+(check (string-split "a,,,b" ",") => '("a" "" "" "b"))
+(check (string-split ",," ",") => '("" "" ""))
+
+; 分隔符重复出现（重叠匹配）- Python 不会重叠匹配
+(check (string-split "aaa" "a") => '("" "" "" ""))
+(check (string-split "aba" "a") => '("" "b" ""))
+(check (string-split "aaaa" "aa") => '("" "" ""))
+(check (string-split "aaa" "aa") => '("" "a"))
+
+; 更多特殊字符场景
+(check (string-split "a\tb\t" "\t") => '("a" "b" ""))
+(check (string-split "a\nb" "\n") => '("a" "b"))
+(check (string-split "line1\nline2" "\n") => '("line1" "line2"))
+
+; 路径/URL 场景
+(check (string-split "/usr/local/bin" "/") => '("" "usr" "local" "bin"))
+(check (string-split "key=val;key2=val2" ";") => '("key=val" "key2=val2"))
+(check (string-split "file.txt" ".") => '("file" "txt"))
+(check (string-split ".hidden" ".") => '("" "hidden"))
+(check (string-split "." ".") => '("" ""))
+
 ; 错误处理测试
 (check-catch 'type-error (string-split 123 ","))
 (check-catch 'type-error (string-split "abc" 123))
@@ -4014,7 +4048,7 @@ string
 ----
 - 这是一个更符合日常编码直觉的 replace：默认替换全部匹配。
 - 替换过程按原字符串从左到右扫描，不会重复扫描刚刚插入的 new。
-- 当 old 为空字符串时，返回 str 的副本，不做插入。
+- 当 old 为空字符串时，在每个字符之间插入 new（Python 兼容行为）。
 - 如果没有匹配，返回原内容的副本。
 
 错误处理
@@ -4030,8 +4064,10 @@ wrong-number-of-args 当参数数量不正确时
 ; 边界条件测试
 (check (string-replace "" "hello" "hi") => "")
 (check (string-replace "hello world" "test" "hi") => "hello world")
-(check (string-replace "hello" "" "x") => "hello")
+(check (string-replace "hello" "" "x") => "xhxexlxlxox")  ; Python 兼容: 空pattern在字符间插入
+(check (string-replace "" "" "x") => "x")  ; Python 兼容: 空串+空pattern=new
 (check (string-replace "hello world hello" "hello" "") => " world ")
+(check (string-replace "hello" "l" "") => "heo")  ; 删除匹配字符
 
 ; 非重叠、从左到右扫描
 (check (string-replace "aaaa" "aa" "b") => "bb")
@@ -4040,6 +4076,34 @@ wrong-number-of-args 当参数数量不正确时
 ; Unicode 支持
 (check (string-replace "测试测试字符串" "测试" "实验") => "实验实验字符串")
 (check (string-replace "你好，世界" "世界" "Goldfish") => "你好，Goldfish")
+(check (string-replace "你好世界" "世界" "") => "你好")  ; Unicode 删除
+(check (string-replace "hello😀world😀" "😀" "!") => "hello!world!")  ; Emoji
+
+; 特殊字符测试
+(check (string-replace "hello world" " " "_") => "hello_world")
+(check (string-replace "a\nb\nc" "\n" "") => "abc")  ; 换行符
+(check (string-replace "a\tb" "\t" "    ") => "a    b")  ; 制表符
+
+; 边界位置测试
+(check (string-replace "hello" "he" "X") => "Xllo")  ; 开头匹配
+(check (string-replace "hello" "lo" "X") => "helX")  ; 结尾匹配
+(check (string-replace "hello" "hello" "world") => "world")  ; 整串匹配
+(check (string-replace "hello" "l" "l") => "hello")  ; 替换为相同内容
+
+; 连续匹配测试
+(check (string-replace "ababab" "ab" "X") => "XXX")
+(check (string-replace "aaa" "a" "") => "")  ; 全部删除
+
+; pattern 长度相关
+(check (string-replace "hi" "hello" "world") => "hi")  ; pattern 比原串长
+(check (string-replace "hello" "hello" "world") => "world")  ; pattern 等于原串
+
+; 大小写敏感测试
+(check (string-replace "Hello" "h" "H") => "Hello")  ; H != h
+(check (string-replace "Hello" "H" "h") => "hello")
+
+; 数字字符串测试
+(check (string-replace "123123" "12" "X") => "X3X3")
 
 ; 返回副本而不是原对象
 (let ((original "hello world")


### PR DESCRIPTION
- 修改 string-replace: 空pattern时在每个字符间插入new（与Python一致）
- 更新文档注释说明Python兼容行为
- 新增17个测试用例覆盖corner case:
  - Unicode删除、Emoji替换
  - 特殊字符（空格、换行、制表符）
  - 边界位置、连续匹配、全部删除
  - pattern长度边界、大小写敏感、数字字符串