### PR TITLE
[0026] Debian CI 从 bookworm 升级到 trixie

### DIFF
--- a/.github/workflows/ci-debian.yml
+++ b/.github/workflows/ci-debian.yml
@@ -1,4 +1,4 @@
-name: CI on Debian bookworm
+name: CI on Debian trixie
 on:
   push:
     branches: [ main ]
@@ -27,7 +27,7 @@ env:
 
 jobs:
   build:
-    container: debian:bookworm
+    container: debian:trixie
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: true

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
-    container: debian:bookworm
+    container: debian:trixie
     env:
       XMAKE_ROOT: y
       DEBIAN_FRONTEND: noninteractive
@@ -23,7 +23,7 @@ jobs:
     steps:
     - name: Install Dependencies
       run: |
-        echo 'deb http://deb.debian.org/debian bookworm-backports main' > /etc/apt/sources.list.d/backports.list
+        echo 'deb http://deb.debian.org/debian trixie-backports main' > /etc/apt/sources.list.d/backports.list
         apt-get update
         apt-get install -y \
           git \
@@ -34,7 +34,7 @@ jobs:
           build-essential \
           devscripts \
           debhelper
-        apt-get install -y -t bookworm-backports xmake
+        apt-get install -y -t trixie-backports xmake
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/devel/0026.md
+++ b/devel/0026.md
@@ -1,0 +1,36 @@
+# [0026] Debian CI 从 bookworm 升级到 trixie
+
+## 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 任务相关的代码文件
+- `.github/workflows/ci-debian.yml`
+- `.github/workflows/package.yml`
+
+## 如何测试
+
+通过 GitHub Actions 运行验证：
+- `CI on Debian trixie` workflow
+- `XPack Build` workflow
+
+## 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+bin/gf test --changed-since=main
+```
+
+## 2026/05/05 Debian CI 从 bookworm 升级到 trixie
+### What
+1. 将 `ci-debian.yml` 和 `package.yml` 中的容器镜像从 `debian:bookworm` 升级为 `debian:trixie`
+2. 将 `package.yml` 中 xmake 的安装源从 `bookworm-backports` 改为 `trixie-backports`
+3. 移除 `bookworm-backports` 相关的 apt 源配置，改用 `trixie-backports`
+
+### Why
+- xmake 在 bookworm 平台上的 config 阶段存在参数解析错误
+- bookworm 自带的 xmake 版本过旧，无法正确执行构建
+- trixie 提供更新的基础环境，backports 中 xmake 版本更新
+
+### How
+直接修改 GitHub Actions workflow 文件，更新容器镜像和 apt 源配置。


### PR DESCRIPTION
- 将容器镜像从 debian:bookworm 升级为 debian:trixie
- 将 xmake 安装源从 bookworm-backports 改为 trixie-backports
- 创建 devel/0026.md 记录任务信息