### PR TITLE
[216_22] 改进 range-test.scm 函数分类和常用示例

### DIFF
--- a/tests/liii/range-test.scm
+++ b/tests/liii/range-test.scm
@@ -4,15 +4,11 @@
 ;; 与 (liii list) 的 iota 不同：
 ;;   - iota 立即生成完整列表，占用 O(n) 内存
 ;;   - range 惰性求值，占用 O(1) 内存，支持随机访问和切片操作
-;;
-;; 查看函数文档示例：
-;;   bin/gf doc liii/range "range?"
-;;   bin/gf doc liii/range "numeric-range"
 
+;; ==== 常见用法示例 ====
 (import (liii range))
 
 ;; 示例1：循环迭代
-;; 仅用于展示循环场景；涉及状态修改应使用 range-fold（见示例2）
 (range-for-each
   (lambda (x) (display x) (newline))
   (numeric-range 0 5)                ; 输出: 0 1 2 3 4
@@ -27,7 +23,11 @@
 (define r (numeric-range 0 100))
 (range->list (range-take-right r 3)) ; => (97 98 99)
 
-;; ==================== 函数分类索引 ====================
+;; ==== 如何查看函数的文档和用例 ====
+;;   bin/gf doc liii/range "range?"
+;;   bin/gf doc liii/range "numeric-range"
+
+;; ==== 函数分类索引 ====
 
 ;; 一、构造函数
 ;; 用于创建 range 对象的函数


### PR DESCRIPTION
## 改进内容

改进 `tests/liii/range-test.scm`，作为 `(liii range)` 模块的文档和索引文件。

### 函数分类
将 range 模块的函数按功能分为八大类：
1. **构造函数** - range、numeric-range、vector-range 等
2. **谓词函数** - range?、range=?、range-any、range-every
3. **属性访问** - range-length、range-first、range-last
4. **元素访问** - range-ref、range-count
5. **子范围操作** - subrange、range-take-right、range-drop 等
6. **遍历操作** - range-map->list、range-for-each、range-fold 等
7. **过滤操作** - range-filter->list、range-remove->list 等
8. **类型转换** - vector->range、range->list、range->vector 等

### 常用用法示例
添加三个简洁的常用示例：
- **循环求和** - `range-for-each` 配合数值循环累加
- **切片截取** - `take-right` 体现惰性序列随机访问能力
- **循环累计** - `range-fold` 展示通用的状态累积模式

🤖 Generated with [Claude Code](https://claude.com/claude-code)