### PR TITLE
[215_4] 修复 (liii range) 导入失败

### DIFF
--- a/goldfish/liii/range.scm
+++ b/goldfish/liii/range.scm
@@ -24,8 +24,5 @@
           range-any range-every range-filter->list range-remove->list
           range-reverse range-map->vector range-filter->vector
           range-remove->vector vector->range range->list range->vector
-          range->string range->generator))
-  (begin
-    ; (liii range) 重新导出 (srfi srfi-196) 的所有函数
-  )
-)
+          range->string range->generator)
+) ;define-library

--- a/tests/liii/range/iota-range-test.scm
+++ b/tests/liii/range/iota-range-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/numeric-range-test.scm
+++ b/tests/liii/range/numeric-range-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-any-test.scm
+++ b/tests/liii/range/range-any-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-append-test.scm
+++ b/tests/liii/range/range-append-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-count-test.scm
+++ b/tests/liii/range/range-count-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-drop-right-test.scm
+++ b/tests/liii/range/range-drop-right-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-drop-test.scm
+++ b/tests/liii/range/range-drop-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-eq-p-test.scm
+++ b/tests/liii/range/range-eq-p-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-every-test.scm
+++ b/tests/liii/range/range-every-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-filter-to-list-test.scm
+++ b/tests/liii/range/range-filter-to-list-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-filter-to-vector-test.scm
+++ b/tests/liii/range/range-filter-to-vector-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-first-test.scm
+++ b/tests/liii/range/range-first-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-fold-right-test.scm
+++ b/tests/liii/range/range-fold-right-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-fold-test.scm
+++ b/tests/liii/range/range-fold-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-for-each-test.scm
+++ b/tests/liii/range/range-for-each-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-last-test.scm
+++ b/tests/liii/range/range-last-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-length-test.scm
+++ b/tests/liii/range/range-length-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-map-to-list-test.scm
+++ b/tests/liii/range/range-map-to-list-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-map-to-vector-test.scm
+++ b/tests/liii/range/range-map-to-vector-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-p-test.scm
+++ b/tests/liii/range/range-p-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-ref-test.scm
+++ b/tests/liii/range/range-ref-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-remove-to-list-test.scm
+++ b/tests/liii/range/range-remove-to-list-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-remove-to-vector-test.scm
+++ b/tests/liii/range/range-remove-to-vector-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-reverse-test.scm
+++ b/tests/liii/range/range-reverse-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-segment-test.scm
+++ b/tests/liii/range/range-segment-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-split-at-test.scm
+++ b/tests/liii/range/range-split-at-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-take-right-test.scm
+++ b/tests/liii/range/range-take-right-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-take-test.scm
+++ b/tests/liii/range/range-take-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-test.scm
+++ b/tests/liii/range/range-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-to-generator-test.scm
+++ b/tests/liii/range/range-to-generator-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-to-list-test.scm
+++ b/tests/liii/range/range-to-list-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-to-string-test.scm
+++ b/tests/liii/range/range-to-string-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/range-to-vector-test.scm
+++ b/tests/liii/range/range-to-vector-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/string-range-test.scm
+++ b/tests/liii/range/string-range-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/subrange-test.scm
+++ b/tests/liii/range/subrange-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/vector-range-test.scm
+++ b/tests/liii/range/vector-range-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)

--- a/tests/liii/range/vector-to-range-test.scm
+++ b/tests/liii/range/vector-to-range-test.scm
@@ -1,5 +1,5 @@
 (import (liii check)
-        (srfi srfi-196)
+        (liii range)
 ) ;import
 
 (check-set-mode! 'report-failed)


### PR DESCRIPTION
## 修复内容

### 问题
`(import (liii range))` 会失败，报错 `unexpected close paren`

### 原因
`goldfish/liii/range.scm` 中的 `begin` 块只有注释没有实际代码，导致 Scheme 解析错误

### 修复
1. 删除 `goldfish/liii/range.scm` 中空的 `begin` 块
2. 将 37 个测试文件的导入从 `(srfi srfi-196)` 改为 `(liii range)`

### 测试
所有 37 个 range 测试全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)