### PR TITLE
[200_39] 简化 gf test 命令参数

### DIFF
--- a/devel/200_39.md
+++ b/devel/200_39.md
@@ -1,0 +1,72 @@
+# [200_39] 简化 gf test 命令参数
+
+## 任务相关的代码文件
+- src/goldfish.hpp
+- tools/goldtest/liii/goldtest.scm
+- tests/liii/goldtest/parse-test-args-test.scm
+- devel/200_39.md
+
+## 如何测试
+```bash
+# 构建
+xmake b goldfish
+
+# 运行所有测试
+bin/gf test
+
+# 运行指定文件
+bin/gf test tests/liii/json-test.scm
+
+# 运行指定目录下的所有测试
+bin/gf test tests/liii/json/
+
+# 按文件名匹配
+bin/gf test json-test.scm
+
+# 按路径模糊匹配
+bin/gf test json
+```
+
+## 2026-03-30 简化 gf test 命令参数
+
+### What
+简化 `gf test` 命令的参数解析逻辑，移除 `--only` 选项，改为根据参数类型自动判断匹配方式：
+
+1. **包含 `/` 的路径** - 按路径处理：
+   - 如果是存在的文件，直接运行该文件
+   - 如果是存在的目录，运行该目录下所有 `*-test.scm` 文件
+   - 如果不存在，按模糊匹配处理
+
+2. **以 `.scm` 结尾但不是路径** - 按文件名精确匹配
+   - 例：`json-test.scm` 匹配所有名为 `json-test.scm` 的文件
+
+3. **其他字符串** - 按路径模糊匹配
+   - 例：`json` 匹配路径中包含 `json` 的所有测试文件
+
+### Why
+- `--only` 选项的语法比较冗长
+- 根据参数形式自动判断更符合直觉
+- 与 `gf run` 命令的参数处理方式保持一致
+
+### How
+修改 `tools/goldtest/liii/goldtest.scm`：
+1. 新增 `parse-test-args` 函数，根据参数特征返回 `(type . value)`：
+   - `'file` - 直接运行该文件
+   - `'dir` - 运行目录下所有测试
+   - `'filename` - 按文件名匹配
+   - `'pattern` - 按路径模糊匹配
+2. 修改 `filter-test-files` 函数，根据类型进行过滤
+3. 新增 `display-filter-info` 函数，显示当前匹配模式
+4. 修改 `run-goldtest` 函数，使用新的解析逻辑
+
+修改 `src/goldfish.hpp`：
+- 更新帮助文本，移除 `--only` 选项，说明新的参数用法
+
+新增 `tests/liii/goldtest/parse-test-args-test.scm`：
+- 单元测试验证参数解析逻辑
+- 测试文件通过 `import (liii goldtest)` 使用库函数
+
+修改 `tools/goldtest/liii/goldtest.scm`：
+- 改为 `define-library (liii goldtest)` 格式
+- 导出 `parse-test-args`, `filter-test-files`, `find-test-files`, `run-goldtest`, `main`
+- 增加 `main` 函数作为程序入口点

--- a/src/goldfish.hpp
+++ b/src/goldfish.hpp
@@ -3365,10 +3365,13 @@ display_help () {
   cout << "  fix [options] PATH Format PATH (PATH can be a .scm file or directory)" << endl;
   cout << "                     Options:" << endl;
   cout << "                       --dry-run  Print formatted result to stdout" << endl;
-  cout << "  test [options]     Run tests (all *-test.scm files under tests/)" << endl;
-  cout << "                     Options:" << endl;
-  cout << "                       --only PATTERN  Run tests matching PATTERN" << endl;
-  cout << "                                         (e.g. json, sicp, list-test.scm)" << endl;
+  cout << "  test [PATTERN]     Run tests (all *-test.scm files under tests/)" << endl;
+  cout << "                     PATTERN can be:" << endl;
+  cout << "                       (none)          Run all tests" << endl;
+  cout << "                       FILE.scm        Run specific test file" << endl;
+  cout << "                       DIR/            Run tests in directory" << endl;
+  cout << "                       name-test.scm   Match by file name" << endl;
+  cout << "                       substring       Match by path substring" << endl;
   cout << "  run TARGET         Run main function from TARGET" << endl;
   cout << "                     TARGET can be:" << endl;
   cout << "                       FILE.scm       Load file and run main" << endl;
@@ -4682,11 +4685,10 @@ repl_for_community_edition (s7_scheme* sc, int argc, char** argv) {
     }
     s7_add_to_load_path (sc, goldtest_root.c_str ());
 
-    // Load the goldtest.scm file
-    string goldtest_scm = goldtest_root + "/liii/goldtest.scm";
-    s7_pointer load_result = s7_load (sc, goldtest_scm.c_str ());
-    if (!load_result) {
-      cerr << "Error: Failed to load " << goldtest_scm << endl;
+    // Import (liii goldtest) module
+    s7_pointer import_result = s7_eval_c_string (sc, "(import (liii goldtest))");
+    if (!import_result) {
+      cerr << "Error: Failed to import (liii goldtest) module." << endl;
       s7_close_output_port (sc, s7_current_error_port (sc));
       s7_set_current_error_port (sc, old_port);
       if (gc_loc != -1) s7_gc_unprotect_at (sc, gc_loc);
@@ -4694,23 +4696,23 @@ repl_for_community_edition (s7_scheme* sc, int argc, char** argv) {
     }
     errmsg = s7_get_output_string (sc, s7_current_error_port (sc));
     if ((errmsg) && (*errmsg)) {
-      cerr << "Error loading goldtest.scm: " << errmsg << endl;
+      cerr << "Error importing (liii goldtest): " << errmsg << endl;
       s7_close_output_port (sc, s7_current_error_port (sc));
       s7_set_current_error_port (sc, old_port);
       if (gc_loc != -1) s7_gc_unprotect_at (sc, gc_loc);
       exit (1);
     }
 
-    // Get the run-goldtest function
-    s7_pointer run_goldtest = s7_name_to_value (sc, "run-goldtest");
-    if ((!run_goldtest) || (!s7_is_procedure (run_goldtest))) {
-      cerr << "Error: Failed to find run-goldtest function." << endl;
+    // Get and call the main function from (liii goldtest)
+    s7_pointer main_func = s7_name_to_value (sc, "main");
+    if ((!main_func) || (!s7_is_procedure (main_func))) {
+      cerr << "Error: Failed to find main function in (liii goldtest)." << endl;
       s7_close_output_port (sc, s7_current_error_port (sc));
       s7_set_current_error_port (sc, old_port);
       if (gc_loc != -1) s7_gc_unprotect_at (sc, gc_loc);
       exit (1);
     }
-    s7_call (sc, run_goldtest, s7_nil (sc));
+    s7_call (sc, main_func, s7_nil (sc));
     errmsg = s7_get_output_string (sc, s7_current_error_port (sc));
     if ((errmsg) && (*errmsg)) cout << errmsg;
     s7_close_output_port (sc, s7_current_error_port (sc));

--- a/tests/liii/goldtest/parse-test-args-test.scm
+++ b/tests/liii/goldtest/parse-test-args-test.scm
@@ -1,0 +1,149 @@
+;; 添加 tools/goldtest 到 load path，以便导入 (liii goldtest)
+;; 注意：假设运行测试时工作目录是项目根目录
+(set! *load-path* (cons "tools/goldtest" *load-path*))
+
+(import (liii check)
+        (liii string)
+        (liii path)
+        (liii sys)
+        (liii list)
+        (liii goldtest)
+) ;import
+
+;; ============================================================
+;; parse-test-args 函数文档和测试
+;; ============================================================
+;;
+;; 函数: parse-test-args
+;; 用途: 解析 gf test 命令的参数，根据参数类型返回不同的匹配策略
+;;
+;; 参数:
+;;   args - 命令行参数列表，第一个元素是可执行文件路径
+;;
+;; 返回值: (type . value) 对
+;;   type 可以是:
+;;     'file     - 直接运行指定文件
+;;     'dir      - 运行目录下所有测试
+;;     'filename - 按文件名精确匹配
+;;     'pattern  - 按路径模糊匹配
+;;     #f        - 无参数，运行所有测试
+;;
+;; 匹配规则（按优先级）:
+;; 1. 包含 "/" 的路径参数:
+;;    - path-file? 返回 #t  -> type='file, 直接运行该文件
+;;    - path-dir? 返回 #t   -> type='dir, 运行目录下所有 *-test.scm
+;;    - 不存在               -> type='pattern, 按路径模糊匹配
+;;
+;; 2. 以 ".scm" 结尾（但不包含 "/"）:
+;;    -> type='filename, 按文件名精确匹配
+;;    例: "json-test.scm" 匹配所有同名文件
+;;
+;; 3. 其他字符串:
+;;    -> type='pattern, 按路径模糊匹配
+;;    例: "json" 匹配路径中包含 "json" 的所有测试
+;;
+;; 特殊处理:
+;; - 自动跳过 gf test 相关的命令选项 (-m, --mode, r7rs 等)
+;; - 自动跳过第一个参数（可执行文件路径）
+
+;; ------------------------------------------------------------
+;; 测试用例
+;; ------------------------------------------------------------
+
+;; ===== 场景1: 无参数 =====
+;; 当 args 只有可执行文件路径时，应该返回 (#f . #f)
+(check (parse-test-args '("bin/gf")) => '(#f . #f))
+
+;; ===== 场景2: 存在的文件路径 =====
+;; 路径包含 / 且 path-file? 返回 #t -> type='file
+(check (parse-test-args '("bin/gf" "tests/liii/json-test.scm"))
+  => (if (path-file? "tests/liii/json-test.scm")
+         '(file . "tests/liii/json-test.scm")
+         ;; 如果文件不存在，按 pattern 处理
+         '(pattern . "tests/liii/json-test.scm"))
+) ;check
+
+;; ===== 场景3: 存在的目录路径 =====
+;; 路径包含 / 且 path-dir? 返回 #t -> type='dir
+(check (parse-test-args '("bin/gf" "tests/liii/"))
+  => (if (path-dir? "tests/liii/")
+         '(dir . "tests/liii/")
+         ;; 如果目录不存在，按 pattern 处理
+         '(pattern . "tests/liii/"))
+) ;check
+
+;; ===== 场景4: 不存在的路径 =====
+;; 路径包含 / 但既不是文件也不是目录 -> type='pattern
+(check (parse-test-args '("bin/gf" "nonexistent/path/test.scm"))
+  => (if (or (path-file? "nonexistent/path/test.scm")
+             (path-dir? "nonexistent/path/test.scm"))
+         ;; 如果存在，按 file 或 dir 处理
+         (if (path-file? "nonexistent/path/test.scm")
+             '(file . "nonexistent/path/test.scm")
+             '(dir . "nonexistent/path/test.scm")
+         ) ;if
+         ;; 如果不存在，按 pattern 处理
+         '(pattern . "nonexistent/path/test.scm"))
+) ;check
+
+;; ===== 场景5: .scm 文件名（无路径） =====
+;; 以 .scm 结尾但不包含 / -> type='filename
+(check (parse-test-args '("bin/gf" "json-test.scm"))
+  => '(filename . "json-test.scm")
+) ;check
+
+(check (parse-test-args '("bin/gf" "list-test.scm"))
+  => '(filename . "list-test.scm")
+) ;check
+
+;; ===== 场景6: 普通字符串（模糊匹配） =====
+;; 不包含 / 且不以 .scm 结尾 -> type='pattern
+(check (parse-test-args '("bin/gf" "json"))
+  => '(pattern . "json")
+) ;check
+
+(check (parse-test-args '("bin/gf" "liii"))
+  => '(pattern . "liii")
+) ;check
+
+;; ===== 场景7: 跳过 test 命令本身 =====
+(check (parse-test-args '("bin/gf" "test" "json"))
+  => '(pattern . "json")
+) ;check
+
+;; ===== 场景8: 跳过 -m 和模式值 =====
+(check (parse-test-args '("bin/gf" "-m" "r7rs" "json"))
+  => '(pattern . "json")
+) ;check
+
+(check (parse-test-args '("bin/gf" "--mode" "liii" "json-test.scm"))
+  => '(filename . "json-test.scm")
+) ;check
+
+;; ===== 场景9: 跳过 -m=... 格式 =====
+(check (parse-test-args '("bin/gf" "-m=r7rs" "json"))
+  => '(pattern . "json")
+) ;check
+
+;; ===== 场景10: 复杂命令行 =====
+(check (parse-test-args '("bin/gf" "-m" "r7rs" "test" "tests/liii/json-test.scm"))
+  => (if (path-file? "tests/liii/json-test.scm")
+         '(file . "tests/liii/json-test.scm")
+         '(pattern . "tests/liii/json-test.scm"))
+) ;check
+
+;; ===== 场景11: 带 ./ 的相对路径 =====
+(check (parse-test-args '("bin/gf" "./tests/liii/json-test.scm"))
+  => (if (path-file? "./tests/liii/json-test.scm")
+         '(file . "./tests/liii/json-test.scm")
+         '(pattern . "./tests/liii/json-test.scm"))
+) ;check
+
+;; ===== 场景12: 绝对路径 =====
+(check (parse-test-args '("bin/gf" "/tmp/test.scm"))
+  => (if (path-file? "/tmp/test.scm")
+         '(file . "/tmp/test.scm")
+         '(pattern . "/tmp/test.scm"))
+) ;check
+
+(check-report)

--- a/tools/goldtest/liii/goldtest.scm
+++ b/tools/goldtest/liii/goldtest.scm
@@ -15,189 +15,278 @@
 ; under the License.
 ;
 
-(import (scheme base)
-        (scheme process-context)
-        (liii sort)
-        (liii list)
-        (liii string)
-        (liii os)
-        (liii path)
-        (liii sys)
-) ;import
+(define-library (liii goldtest)
+  (import (scheme base)
+          (scheme process-context)
+          (liii sort)
+          (liii list)
+          (liii string)
+          (liii os)
+          (liii path)
+          (liii sys)
+  ) ;import
+  (export parse-test-args
+          filter-test-files
+          find-test-files
+          run-goldtest
+          main
+  ) ;export
+  (begin
 
-(define ESC (string #\escape #\[))
-
-(define (color code)
-  (string-append ESC (number->string code) "m")
-) ;define
-
-(define GREEN (color 32))
-(define RED (color 31))
-(define YELLOW (color 33))
-(define RESET (color 0))
-
-(define (test-path-join . parts)
-  (let ((sep (string (os-sep))))
-    (let loop ((result "")
-               (rest parts))
-      (if (null? rest)
-        result
-        (let ((part (car rest)))
-          (if (string-null? result)
-            (loop part (cdr rest))
-            (loop (string-append result sep part) (cdr rest))
+    (define ESC (string #\escape #\[))
+    
+    (define (color code)
+      (string-append ESC (number->string code) "m")
+    ) ;define
+    
+    (define GREEN (color 32))
+    (define RED (color 31))
+    (define YELLOW (color 33))
+    (define RESET (color 0))
+    
+    (define (test-path-join . parts)
+      (let ((sep (string (os-sep))))
+        (let loop ((result "")
+                   (rest parts))
+          (if (null? rest)
+            result
+            (let ((part (car rest)))
+              (if (string-null? result)
+                (loop part (cdr rest))
+                (loop (string-append result sep part) (cdr rest))
+              ) ;if
+            ) ;let
           ) ;if
         ) ;let
-      ) ;if
-    ) ;let
-  ) ;let
-) ;define
-
-(define (find-test-files dir)
-  (let ((files '()))
-    (when (path-dir? dir)
-      (let ((entries (listdir dir)))
+      ) ;let
+    ) ;define
+    
+    (define (find-test-files dir)
+      (let ((files '()))
+        (when (path-dir? dir)
+          (let ((entries (listdir dir)))
+            (for-each
+              (lambda (entry)
+                (let ((full-path (test-path-join dir entry)))
+                  (cond
+                    ((path-dir? full-path)
+                     (set! files (append files (find-test-files full-path)))
+                    ) ;
+                    ((and (path-file? full-path)
+                          (string-ends? entry "-test.scm"))
+                     (set! files (cons full-path files))
+                    ) ;
+                  ) ;cond
+                ) ;let
+              ) ;lambda
+              entries
+            ) ;for-each
+          ) ;let
+        ) ;when
+        files
+      ) ;let
+    ) ;define
+    
+    (define (goldfish-cmd)
+      (string-append (executable) " -m r7rs ")
+    ) ;define
+    
+    (define (run-test-file test-file)
+      (let ((cmd (string-append (goldfish-cmd) test-file)))
+        (display "----------->") (newline)
+        (display cmd) (newline)
+        (let ((result (os-call cmd)))
+          (cons test-file result)
+        ) ;let
+      ) ;let
+    ) ;define
+    
+    (define (display-summary test-results)
+      (let ((total (length test-results))
+            (passed (count (lambda (x) (zero? (cdr x))) test-results))
+            (failed (- (length test-results)
+                       (count (lambda (x) (zero? (cdr x))) test-results)))
+            ) ;failed
+        (newline)
+        (display "=== Test Summary ===") (newline)
+        (newline)
         (for-each
-          (lambda (entry)
-            (let ((full-path (test-path-join dir entry)))
-              (cond
-                ((path-dir? full-path)
-                 (set! files (append files (find-test-files full-path)))
-                ) ;
-                ((and (path-file? full-path)
-                      (string-ends? entry "-test.scm"))
-                 (set! files (cons full-path files))
-                ) ;
-              ) ;cond
+          (lambda (test-result)
+            (let ((test-file (car test-result))
+                  (exit-code (cdr test-result)))
+              (display (string-append "  " test-file " ... "))
+              (if (zero? exit-code)
+                (display (string-append GREEN "PASS" RESET))
+                (display (string-append RED "FAIL" RESET))
+              ) ;if
+              (newline)
             ) ;let
           ) ;lambda
-          entries
+          test-results
         ) ;for-each
+        (newline)
+        (display "=== Summary ===") (newline)
+        (display (string-append "  Total:  " (number->string total))) (newline)
+        (display (string-append "  " GREEN "Passed: " (number->string passed) RESET)) (newline)
+        (when (> failed 0)
+          (display (string-append "  " RED "Failed: " (number->string failed) RESET)) (newline)
+        ) ;when
+        (newline)
+        failed
       ) ;let
-    ) ;when
-    files
-  ) ;let
-) ;define
-
-(define (goldfish-cmd)
-  (string-append (executable) " -m r7rs ")
-) ;define
-
-(define (run-test-file test-file)
-  (let ((cmd (string-append (goldfish-cmd) test-file)))
-    (display "----------->") (newline)
-    (display cmd) (newline)
-    (let ((result (os-call cmd)))
-      (cons test-file result)
-    ) ;let
-  ) ;let
-) ;define
-
-(define (display-summary test-results)
-  (let ((total (length test-results))
-        (passed (count (lambda (x) (zero? (cdr x))) test-results))
-        (failed (- (length test-results)
-                   (count (lambda (x) (zero? (cdr x))) test-results)))
-        ) ;failed
-    (newline)
-    (display "=== Test Summary ===") (newline)
-    (newline)
-    (for-each
-      (lambda (test-result)
-        (let ((test-file (car test-result))
-              (exit-code (cdr test-result)))
-          (display (string-append "  " test-file " ... "))
-          (if (zero? exit-code)
-            (display (string-append GREEN "PASS" RESET))
-            (display (string-append RED "FAIL" RESET))
+    ) ;define
+    
+    (define (parse-test-args args)
+      ;; 解析 test 命令的参数
+      ;; 规则：
+      ;; 1. 如果参数包含 /，视为路径处理
+      ;;    - 如果是存在的文件，直接返回该文件
+      ;;    - 如果是存在的目录，返回该目录用于后续查找
+      ;; 2. 如果参数以 .scm 结尾但不是路径，按文件名匹配
+      ;; 3. 其他情况，按模糊匹配（路径中包含该字符串）
+      ;; 返回值: (type . value)
+      ;;   type 可以是: 'file, 'dir, 'filename, 'pattern, #f
+      ;; args 的第一个元素是可执行文件路径，需要跳过
+      (if (null? args)
+        (cons #f #f)
+        (let loop ((remaining (cdr args)) ; 跳过第一个参数（可执行文件）
+                   (skip-next #f))        ; 是否跳过下一个参数（模式值）
+          (if (null? remaining)
+            (cons #f #f)
+            (let ((arg (car remaining)))
+              (cond
+                ;; 如果需要跳过当前参数（作为 -m/--mode 的值）
+                (skip-next
+                 (loop (cdr remaining) #f)
+                ) ;skip-next
+                ;; 跳过 test 命令
+                ((equal? arg "test")
+                 (loop (cdr remaining) #f)
+                ) ;
+                ;; -m 或 --mode 后面需要跳过模式值
+                ((or (equal? arg "-m") (equal? arg "--mode"))
+                 (loop (cdr remaining) #t)
+                ) ;
+                ;; -m=... 或 --mode=... 格式，跳过当前参数
+                ((or (string-starts? arg "-m=") (string-starts? arg "--mode="))
+                 (loop (cdr remaining) #f)
+                ) ;
+                ;; 包含 / 的路径
+                ((string-contains arg "/")
+                 (cond
+                   ((path-file? arg) (cons 'file arg))
+                   ((path-dir? arg) (cons 'dir arg))
+                   (else (cons 'pattern arg)) ; 不存在的路径，按模式匹配
+                 ) ;cond
+                ) ;
+                ;; 以 .scm 结尾的文件名
+                ((string-ends? arg ".scm")
+                 (cons 'filename arg)
+                ) ;
+                ;; 其他视为模糊匹配模式
+                (else
+                 (cons 'pattern arg)
+                ) ;else
+              ) ;cond
+            ) ;let
           ) ;if
-          (newline)
         ) ;let
-      ) ;lambda
-      test-results
-    ) ;for-each
-    (newline)
-    (display "=== Summary ===") (newline)
-    (display (string-append "  Total:  " (number->string total))) (newline)
-    (display (string-append "  " GREEN "Passed: " (number->string passed) RESET)) (newline)
-    (when (> failed 0)
-      (display (string-append "  " RED "Failed: " (number->string failed) RESET)) (newline)
-    ) ;when
-    (newline)
-    failed
-  ) ;let
-) ;define
-
-(define (parse-only-filter args)
-  (let loop ((remaining args)
-             (filter #f))
-    (if (null? remaining)
-      filter
-      (if (and (equal? (car remaining) "--only")
-               (not (null? (cdr remaining))))
-        (loop (cddr remaining) (cadr remaining))
-        (loop (cdr remaining) filter)
       ) ;if
-    ) ;if
-  ) ;let
-) ;define
-
-(define (filter-test-files test-files only-pattern)
-  (if only-pattern
-    (if (string-ends? only-pattern ".scm")
-      ; 如果以 .scm 结尾，直接匹配文件名
-      (filter (lambda (file) (string=? (path-name file) only-pattern)) test-files)
-      ; 否则使用 string-contains 进行模糊匹配
-      (filter (lambda (file) (string-contains file only-pattern)) test-files)
-    ) ;if
-    test-files
-  ) ;if
-) ;define
-
-(define (run-goldtest)
-  (let* ((args (command-line))
-         (only-pattern (parse-only-filter args))
-         (all-test-files (list-sort string<? (find-test-files "tests")))
-         (test-files (filter-test-files all-test-files only-pattern)))
-    (if (null? test-files)
-      (begin
-        (if only-pattern
+    ) ;define
+    
+    (define (filter-test-files test-files arg-type arg-value)
+      ;; 根据参数类型过滤测试文件
+      (case arg-type
+        ((file)
+         ;; 直接返回单个文件
+         (if (member arg-value test-files) (list arg-value) '())
+        ) ;
+        ((dir)
+         ;; 返回该目录下的所有测试文件
+         (filter (lambda (file) (string-starts? file arg-value)) test-files)
+        ) ;
+        ((filename)
+         ;; 精确匹配文件名
+         (filter (lambda (file) (string=? (path-name file) arg-value)) test-files)
+        ) ;
+        ((pattern)
+         ;; 模糊匹配路径
+         (filter (lambda (file) (string-contains file arg-value)) test-files)
+        ) ;
+        (else
+         ;; 无参数，返回所有文件
+         test-files
+        ) ;else
+      ) ;case
+    ) ;define
+    
+    (define (display-filter-info arg-type arg-value)
+      ;; 显示过滤信息
+      (case arg-type
+        ((file)
+         (display (string-append "Running test file: " arg-value))
+         (newline)
+        ) ;
+        ((dir)
+         (display (string-append "Running tests in directory: " arg-value))
+         (newline)
+        ) ;
+        ((filename)
+         (display (string-append "Running tests with file name: " arg-value))
+         (newline)
+        ) ;
+        ((pattern)
+         (display (string-append "Running tests matching pattern: " arg-value))
+         (newline)
+        ) ;
+      ) ;case
+    ) ;define
+    
+    (define (run-goldtest)
+      (let* ((args (command-line))
+             (parsed (parse-test-args args))
+             (arg-type (car parsed))
+             (arg-value (cdr parsed))
+             (all-test-files (list-sort string<? (find-test-files "tests")))
+             (test-files (filter-test-files all-test-files arg-type arg-value)))
+        (if (null? test-files)
           (begin
-            (display (string-append YELLOW "No test files matching --only " only-pattern RESET))
-            (newline)
+            (if arg-value
+              (begin
+                (display (string-append YELLOW "No test files matching " arg-value RESET))
+                (newline)
+              ) ;begin
+              (begin
+                (display (string-append YELLOW "No test files found in tests directory" RESET))
+                (newline)
+              ) ;begin
+            ) ;if
+            (exit 0)
           ) ;begin
           (begin
-            (display (string-append YELLOW "No test files found in tests directory" RESET))
-            (newline)
+            (when arg-value
+              (display-filter-info arg-type arg-value)
+            ) ;when
+            (let ((test-results
+                    (fold (lambda (test-file acc)
+                            (newline)
+                            (cons (run-test-file test-file) acc))
+                          (list)
+                          test-files))
+                    ) ;fold
+              (let ((failed (display-summary test-results)))
+                (exit (if (> failed 0) -1 0))
+              ) ;let
+            ) ;let
           ) ;begin
         ) ;if
-        (exit 0)
-      ) ;begin
-      (begin
-        (when only-pattern
-          (if (string-ends? only-pattern ".scm")
-            (begin
-              (display (string-append "Run test with file name: " only-pattern))
-              (newline)
-            ) ;begin
-            (begin
-              (display (string-append "Running tests matching: " only-pattern))
-              (newline)
-            ) ;begin
-          ) ;if
-        ) ;when
-        (let ((test-results
-                (fold (lambda (test-file acc)
-                        (newline)
-                        (cons (run-test-file test-file) acc))
-                      (list)
-                      test-files))
-                ) ;fold
-          (let ((failed (display-summary test-results)))
-            (exit (if (> failed 0) -1 0))
-          ) ;let
-        ) ;let
-      ) ;begin
-    ) ;if
-  ) ;let*
-) ;define
+      ) ;let*
+    ) ;define
+    
+    (define (main)
+      ;; 程序入口点
+      (run-goldtest)
+    ) ;define
+
+  ) ;begin
+) ;define-library


### PR DESCRIPTION
## Summary
简化 `gf test` 命令的参数解析逻辑，移除 `--only` 选项，改为根据参数类型自动判断匹配方式。

## 变更内容
- **移除 `--only` 选项**：参数不再需要 `--only` 前缀
- **自动识别参数类型**：
  - 路径参数（含 `/`）：文件直接运行，目录运行该目录下所有测试
  - `.scm` 文件名：按文件名精确匹配
  - 其他字符串：按路径模糊匹配

## 新用法示例
```bash
# 运行所有测试
bin/gf test

# 运行指定文件
bin/gf test tests/liii/json-test.scm

# 运行指定目录
bin/gf test tests/liii/json/

# 按文件名匹配
bin/gf test json-test.scm

# 按路径模糊匹配
bin/gf test json
```

## 测试
- 新增 `tests/goldfish/liii/goldtest-test.scm` 单元测试
- 手动验证所有使用场景

🤖 Generated with [Claude Code](https://claude.com/claude-code)