### PR TITLE
[216_47] substring 文档和测试

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,18 +12,52 @@
 - 使用空格进行缩进，而不是制表符
 - 建议缩进宽度为2个空格
 
-## 代码格式化工具
-Goldfish 内置了代码格式化工具 `gf fix`，用于自动格式化 Scheme 代码。
+## CLI 工具
 
-### 基本用法
+### gf doc - 文档浏览工具
+`gf doc` 用于浏览 Goldfish Scheme 库的文档和测试用例。
+
+```bash
+# 查看某个库的文档
+bin/gf doc scheme/base
+
+# 查看某个函数的文档
+bin/gf doc substring
+
+# 查看指定库下某个函数的文档
+bin/gf doc scheme/base "substring"
+
+# 重建函数索引（在新增或修改测试文件后执行）
+bin/gf doc --build-json
+```
+
+文档来源是 `tests/` 目录下的 `*-test.scm` 测试文件。为函数添加文档时，只需在对应库的路径下创建 `函数名-test.scm` 测试文件，然后执行 `bin/gf doc --build-json` 更新索引。
+
+### gf fmt - 代码格式化工具
+`gf fmt` 用于自动格式化 Scheme 代码（调整缩进、换行等）。
+
 ```bash
 # 格式化单个文件（原地修改）
-bin/gf fix goldfish/liii/os.scm
+bin/gf fmt goldfish/liii/os.scm
 
 # 格式化整个目录（原地修改）
-bin/gf fix goldfish/
+bin/gf fmt goldfish/
 
 # 仅查看格式化结果（不修改文件）
+bin/gf fmt --dry-run goldfish/liii/os.scm
+```
+
+### gf fix - 括号修正工具
+`gf fix` 用于根据缩进自动修正 Scheme 代码的括号。
+
+```bash
+# 修正单个文件（原地修改）
+bin/gf fix goldfish/liii/os.scm
+
+# 修正整个目录（原地修改）
+bin/gf fix goldfish/
+
+# 仅查看修正结果（不修改文件）
 bin/gf fix --dry-run goldfish/liii/os.scm
 ```
 
@@ -34,8 +68,8 @@ bin/gf fix --dry-run goldfish/liii/os.scm
 xmake b goldfish
 
 # 2. 格式化代码
-bin/gf fix goldfish/liii/xxx.scm
-bin/gf fix tests/goldfish/liii/xxx-test.scm
+bin/gf fmt goldfish/liii/xxx.scm
+bin/gf fmt tests/goldfish/liii/xxx-test.scm
 
 # 3. 运行测试
 bin/gf tests/goldfish/liii/xxx-test.scm

--- a/tests/liii/unicode/utf8-substring-test.scm
+++ b/tests/liii/unicode/utf8-substring-test.scm
@@ -32,7 +32,13 @@
 ;;
 ;; 描述
 ;; ----
-;; 与 string-substring 不同，utf8-substring 基于 Unicode 字符位置而非字节位置进行提取。
+;; 与 substring 不同，utf8-substring 基于 Unicode 字符位置而非字节位置进行提取。
+;; 对于纯 ASCII 字符串，两者效果相同；对于包含中文、emoji 等多字节字符的字符串，
+;; 应使用 utf8-substring 以避免字符被拆断。
+;;
+;; 相关函数
+;; ----
+;; (scheme base) 中的 substring — R7RS 标准子串提取函数。
 ;;
 ;; 错误处理
 ;; ----

--- a/tests/scheme/base/substring-test.scm
+++ b/tests/scheme/base/substring-test.scm
@@ -1,0 +1,77 @@
+(import (liii check))
+(import (scheme base))
+(check-set-mode! 'report-failed)
+
+;; substring
+;; 提取字符串的子串。
+;;
+;; 语法
+;; ----
+;; (substring string start end)
+;;
+;; 参数
+;; ----
+;; string : string
+;; 源字符串。
+;;
+;; start : integer
+;; 起始位置（基于字符位置，从 0 开始计数）。
+;;
+;; end : integer
+;; 结束位置（不包含）。
+;;
+;; 返回值
+;; ----
+;; string
+;; 从 start 到 end（不包含）的子字符串。
+;;
+;; 说明
+;; ----
+;; 1. substring 基于字符位置（而非 Unicode 码点位置）进行提取。
+;; 2. 对于包含多字节字符（如中文）的字符串，建议使用 utf8-substring。
+;;    使用 `gf doc utf8-substring` 可查看 utf8-substring 的文档和用法。
+;;
+;; 注意
+;; ----
+;; substring 是 R7RS (scheme base) 标准函数，不支持 UTF-8 多字节字符的正确拆分。
+;; 如果需要处理 Unicode 字符串，请使用 utf8-substring。
+;;
+;; 错误处理
+;; ----
+;; wrong-type-arg 当参数类型不正确时。
+;; out-of-range 当 start 或 end 超出字符串范围时。
+
+;; 基本 ASCII 测试
+(check (substring "Hello" 0 5)
+  =>
+  "Hello"
+) ;check
+(check (substring "Hello" 0 2) => "He")
+(check (substring "Hello" 2 4) => "ll")
+(check (substring "Hello" 1 5)
+  =>
+  "ello"
+) ;check
+(check (substring "Hello" 0 0) => "")
+(check (substring "Hello" 3 3) => "")
+
+;; 空字符串
+(check (substring "" 0 0) => "")
+
+;; 边界测试
+(check (substring "abc" 0 1) => "a")
+(check (substring "abc" 1 2) => "b")
+(check (substring "abc" 2 3) => "c")
+
+;; 错误处理
+(check-catch 'out-of-range
+  (substring "Hello" 0 6)
+) ;check-catch
+(check-catch 'out-of-range
+  (substring "Hello" 6 6)
+) ;check-catch
+(check-catch 'out-of-range
+  (substring "Hello" 3 2)
+) ;check-catch
+
+(check-report)


### PR DESCRIPTION
## Summary
- 新增 `tests/scheme/base/substring-test.scm`，为 `(scheme base)` 的 `substring` 添加文档和测试用例
- 在文档中提及 `utf8-substring` 作为 Unicode 字符串的替代方案
- 更新 `tests/liii/unicode/utf8-substring-test.scm`，在文档中关联 `substring`
- 在 `CLAUDE.md` 中补充 `gf doc`、`gf fmt`、`gf fix` 的 CLI 工具说明