### PR TITLE
[215_17] 实现 (liii stack) 模块

### DIFF
--- a/devel/215_17.md
+++ b/devel/215_17.md
@@ -1,0 +1,85 @@
+# [215_17] 实现 (liii stack) 模块
+
+## 任务相关的代码文件
+- `goldfish/liii/stack.scm` - 栈模块实现（Apache License 2.0）
+- `tests/liii/stack/` - 栈单元测试目录
+
+## 如何测试
+```bash
+# 构建
+xmake b goldfish
+
+# 格式化代码
+bin/gf fix goldfish/liii/stack.scm
+bin/gf fix tests/liii/stack/*.scm
+
+# 运行单个测试
+bin/gf tests/liii/stack/make-stack-test.scm
+
+# 运行所有栈测试
+bin/gf test tests/liii/stack
+```
+
+## 2025-04-01 实现 (liii stack) 模块
+
+### What
+基于列表实现 `(liii stack)` 模块，提供后进先出（LIFO）的栈数据结构。
+
+共实现 14 个函数：
+
+**构造函数 (2个):**
+- `make-stack` - 创建空栈或从列表创建栈
+- `stack` - 从任意参数创建栈
+
+**谓词 (2个):**
+- `stack?` - 检查是否为栈
+- `stack-empty?` - 检查栈是否为空
+
+**访问器 (2个):**
+- `stack-top` - 获取栈顶元素（不移除）
+- `stack-size` - 获取栈中元素个数
+
+**修改器 (2个):**
+- `stack-push!` - 将元素压入栈顶
+- `stack-pop!` - 从栈顶弹出元素
+
+**转换函数 (2个):**
+- `stack->list` - 将栈转换为列表（从栈顶到栈底）
+- `list->stack` - 从列表创建栈
+
+**映射操作 (3个):**
+- `stack-map` - 映射函数到栈元素，返回新栈
+- `stack-map!` - 映射函数到栈元素，修改原栈
+- `stack-for-each` - 遍历栈元素
+
+**复制 (1个):**
+- `stack-copy` - 复制栈
+
+### How
+1. 直接在 `goldfish/liii/stack.scm` 中实现，采用 Apache License 2.0 协议
+2. 使用 `define-record-type` 定义栈记录类型，内部使用列表存储元素
+3. 栈顶对应列表的头部，保证 `stack-push!` 和 `stack-pop!` 操作的时间复杂度为 O(1)
+4. 所有单元测试放在 `tests/liii/stack/` 目录，每个函数一个独立的测试文件
+5. 测试文件命名规范：`函数名-test.scm`（例如 `make-stack-test.scm`）
+6. 参考 `(liii queue)` 的接口设计保持一致性
+
+### 单元测试统计
+共 13 个测试文件，总计 127 个测试用例全部通过：
+
+| 测试文件 | 测试用例数 |
+|---------|-----------|
+| make-stack-test.scm | 10 |
+| stack-test.scm | 12 |
+| stack-p-test.scm | 10 |
+| stack-empty-p-test.scm | 10 |
+| stack-top-test.scm | 7 |
+| stack-size-test.scm | 10 |
+| stack-push-test.scm | 8 |
+| stack-pop-test.scm | 13 |
+| stack-to-list-test.scm | 7 |
+| list-to-stack-test.scm | 12 |
+| stack-map-test.scm | 7 |
+| stack-map-bang-test.scm | 6 |
+| stack-for-each-test.scm | 6 |
+| stack-copy-test.scm | 9 |
+| **总计** | **127** |

--- a/goldfish/liii/stack.scm
+++ b/goldfish/liii/stack.scm
@@ -1,0 +1,116 @@
+;
+; Copyright (C) 2024 The Goldfish Scheme Authors
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+; http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+
+(define-library (liii stack)
+(export
+  ; Constructors
+  make-stack stack
+  ; Predicates
+  stack? stack-empty?
+  ; Accessors
+  stack-top stack-size
+  ; Mutators
+  stack-push! stack-pop!
+  ; Conversion
+  stack->list list->stack
+  ; Mapping
+  stack-map stack-map! stack-for-each
+  ; Copy
+  stack-copy
+) ;export
+(begin
+
+(define-record-type stack
+  (%make-stack elements)
+  stack?
+  (elements stack-elements stack-elements-set!)
+) ;define-record-type
+
+; Constructors
+(define (make-stack . args)
+  (if (null? args)
+      (%make-stack '())
+      (%make-stack (car args))
+  ) ;if
+) ;define
+
+(define (stack . elements)
+  (%make-stack elements)
+) ;define
+
+; Predicates
+(define (stack-empty? s)
+  (null? (stack-elements s))
+) ;define
+
+; Accessors
+(define (stack-top s)
+  (if (stack-empty? s)
+      (error 'stack-top "stack is empty")
+      (car (stack-elements s))
+  ) ;if
+) ;define
+
+(define (stack-size s)
+  (length (stack-elements s))
+) ;define
+
+; Mutators
+(define (stack-push! s elem)
+  (stack-elements-set! s (cons elem (stack-elements s)))
+  s
+) ;define
+
+(define (stack-pop! s)
+  (if (stack-empty? s)
+      (error 'stack-pop! "stack is empty")
+      (let ((top (car (stack-elements s))))
+        (stack-elements-set! s (cdr (stack-elements s)))
+        top
+      ) ;let
+  ) ;if
+) ;define
+
+; Conversion
+(define (stack->list s)
+  (stack-elements s)
+) ;define
+
+(define (list->stack lst)
+  (%make-stack lst)
+) ;define
+
+; Mapping
+(define (stack-map proc s)
+  (%make-stack (map proc (stack-elements s)))
+) ;define
+
+(define (stack-map! proc s)
+  (stack-elements-set! s (map proc (stack-elements s)))
+  s
+) ;define
+
+(define (stack-for-each proc s)
+  (for-each proc (stack-elements s))
+) ;define
+
+; Copy
+(define (stack-copy s)
+  (%make-stack (stack-elements s))
+) ;define
+
+) ;begin
+) ;define-library

--- a/tests/liii/stack-test.scm
+++ b/tests/liii/stack-test.scm
@@ -1,0 +1,41 @@
+(import (liii check)
+        (liii stack)
+) ;import
+
+(check-set-mode! 'report-failed)
+
+;; (liii stack) - 栈数据结构模块
+;; 提供后进先出（LIFO）的栈数据结构
+
+;; 构造函数
+;; make-stack - 创建空栈或从列表创建栈
+;; stack - 从任意参数创建栈
+
+;; 谓词
+;; stack? - 检查是否为栈
+;; stack-empty? - 检查栈是否为空
+
+;; 访问器
+;; stack-top - 获取栈顶元素
+;; stack-size - 获取栈中元素个数
+
+;; 修改器
+;; stack-push! - 将元素压入栈顶
+;; stack-pop! - 从栈顶弹出元素
+
+;; 转换函数
+;; stack->list - 将栈转换为列表（从栈顶到栈底）
+;; list->stack - 从列表创建栈
+
+;; 映射操作
+;; stack-map - 映射函数到栈元素，返回新栈
+;; stack-map! - 映射函数到栈元素，修改原栈
+;; stack-for-each - 遍历栈元素
+
+;; 复制
+;; stack-copy - 复制栈
+
+(display "=== Stack module loaded successfully ===")
+(newline)
+
+(check-report)

--- a/tests/liii/stack/list-to-stack-test.scm
+++ b/tests/liii/stack/list-to-stack-test.scm
@@ -1,0 +1,40 @@
+(import (liii check)
+        (liii stack)
+) ;import
+
+; Test list->stack with empty list
+(let ((s (list->stack '())))
+  (check (stack? s) => #t)
+  (check (stack-empty? s) => #t)
+  (check (stack-size s) => 0)
+) ;let
+
+; Test list->stack with single element
+(let ((s (list->stack '(1))))
+  (check (stack? s) => #t)
+  (check (stack-size s) => 1)
+  (check (stack-top s) => 1)
+) ;let
+
+; Test list->stack with multiple elements
+; First element of list becomes top of stack
+(let ((s (list->stack '(1 2 3))))
+  (check (stack-size s) => 3)
+  (check (stack-top s) => 1)
+) ;let
+
+; Test list->stack roundtrip with stack->list
+(let ((lst '(1 2 3 4 5)))
+  (let ((s (list->stack lst)))
+    (check (stack->list s) => lst)
+  ) ;let
+) ;let
+
+; Test list->stack then stack-pop!
+(let ((s (list->stack '(a b c))))
+  (check (stack-pop! s) => 'a)
+  (check (stack-pop! s) => 'b)
+  (check (stack-pop! s) => 'c)
+) ;let
+
+(check-report)

--- a/tests/liii/stack/make-stack-test.scm
+++ b/tests/liii/stack/make-stack-test.scm
@@ -1,0 +1,27 @@
+(import (liii check)
+        (liii stack)
+) ;import
+
+; Test make-stack with no arguments
+(let ((s (make-stack)))
+  (check (stack? s) => #t)
+  (check (stack-empty? s) => #t)
+  (check (stack-size s) => 0)
+) ;let
+
+; Test make-stack with a list
+(let ((s (make-stack '(1 2 3))))
+  (check (stack? s) => #t)
+  (check (stack-empty? s) => #f)
+  (check (stack-size s) => 3)
+  (check (stack-top s) => 1)
+) ;let
+
+; Test make-stack with empty list
+(let ((s (make-stack '())))
+  (check (stack? s) => #t)
+  (check (stack-empty? s) => #t)
+  (check (stack-size s) => 0)
+) ;let
+
+(check-report)

--- a/tests/liii/stack/stack-copy-test.scm
+++ b/tests/liii/stack/stack-copy-test.scm
@@ -1,0 +1,55 @@
+(import (liii check)
+        (liii stack)
+) ;import
+
+; Test stack-copy with empty stack
+(let ((s (make-stack)))
+  (let ((copy (stack-copy s)))
+    (check (stack? copy) => #t)
+    (check (stack-empty? copy) => #t)
+  ) ;let
+) ;let
+
+; Test stack-copy with single element
+(let ((s (stack 1)))
+  (let ((copy (stack-copy s)))
+    (check (stack-top copy) => 1)
+  ) ;let
+) ;let
+
+; Test stack-copy with multiple elements
+(let ((s (stack 1 2 3)))
+  (let ((copy (stack-copy s)))
+    (check (stack->list copy) => '(1 2 3))
+  ) ;let
+) ;let
+
+; Test stack-copy creates independent copy
+(let ((s (stack 1 2 3)))
+  (let ((copy (stack-copy s)))
+    (stack-push! copy 0)
+    ; Original should be unchanged
+    (check (stack->list s) => '(1 2 3))
+    (check (stack->list copy) => '(0 1 2 3))
+  ) ;let
+) ;let
+
+; Test stack-copy after pop
+(let ((s (stack 1 2 3)))
+  (stack-pop! s)
+  (let ((copy (stack-copy s)))
+    (check (stack->list copy) => '(2 3))
+  ) ;let
+) ;let
+
+; Test stack-copy preserves order
+(let ((s (make-stack)))
+  (stack-push! s 'first)
+  (stack-push! s 'second)
+  (let ((copy (stack-copy s)))
+    (check (stack-pop! copy) => 'second)
+    (check (stack-pop! copy) => 'first)
+  ) ;let
+) ;let
+
+(check-report)

--- a/tests/liii/stack/stack-empty-p-test.scm
+++ b/tests/liii/stack/stack-empty-p-test.scm
@@ -1,0 +1,43 @@
+(import (liii check)
+        (liii stack)
+) ;import
+
+; Test stack-empty? with empty stack
+(let ((s (make-stack)))
+  (check (stack-empty? s) => #t)
+) ;let
+
+(let ((s (stack)))
+  (check (stack-empty? s) => #t)
+) ;let
+
+; Test stack-empty? with non-empty stack
+(let ((s (make-stack '(1))))
+  (check (stack-empty? s) => #f)
+) ;let
+
+(let ((s (stack 1)))
+  (check (stack-empty? s) => #f)
+) ;let
+
+(let ((s (stack 1 2 3)))
+  (check (stack-empty? s) => #f)
+) ;let
+
+; Test stack-empty? after operations
+(let ((s (stack 1 2)))
+  (check (stack-empty? s) => #f)
+  (stack-pop! s)
+  (check (stack-empty? s) => #f)
+  (stack-pop! s)
+  (check (stack-empty? s) => #t)
+) ;let
+
+; Test stack-empty? after push
+(let ((s (make-stack)))
+  (check (stack-empty? s) => #t)
+  (stack-push! s 1)
+  (check (stack-empty? s) => #f)
+) ;let
+
+(check-report)

--- a/tests/liii/stack/stack-for-each-test.scm
+++ b/tests/liii/stack/stack-for-each-test.scm
@@ -1,0 +1,47 @@
+(import (liii check)
+        (liii stack)
+) ;import
+
+; Test stack-for-each on empty stack
+(let ((s (make-stack))
+      (count 0))
+  (stack-for-each (lambda (x) (set! count (+ count 1)))
+s)
+  (check count => 0))
+
+; Test stack-for-each on single element
+(let ((s (stack 1))
+      (sum 0))
+  (stack-for-each (lambda (x) (set! sum (+ sum x))) s)
+  (check sum => 1)
+) ;let
+
+; Test stack-for-each on multiple elements
+(let ((s (stack 1 2 3))
+      (sum 0))
+  (stack-for-each (lambda (x) (set! sum (+ sum x))) s)
+  (check sum => 6)
+) ;let
+
+; Test stack-for-each processes elements in order
+(let ((s (stack 1 2 3))
+      (lst '()))
+  (stack-for-each (lambda (x) (set! lst (cons x lst))) s)
+  ; Elements are processed from top to bottom
+  (check lst => '(3 2 1))
+) ;let
+
+; Test stack-for-each doesn't modify stack
+(let ((s (stack 1 2 3)))
+  (stack-for-each (lambda (x) (* x 2)) s)
+  (check (stack->list s) => '(1 2 3))
+) ;let
+
+; Test stack-for-each with side effects
+(let ((s (stack "a" "b" "c"))
+      (result ""))
+  (stack-for-each (lambda (x) (set! result (string-append result x))) s)
+  (check result => "abc")
+) ;let
+
+(check-report)

--- a/tests/liii/stack/stack-map-bang-test.scm
+++ b/tests/liii/stack/stack-map-bang-test.scm
@@ -1,0 +1,40 @@
+(import (liii check)
+        (liii stack)
+) ;import
+
+; Test stack-map! on empty stack
+(let ((s (make-stack)))
+  (stack-map! (lambda (x) (* x 2)) s)
+  (check (stack-empty? s) => #t)
+) ;let
+
+; Test stack-map! on single element
+(let ((s (stack 1)))
+  (stack-map! (lambda (x) (* x 2)) s)
+  (check (stack-top s) => 2)
+) ;let
+
+; Test stack-map! on multiple elements
+(let ((s (stack 1 2 3)))
+  (stack-map! (lambda (x) (* x 2)) s)
+  (check (stack->list s) => '(2 4 6))
+) ;let
+
+; Test stack-map! modifies original stack
+(let ((s (stack 1 2 3)))
+  (stack-map! (lambda (x) (* x 2)) s)
+  (check (stack->list s) => '(2 4 6))
+) ;let
+
+; Test stack-map! returns the stack
+(let ((s (stack 1 2 3)))
+  (check (stack-map! (lambda (x) (* x 2)) s) => s)
+) ;let
+
+; Test stack-map! with different function
+(let ((s (stack 10 20 30)))
+  (stack-map! (lambda (x) (/ x 10)) s)
+  (check (stack->list s) => '(1 2 3))
+) ;let
+
+(check-report)

--- a/tests/liii/stack/stack-map-test.scm
+++ b/tests/liii/stack/stack-map-test.scm
@@ -1,0 +1,47 @@
+(import (liii check)
+        (liii stack)
+) ;import
+
+; Test stack-map on empty stack
+(let ((s (make-stack)))
+  (let ((result (stack-map (lambda (x) (* x 2)) s)))
+    (check (stack? result) => #t)
+    (check (stack-empty? result) => #t)
+  ) ;let
+) ;let
+
+; Test stack-map on single element
+(let ((s (stack 1)))
+  (let ((result (stack-map (lambda (x) (* x 2)) s)))
+    (check (stack-top result) => 2)
+  ) ;let
+) ;let
+
+; Test stack-map on multiple elements
+(let ((s (stack 1 2 3)))
+  (let ((result (stack-map (lambda (x) (* x 2)) s)))
+    (check (stack->list result) => '(2 4 6))
+  ) ;let
+) ;let
+
+; Test stack-map doesn't modify original stack
+(let ((s (stack 1 2 3)))
+  (stack-map (lambda (x) (* x 2)) s)
+  (check (stack->list s) => '(1 2 3))
+) ;let
+
+; Test stack-map with different function
+(let ((s (stack 1 2 3)))
+  (let ((result (stack-map (lambda (x) (+ x 10)) s)))
+    (check (stack->list result) => '(11 12 13))
+  ) ;let
+) ;let
+
+; Test stack-map with list result function
+(let ((s (stack 1 2)))
+  (let ((result (stack-map (lambda (x) (list x x)) s)))
+    (check (stack->list result) => '((1 1) (2 2)))
+  ) ;let
+) ;let
+
+(check-report)

--- a/tests/liii/stack/stack-p-test.scm
+++ b/tests/liii/stack/stack-p-test.scm
@@ -1,0 +1,26 @@
+(import (liii check)
+        (liii stack)
+) ;import
+
+; Test stack? with stack
+(let ((s (make-stack)))
+  (check (stack? s) => #t)
+) ;let
+
+(let ((s (stack 1 2 3)))
+  (check (stack? s) => #t)
+) ;let
+
+; Test stack? with non-stack values
+(check (stack? '()) => #f)
+(check (stack? '(1 2 3)) => #f)
+(check (stack? 42) => #f)
+(check (stack? "hello") => #f)
+(check (stack? #t) => #f)
+(check (stack? 'symbol) => #f)
+(check (stack? (list 1 2 3)) => #f)
+
+; Test that internal record is not exposed
+(check (stack? (list->stack '(1 2 3))) => #t)
+
+(check-report)

--- a/tests/liii/stack/stack-pop-test.scm
+++ b/tests/liii/stack/stack-pop-test.scm
@@ -1,0 +1,46 @@
+(import (liii check)
+        (liii stack)
+) ;import
+
+; Test stack-pop! returns top element
+(let ((s (stack 1 2 3)))
+  (check (stack-pop! s) => 1)
+  (check (stack-pop! s) => 2)
+  (check (stack-pop! s) => 3)
+) ;let
+
+; Test stack-pop! modifies stack
+(let ((s (stack 1 2 3)))
+  (check (stack-size s) => 3)
+  (stack-pop! s)
+  (check (stack-size s) => 2)
+  (check (stack-top s) => 2)
+) ;let
+
+; Test stack-pop! all elements
+(let ((s (stack 1 2)))
+  (stack-pop! s)
+  (stack-pop! s)
+  (check (stack-empty? s) => #t)
+) ;let
+
+; Test stack-push! then stack-pop!
+(let ((s (make-stack)))
+  (stack-push! s 1)
+  (stack-push! s 2)
+  (check (stack-pop! s) => 2)
+  (check (stack-pop! s) => 1)
+  (check (stack-empty? s) => #t)
+) ;let
+
+; Test stack-pop! with LIFO order
+(let ((s (make-stack)))
+  (stack-push! s 'first)
+  (stack-push! s 'second)
+  (stack-push! s 'third)
+  (check (stack-pop! s) => 'third)
+  (check (stack-pop! s) => 'second)
+  (check (stack-pop! s) => 'first)
+) ;let
+
+(check-report)

--- a/tests/liii/stack/stack-push-test.scm
+++ b/tests/liii/stack/stack-push-test.scm
@@ -1,0 +1,42 @@
+(import (liii check)
+        (liii stack)
+) ;import
+
+; Test stack-push! on empty stack
+(let ((s (make-stack)))
+  (stack-push! s 1)
+  (check (stack-size s) => 1)
+  (check (stack-top s) => 1)
+) ;let
+
+; Test stack-push! multiple times
+(let ((s (make-stack)))
+  (stack-push! s 1)
+  (stack-push! s 2)
+  (stack-push! s 3)
+  (check (stack-size s) => 3)
+  ; Top should be the last pushed
+  (check (stack-top s) => 3)
+) ;let
+
+; Test stack-push! on non-empty stack
+(let ((s (stack 1 2)))
+  (stack-push! s 3)
+  (check (stack-size s) => 3)
+  (check (stack-top s) => 3)
+) ;let
+
+; Test stack-push! returns the stack
+(let ((s (make-stack)))
+  (check (stack-push! s 1) => s)
+) ;let
+
+; Test stack-push! with different types
+(let ((s (make-stack)))
+  (stack-push! s 1)
+  (stack-push! s "hello")
+  (stack-push! s 'symbol)
+  (check (stack-top s) => 'symbol)
+) ;let
+
+(check-report)

--- a/tests/liii/stack/stack-size-test.scm
+++ b/tests/liii/stack/stack-size-test.scm
@@ -1,0 +1,42 @@
+(import (liii check)
+        (liii stack)
+) ;import
+
+; Test stack-size with empty stack
+(let ((s (make-stack)))
+  (check (stack-size s) => 0)
+) ;let
+
+; Test stack-size with single element
+(let ((s (stack 1)))
+  (check (stack-size s) => 1)
+) ;let
+
+; Test stack-size with multiple elements
+(let ((s (stack 1 2 3)))
+  (check (stack-size s) => 3)
+) ;let
+
+(let ((s (stack 'a 'b 'c 'd 'e)))
+  (check (stack-size s) => 5)
+) ;let
+
+; Test stack-size after push
+(let ((s (make-stack)))
+  (check (stack-size s) => 0)
+  (stack-push! s 1)
+  (check (stack-size s) => 1)
+  (stack-push! s 2)
+  (check (stack-size s) => 2)
+) ;let
+
+; Test stack-size after pop
+(let ((s (stack 1 2 3)))
+  (check (stack-size s) => 3)
+  (stack-pop! s)
+  (check (stack-size s) => 2)
+  (stack-pop! s)
+  (check (stack-size s) => 1)
+) ;let
+
+(check-report)

--- a/tests/liii/stack/stack-test.scm
+++ b/tests/liii/stack/stack-test.scm
@@ -1,0 +1,34 @@
+(import (liii check)
+        (liii stack)
+) ;import
+
+; Test stack with no arguments
+(let ((s (stack)))
+  (check (stack? s) => #t)
+  (check (stack-empty? s) => #t)
+  (check (stack-size s) => 0)
+) ;let
+
+; Test stack with single element
+(let ((s (stack 1)))
+  (check (stack? s) => #t)
+  (check (stack-empty? s) => #f)
+  (check (stack-size s) => 1)
+  (check (stack-top s) => 1)
+) ;let
+
+; Test stack with multiple elements
+(let ((s (stack 1 2 3)))
+  (check (stack? s) => #t)
+  (check (stack-size s) => 3)
+  ; Top should be the first element (1)
+  (check (stack-top s) => 1)
+) ;let
+
+; Test stack with different types
+(let ((s (stack 'a "hello" 42)))
+  (check (stack-size s) => 3)
+  (check (stack-top s) => 'a)
+) ;let
+
+(check-report)

--- a/tests/liii/stack/stack-to-list-test.scm
+++ b/tests/liii/stack/stack-to-list-test.scm
@@ -1,0 +1,38 @@
+(import (liii check)
+        (liii stack)
+) ;import
+
+; Test stack->list with empty stack
+(let ((s (make-stack)))
+  (check (stack->list s) => '())
+) ;let
+
+; Test stack->list with single element
+(let ((s (stack 1)))
+  (check (stack->list s) => '(1))
+) ;let
+
+; Test stack->list with multiple elements
+; Elements should be returned as stored (top first)
+(let ((s (stack 1 2 3)))
+  (check (stack->list s) => '(1 2 3))
+) ;let
+
+; Test stack->list doesn't modify stack
+(let ((s (stack 1 2 3)))
+  (stack->list s)
+  (check (stack-size s) => 3)
+  (check (stack-top s) => 1)
+) ;let
+
+; Test stack->list after push/pop operations
+(let ((s (make-stack)))
+  (stack-push! s 'a)
+  (stack-push! s 'b)
+  (stack-push! s 'c)
+  (check (stack->list s) => '(c b a))
+  (stack-pop! s)
+  (check (stack->list s) => '(b a))
+) ;let
+
+(check-report)

--- a/tests/liii/stack/stack-top-test.scm
+++ b/tests/liii/stack/stack-top-test.scm
@@ -1,0 +1,32 @@
+(import (liii check)
+        (liii stack)
+) ;import
+
+; Test stack-top with single element
+(let ((s (stack 1)))
+  (check (stack-top s) => 1)
+) ;let
+
+; Test stack-top with multiple elements (top is first)
+(let ((s (stack 1 2 3)))
+  (check (stack-top s) => 1)
+) ;let
+
+; Test stack-top with different types
+(let ((s (stack 'symbol "string" 42)))
+  (check (stack-top s) => 'symbol)
+) ;let
+
+; Test stack-top doesn't modify stack
+(let ((s (stack 1 2 3)))
+  (check (stack-top s) => 1)
+  (check (stack-size s) => 3)
+  (check (stack-top s) => 1)
+) ;let
+
+; Test stack-top with nested list
+(let ((s (stack '(1 2) '(3 4))))
+  (check (stack-top s) => '(1 2))
+) ;let
+
+(check-report)


### PR DESCRIPTION
## 摘要
基于列表实现 `(liii stack)` 模块，提供后进先出（LIFO）的栈数据结构。

## 实现内容

### 14个函数

**构造函数 (2个):**
- `make-stack` - 创建空栈或从列表创建栈
- `stack` - 从任意参数创建栈

**谓词 (2个):**
- `stack?` - 检查是否为栈
- `stack-empty?` - 检查栈是否为空

**访问器 (2个):**
- `stack-top` - 获取栈顶元素（不移除）
- `stack-size` - 获取栈中元素个数

**修改器 (2个):**
- `stack-push!` - 将元素压入栈顶
- `stack-pop!` - 从栈顶弹出元素

**转换函数 (2个):**
- `stack->list` - 将栈转换为列表（从栈顶到栈底）
- `list->stack` - 从列表创建栈

**映射操作 (3个):**
- `stack-map` - 映射函数到栈元素，返回新栈
- `stack-map!` - 映射函数到栈元素，修改原栈
- `stack-for-each` - 遍历栈元素

**复制 (1个):**
- `stack-copy` - 复制栈

### 单元测试
共 14 个测试文件，127 个测试用例全部通过

## 测试方法
```bash
xmake b goldfish
for f in tests/liii/stack/*.scm; do bin/gf "$f"; done
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)