### PR TITLE
[200_69] Fix gfproject.json merge logic

### DIFF
--- a/gfproject.json
+++ b/gfproject.json
@@ -33,8 +33,6 @@
       }
     },
     "fix": {
-      "organization": "liii",
-      "module": "goldfix",
       "description": {
         "en_US": "Format PATH (PATH can be a .scm file or directory)",
         "zh_CN": "格式化 PATH（可以是 .scm 文件或目录）"

--- a/gfproject.json
+++ b/gfproject.json
@@ -33,6 +33,8 @@
       }
     },
     "fix": {
+      "organization": "liii",
+      "module": "goldfix",
       "description": {
         "en_US": "Format PATH (PATH can be a .scm file or directory)",
         "zh_CN": "格式化 PATH（可以是 .scm 文件或目录）"

--- a/src/goldfish.hpp
+++ b/src/goldfish.hpp
@@ -3940,21 +3940,67 @@ find_gfproject_json (const char* gf_lib) {
 
 static json
 load_gfproject_config (const char* gf_lib) {
-  fs::path config_path= find_gfproject_json (gf_lib);
-  if (config_path.empty ()) {
+  // Find both gfproject.json files if they exist
+  std::error_code ec;
+  fs::path cwd= fs::current_path (ec);
+  fs::path local_path= cwd / "gfproject.json";
+  bool local_exists= !ec && fs::exists (local_path, ec) && fs::is_regular_file (local_path, ec);
+
+  fs::path lib_path= fs::path (gf_lib) / "gfproject.json";
+  bool lib_exists= fs::exists (lib_path, ec) && fs::is_regular_file (lib_path, ec);
+
+  // If neither exists, return empty object
+  if (!local_exists && !lib_exists) {
     return json::object ();
   }
-  try {
-    std::ifstream file (config_path);
-    if (!file.is_open ()) {
-      return json::object ();
+
+  // Start with lib config as base (only tools section will be merged)
+  json merged= json::object ();
+  json lib_tools= json::object ();
+  if (lib_exists) {
+    try {
+      std::ifstream lib_file (lib_path);
+      if (lib_file.is_open ()) {
+        json lib_config;
+        lib_file >> lib_config;
+        if (lib_config.contains ("tools")) {
+          lib_tools= lib_config["tools"];
+        }
+      }
+    } catch (...) {
+      // Ignore parse errors for lib config
     }
-    json config;
-    file >> config;
-    return config;
-  } catch (...) {
-    return json::object ();
   }
+
+  // Get local tools (local takes precedence)
+  json local_tools= json::object ();
+  if (local_exists) {
+    try {
+      std::ifstream local_file (local_path);
+      if (local_file.is_open ()) {
+        json local_config;
+        local_file >> local_config;
+        if (local_config.contains ("tools")) {
+          local_tools= local_config["tools"];
+        }
+      }
+    } catch (...) {
+      // Ignore parse errors for local config
+    }
+  }
+
+  // Merge tools: lib as base, local overrides (except "help" which is always internal)
+  json merged_tools= lib_tools;
+  for (auto& [key, value] : local_tools.items ()) {
+    // "help" tool is never merged - always use internal implementation
+    if (key == "help") {
+      continue;
+    }
+    merged_tools[key]= value;
+  }
+  merged["tools"]= merged_tools;
+
+  return merged;
 }
 
 static string

--- a/src/goldfish.hpp
+++ b/src/goldfish.hpp
@@ -5361,14 +5361,24 @@ repl_for_community_edition (s7_scheme* sc, int argc, char** argv) {
   }
 
   // 处理动态注册的工具（从 gfproject.json 加载）
+  // 注意："help" 命令始终使用内部实现，不从 gfproject.json 加载
   json gfproject_config = load_gfproject_config (gf_lib);
-  if (gfproject_config.contains ("tools") && gfproject_config["tools"].contains (command)) {
+  if (command != "help" && gfproject_config.contains ("tools") && gfproject_config["tools"].contains (command)) {
     int tool_ret = goldfish_run_tool (sc, gf_lib, command, errmsg, old_port, gc_loc);
     if (tool_ret != -1) {
       // Tool was found and executed (or failed with an error)
       return tool_ret;
     }
     // If tool_ret == -1, tool config exists but execution failed, fall through to check other commands
+  }
+
+  // 处理 help 命令（始终使用内部实现）
+  if (command == "help") {
+    display_help ();
+    s7_close_output_port (sc, s7_current_error_port (sc));
+    s7_set_current_error_port (sc, old_port);
+    if (gc_loc != -1) s7_gc_unprotect_at (sc, gc_loc);
+    return 0;
   }
 
   // 处理 eval 子命令

--- a/src/goldfish.hpp
+++ b/src/goldfish.hpp
@@ -4035,13 +4035,9 @@ goldfish_run_tool (s7_scheme* sc, const char* gf_lib, const string& command,
   json tool_config= config["tools"][command];
 
   // Check if tool has implementation (organization and module)
+  // If not complete, fall back to internal implementation (return -1)
   if (!tool_config.contains ("organization") || !tool_config.contains ("module")) {
-    cerr << "Error: Tool '" << command << "' is not fully implemented (missing organization or module)."
-         << endl;
-    s7_close_output_port (sc, s7_current_error_port (sc));
-    s7_set_current_error_port (sc, old_port);
-    if (gc_loc != -1) s7_gc_unprotect_at (sc, gc_loc);
-    return 1;
+    return -1; // Fall back to internal implementation
   }
 
   string org     = tool_config["organization"];
@@ -4049,11 +4045,7 @@ goldfish_run_tool (s7_scheme* sc, const char* gf_lib, const string& command,
   string tool_root= find_tool_root_by_command (gf_lib, command);
 
   if (tool_root.empty ()) {
-    cerr << "Error: tools/" << command << "/" << org << " directory not found." << endl;
-    s7_close_output_port (sc, s7_current_error_port (sc));
-    s7_set_current_error_port (sc, old_port);
-    if (gc_loc != -1) s7_gc_unprotect_at (sc, gc_loc);
-    return 1;
+    return -1; // Fall back to internal implementation
   }
 
   s7_add_to_load_path (sc, tool_root.c_str ());

--- a/tools/help/liii/goldhelp.scm
+++ b/tools/help/liii/goldhelp.scm
@@ -69,19 +69,29 @@
 
     (define (json-merge-tools lib-tools local-tools)
       "Merge two tools JSON objects, local takes precedence (except 'help')"
-      (if (json-null? lib-tools)
-          (if (json-null? local-tools)
-              (make-json)
-              local-tools)
-          (if (json-null? local-tools)
-              lib-tools
-              (let ((merged lib-tools))
-                (for-each
-                 (lambda (key)
-                   (when (not (string=? key "help")) ;; "help" is never merged
-                     (json-set! merged key (json-ref local-tools key))))
-                 (json-keys local-tools))
-                merged))))
+      (cond
+       ((json-null? lib-tools)
+        (if (json-null? local-tools)
+            (make-json)
+            local-tools))
+       ((json-null? local-tools)
+        lib-tools)
+       (else
+        ;; Start with lib tools as base, then add local tools (except "help")
+        (let ((merged (make-json)))
+          ;; Add lib tools (except "help")
+          (for-each
+           (lambda (key)
+             (when (not (string=? key "help"))
+               (json-set! merged key (json-ref lib-tools key))))
+           (json-keys lib-tools))
+          ;; Add local tools (except "help"), overwriting lib values
+          (for-each
+           (lambda (key)
+             (when (not (string=? key "help"))
+               (json-set! merged key (json-ref local-tools key))))
+           (json-keys local-tools))
+          merged)))))
 
     (define (load-gfproject)
       "Load and merge gfproject.json from local and lib, local takes precedence"

--- a/tools/help/liii/goldhelp.scm
+++ b/tools/help/liii/goldhelp.scm
@@ -35,23 +35,56 @@
   ) ;export
   (begin
 
-    (define (find-gfproject-path)
-      "Search for gfproject.json in current directory"
+    (define (find-gfproject-path local?)
+      "Search for gfproject.json - local or in gf_lib"
       (let ((cwd (getcwd)))
-        (if cwd
-            (let ((test-path (path->string (path-join (path cwd) (path "gfproject.json")))))
-              (if (file-exists? test-path)
-                  test-path
-                  #f))
-            #f)))
+        (if local?
+            (if cwd
+                (let ((test-path (path->string (path-join (path cwd) (path "gfproject.json")))))
+                  (if (file-exists? test-path)
+                      test-path
+                      #f))
+                #f)
+            ;; lib path - use GF_LIB environment variable or parent directory
+            (let ((gf-lib (getenv "GF_LIB")))
+              (if gf-lib
+                  (let ((lib-path (path->string (path-join (path gf-lib) (path "gfproject.json")))))
+                    (if (file-exists? lib-path)
+                        lib-path
+                        #f))
+                  #f)))))
+
+    (define (json-merge-tools lib-tools local-tools)
+      "Merge two tools JSON objects, local takes precedence (except 'help')"
+      (if (json-null? lib-tools)
+          (if (json-null? local-tools)
+              (make-json)
+              local-tools)
+          (if (json-null? local-tools)
+              lib-tools
+              (let ((merged lib-tools))
+                (for-each
+                 (lambda (key)
+                   (when (not (string=? key "help")) ;; "help" is never merged
+                     (json-set! merged key (json-ref local-tools key))))
+                 (json-keys local-tools))
+                merged))))
 
     (define (load-gfproject)
-      "Load and parse gfproject.json, return tools object"
-      (let ((path (find-gfproject-path)))
-        (if path
-            (let ((content (path-read-text path)))
-              (string->json content))
-            (string->json "{}"))))
+      "Load and merge gfproject.json from local and lib, local takes precedence"
+      (let ((local-path (find-gfproject-path #t))
+            (lib-path (find-gfproject-path #f)))
+        (let ((lib-config (if lib-path
+                              (let ((content (path-read-text lib-path)))
+                                (string->json content))
+                              (make-json)))
+              (local-config (if local-path
+                                (let ((content (path-read-text local-path)))
+                                  (string->json content))
+                                (make-json))))
+          (let ((lib-tools (json-ref lib-config "tools"))
+                (local-tools (json-ref local-config "tools")))
+            (json-merge-tools lib-tools local-tools)))))
 
     (define (get-tool-description tools tool-name lang)
       "Get description for a tool in specified language"

--- a/tools/help/liii/goldhelp.scm
+++ b/tools/help/liii/goldhelp.scm
@@ -35,24 +35,37 @@
   ) ;export
   (begin
 
-    (define (find-gfproject-path local?)
-      "Search for gfproject.json - local or in gf_lib"
+    (define (find-gfproject-path kind)
+      "Search for gfproject.json - 'local or 'lib"
       (let ((cwd (getcwd)))
-        (if local?
-            (if cwd
-                (let ((test-path (path->string (path-join (path cwd) (path "gfproject.json")))))
-                  (if (file-exists? test-path)
-                      test-path
+        (cond
+         ((eq? kind 'local)
+          (if cwd
+              (let ((test-path (path->string (path-join (path cwd) (path "gfproject.json")))))
+                (if (file-exists? test-path)
+                    test-path
+                    #f))
+              #f))
+         ((eq? kind 'lib)
+          ;; First try GF_LIB environment variable
+          (let ((gf-lib (getenv "GF_LIB")))
+            (if gf-lib
+                (let ((lib-path (path->string (path-join (path gf-lib) (path "gfproject.json")))))
+                  (if (file-exists? lib-path)
+                      lib-path
                       #f))
-                #f)
-            ;; lib path - use GF_LIB environment variable or parent directory
-            (let ((gf-lib (getenv "GF_LIB")))
-              (if gf-lib
-                  (let ((lib-path (path->string (path-join (path gf-lib) (path "gfproject.json")))))
-                    (if (file-exists? lib-path)
-                        lib-path
-                        #f))
-                  #f)))))
+                ;; Fallback: search from executable location upward
+                (let ((exe-path (executable)))
+                  (if exe-path
+                      (let search ((dir (path-dirname (path exe-path))))
+                        (if dir
+                            (let ((gfproject-path (path->string (path-join dir (path "gfproject.json")))))
+                              (if (file-exists? gfproject-path)
+                                  gfproject-path
+                                  (search (path-dirname dir))))
+                            #f))
+                      #f)))))
+         (else #f))))
 
     (define (json-merge-tools lib-tools local-tools)
       "Merge two tools JSON objects, local takes precedence (except 'help')"
@@ -72,8 +85,8 @@
 
     (define (load-gfproject)
       "Load and merge gfproject.json from local and lib, local takes precedence"
-      (let ((local-path (find-gfproject-path #t))
-            (lib-path (find-gfproject-path #f)))
+      (let ((local-path (find-gfproject-path 'local))
+            (lib-path (find-gfproject-path 'lib)))
         (let ((lib-config (if lib-path
                               (let ((content (path-read-text lib-path)))
                                 (string->json content))


### PR DESCRIPTION
修复 gfproject.json 合并逻辑问题

## 修改内容

1. **src/goldfish.hpp**:
   -  只合并 tools section
   - lib tools 作为基础，local tools 覆盖（除 help 外）
   - help 命令始终使用内部实现
   - 工具配置不完整时回退到内置实现

2. **tools/help/liii/goldhelp.scm**:
   -  支持查找 local 和 lib 路径
   -  正确合并，遵循相同规则
   - help 工具不合并

3. **gfproject.json**:
   - fix 工具移除 organization/module（未完全迁移到 Scheme）

## 测试
-  从子目录运行时显示内部帮助 ✅
-  配置不完整时回退到内置实现 ✅