### PR TITLE
[216_7] 添加跨平台数值比较行为不一致的调研记录

### DIFF
--- a/devel/216_7.md
+++ b/devel/216_7.md
@@ -64,6 +64,23 @@
 
 3. **以下函数在 `(scheme base)` 中未绑定**：`delay` `delay-force` `parameterize` `let*-values` `define-syntax` `syntax-rules` `raise-continuable` `with-exception-handler` `features` `open-input-bytevector` `open-output-bytevector` `get-output-bytevector` `read-u8` `write-u8` `peek-u8` `u8-ready?` `read-bytevector` `read-bytevector!` `write-bytevector` `write-shared` `write-simple`。
 
+4. **跨平台数值比较行为不一致**（调研记录，参见 [x_y.md](x_y.md) 模板格式）：
+   - **问题**：`tests/scheme/base/eq-sign-test.scm` 第 59 行 `(= 1/3 0.3333333333333333)` 在 Linux 和 macOS/Windows 上行为不一致
+   - **数值类型**：`1/3` 是 **exact**（精确有理数），`0.3333333333333333` 是 **inexact**（不精确浮点数）
+   - **Linux**：正确返回 `#f`（精确数 `1/3` 与不精确数 `0.3333333333333333` 不相等）
+   - **macOS/Windows**：错误返回 `#t`
+   - **S7 Scheme 的比较逻辑**：
+     - 当比较 **T_RATIO**（有理数）和 **T_REAL**（浮点数）时，S7 的做法是将有理数转换为浮点数后比较
+     - 代码路径：`src/s7.c:18957` `case T_REAL: return(fraction(x) == real(y));`
+     - `fraction` 宏定义：`src/s7.c:3755` `#define fraction(p) (((long_double)numerator(p)) / ((long_double)denominator(p)))`
+   - **根本原因**：`long_double` 在不同平台上的精度不同
+     - **Linux**：`long double` 通常是 80 位或 128 位扩展精度，能区分 `1/3` 和 `0.3333333333333333`
+     - **macOS (ARM64)** 和 **Windows**：`long double` 只有 64 位（与 `double` 相同），无法区分两者
+   - **为什么有些 exact/inexact 比较是正确的**：
+     - 如 `(= 1/2 0.5)` => `#t`，因为 `1/2` 可以在二进制浮点数中**精确表示**
+     - 但 `1/3` 在二进制中是无限循环小数，无法精确表示，`0.3333333333333333` 只是近似值
+   - **状态**：当前通过 `(os-linux?)` 在测试中进行平台适配，但根本问题需要 S7 Scheme 层面修复。
+
 ### Why
 1. 完整的文档注释便于后续通过 `gf doc` 工具自动生成函数文档
 2. 统一格式后，AI 和人类开发者都能快速理解每个函数的用途和行为


### PR DESCRIPTION
## 摘要
在 <code>tests/scheme/base/eq-sign-test.scm</code> 中发现跨平台数值比较行为不一致的问题，添加调研记录到开发文档。

## 问题描述
<code>(= 1/3 0.3333333333333333)</code> 在不同平台上行为不一致：
- **Linux**：正确返回 <code>#f</code>
- **macOS/Windows**：错误返回 <code>#t</code>

## 根本原因
S7 Scheme 在比较有理数和浮点数时，使用 <code>long_double</code> 将有理数转换为浮点数后比较。不同平台上 <code>long double</code> 的精度不同：
- Linux：80/128 位扩展精度
- macOS/Windows：64 位（与 double 相同）

## 相关代码
- <code>src/s7.c:18957</code>: 数值比较逻辑
- <code>src/s7.c:3755</code>: fraction 宏定义

## 状态
当前通过 <code>(os-linux?)</code> 在测试中进行平台适配，根本问题需 S7 Scheme 层面修复。