### PR TITLE
[0013] njson set! 支持 vector 类型

### DIFF
--- a/devel/0013.md
+++ b/devel/0013.md
@@ -1,0 +1,40 @@
+# [0013] njson set! 支持 vector 类型
+
+## 任务相关的代码文件
+- `src/goldfish.hpp` - njson C++ 绑定实现
+- `goldfish/liii/njson.scm` - njson Scheme 封装
+- `tests/liii/njson/njson-set-bang-test.scm` - set! 测试
+- `tests/liii/njson/njson-set-test.scm` - set 测试
+- `tests/liii/njson/njson-append-test.scm` - append 测试
+- `tests/liii/njson/njson-append-bang-test.scm` - append! 测试
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf tests/liii/njson/njson-set-bang-test.scm
+bin/gf tests/liii/njson/njson-set-test.scm
+bin/gf tests/liii/njson/njson-append-test.scm
+bin/gf tests/liii/njson/njson-append-bang-test.scm
+```
+
+## 2026-05-08 njson set! 支持 vector 类型
+
+### What
+让 `njson-set!`、`njson-set`、`njson-append`、`njson-append!` 支持 `vector` 类型的 value，将 Scheme vector 转换为 JSON array。
+
+1. 在 `scheme_to_njson_scalar_or_handle` 中增加对 `s7_is_vector` 的处理
+2. 递归将 vector 的每个元素转换为 JSON value，构建 JSON array
+3. 为上述四个函数补充 vector 相关的测试用例
+
+### Why
+`njson-array->vector` 已支持将 JSON array 转换为 Scheme vector，但 `njson-set!` 等更新函数不支持反向转换（Scheme vector → JSON array），API 不对称。用户从 njson 中取出 vector 修改后，无法直接通过 set! 写回。
+
+### How
+在 `scheme_to_njson_scalar_or_handle` 中新增 vector 分支：
+- 使用 `s7_is_vector` 判断是否为 vector
+- 使用 `s7_vector_length` 获取长度
+- 使用 `s7_vector_elements` 获取元素数组指针
+- 遍历每个元素，递归调用 `scheme_to_njson_scalar_or_handle` 转换
+- 将结果收集到 `nlohmann::json` 的 array 类型中
+
+注意：由于 `scheme_to_njson_scalar_or_handle` 是静态函数且实现靠前，需要在函数声明前添加前向声明，或者将 vector 处理逻辑内联到函数中（C++ 允许在函数体内部递归调用自身，无需前向声明）。

--- a/src/goldfish.hpp
+++ b/src/goldfish.hpp
@@ -524,7 +524,22 @@ scheme_to_njson_scalar_or_handle (s7_scheme* sc, s7_pointer value, json& out, st
     return false;
   }
 
-  error_msg = "value must be njson handle, string?, number?, boolean?, or null symbol";
+  if (s7_is_vector (value)) {
+    s7_int len = s7_vector_length (value);
+    s7_pointer* elements = s7_vector_elements (value);
+    out = json::array ();
+    for (s7_int i = 0; i < len; ++i) {
+      json element_json;
+      if (!scheme_to_njson_scalar_or_handle (sc, elements[i], element_json, error_msg)) {
+        error_msg = "vector element " + std::to_string (i) + ": " + error_msg;
+        return false;
+      }
+      out.push_back (element_json);
+    }
+    return true;
+  }
+
+  error_msg = "value must be njson handle, string?, number?, boolean?, vector?, or null symbol";
   return false;
 }
 

--- a/tests/liii/njson/njson-append-bang-test.scm
+++ b/tests/liii/njson/njson-append-bang-test.scm
@@ -16,7 +16,7 @@
 ;; ----
 ;; json : njson-handle
 ;; k1..kn : string | integer
-;; value : njson-handle | string | number | boolean | 'null
+;; value : njson-handle | string | number | boolean | 'null | vector
 ;;
 ;; 返回值
 ;; ----
@@ -101,6 +101,29 @@
     =>
     "g_njson-append!: append target must be array"
   ) ;check
+) ;let-njson
+
+
+(let-njson ((root (string->njson sample-json)))
+  (njson-append! root "nums" #("a" "b"))
+  (check-true (njson-array? (njson-ref root "nums" 5)))
+  (check (njson-ref root "nums" 5 0) => "a")
+  (check (njson-ref root "nums" 5 1) => "b")
+  (check (njson-size (njson-ref root "nums")) => 6)
+) ;let-njson
+
+
+(let-njson ((arr (string->njson "[1,2]")))
+  (njson-append! arr #(3 4))
+  (check-true (njson-array? (njson-ref arr 2)))
+  (check (njson-ref arr 2 0) => 3)
+  (check (njson-ref arr 2 1) => 4)
+) ;let-njson
+
+
+(let-njson ((root (string->njson sample-json)))
+  (njson-append! root "nums" #())
+  (check (njson-size (njson-ref root "nums")) => 6)
 ) ;let-njson
 
 

--- a/tests/liii/njson/njson-append-test.scm
+++ b/tests/liii/njson/njson-append-test.scm
@@ -16,7 +16,7 @@
 ;; ----
 ;; json : njson-handle
 ;; k1..kn : string | integer
-;; value : njson-handle | string | number | boolean | 'null
+;; value : njson-handle | string | number | boolean | 'null | vector
 ;;
 ;; 返回值
 ;; ----
@@ -101,6 +101,30 @@
     =>
     "g_njson-append: append target must be array"
   ) ;check
+) ;let-njson
+
+
+(let-njson ((root (string->njson sample-json))
+            (root2 (njson-append root "nums" #("a" "b")))
+           ) ;
+  (check-true (njson-array? (njson-ref root2 "nums" 5)))
+  (check (njson-ref root2 "nums" 5 0) => "a")
+  (check (njson-ref root2 "nums" 5 1) => "b")
+  (check (njson-size (njson-ref root "nums")) => 5)
+) ;let-njson
+
+
+(let-njson ((arr (string->njson "[1,2]")) (arr2 (njson-append arr #(3 4))))
+  (check-true (njson-array? (njson-ref arr2 2)))
+  (check (njson-ref arr2 2 0) => 3)
+  (check (njson-ref arr2 2 1) => 4)
+  (check (njson-size arr) => 2)
+) ;let-njson
+
+
+(let-njson ((root (string->njson sample-json)) (root2 (njson-append root "nums" #())))
+  (check-true (njson-array? (njson-ref root2 "nums")))
+  (check (njson-size (njson-ref root2 "nums")) => 6)
 ) ;let-njson
 
 

--- a/tests/liii/njson/njson-set-bang-test.scm
+++ b/tests/liii/njson/njson-set-bang-test.scm
@@ -15,7 +15,7 @@
 ;; ----
 ;; json : njson-handle
 ;; key ... : string | integer
-;; value : njson-handle | string | number | boolean | 'null
+;; value : njson-handle | string | number | boolean | 'null | vector
 ;;
 ;; 返回值
 ;; ----
@@ -120,6 +120,58 @@
     =>
     "g_njson-set!: set target must be array or object"
   ) ;check
+) ;let-njson
+
+
+(let-njson ((root (string->njson sample-json)))
+  (njson-set! root "tags" #("a" "b" "c"))
+  (check (njson-ref root "tags" 0) => "a")
+  (check (njson-ref root "tags" 1) => "b")
+  (check (njson-ref root "tags" 2) => "c")
+  (check (njson-size (njson-ref root "tags")) => 3)
+) ;let-njson
+
+
+(let-njson ((root (string->njson sample-json)))
+  (njson-set! root "nums" #(10 20 30 40 50))
+  (check (njson-ref root "nums" 0) => 10)
+  (check (njson-ref root "nums" 1) => 20)
+  (check (njson-ref root "nums" 2) => 30)
+  (check (njson-size (njson-ref root "nums")) => 5)
+) ;let-njson
+
+
+(let-njson ((root (string->njson sample-json)))
+  (njson-set! root "mixed" #(1 "two" #f 3.14))
+  (check (njson-ref root "mixed" 0) => 1)
+  (check (njson-ref root "mixed" 1) => "two")
+  (check (njson-ref root "mixed" 2) => #f)
+  (check (njson-ref root "mixed" 3) => 3.14)
+) ;let-njson
+
+
+(let-njson ((root (string->njson sample-json)))
+  (njson-set! root "nested" #(#(1 2) #(3 4)))
+  (check (njson-ref root "nested" 0 0) => 1)
+  (check (njson-ref root "nested" 0 1) => 2)
+  (check (njson-ref root "nested" 1 0) => 3)
+  (check (njson-ref root "nested" 1 1) => 4)
+) ;let-njson
+
+
+(let-njson ((root (string->njson sample-json)))
+  (njson-set! root "nums" 0 #(99 100))
+  (check (njson-ref root "nums" 0 0) => 99)
+  (check (njson-ref root "nums" 0 1) => 100)
+  (check (njson-ref root "nums" 1) => 2)
+  (check (njson-size (njson-ref root "nums")) => 5)
+) ;let-njson
+
+
+(let-njson ((root (string->njson sample-json)))
+  (njson-set! root "empty" #())
+  (check-true (njson-array? (njson-ref root "empty")))
+  (check (njson-size (njson-ref root "empty")) => 0)
 ) ;let-njson
 
 

--- a/tests/liii/njson/njson-set-test.scm
+++ b/tests/liii/njson/njson-set-test.scm
@@ -15,7 +15,7 @@
 ;; ----
 ;; json : njson-handle
 ;; key ... : string | integer
-;; value : njson-handle | string | number | boolean | 'null
+;; value : njson-handle | string | number | boolean | 'null | vector
 ;;
 ;; 返回值
 ;; ----
@@ -128,6 +128,48 @@
     =>
     "g_njson-set: set target must be array or object"
   ) ;check
+) ;let-njson
+
+
+(let-njson ((root (string->njson sample-json))
+            (root2 (njson-set root "tags" #("a" "b" "c")))
+            (root3 (njson-set root "nums" #(10 20 30 40 50)))
+           ) ;
+  (check (njson-ref root2 "tags" 0) => "a")
+  (check (njson-ref root2 "tags" 1) => "b")
+  (check (njson-ref root2 "tags" 2) => "c")
+  (check-false (njson-contains-key? root "tags"))
+  (check (njson-ref root3 "nums" 0) => 10)
+  (check (njson-ref root3 "nums" 1) => 20)
+  (check (njson-ref root3 "nums" 2) => 30)
+  (check (njson-ref root "nums" 0) => 1)
+) ;let-njson
+
+
+(let-njson ((root (string->njson sample-json))
+            (root2 (njson-set root "mixed" #(1 "two" #f 3.14)))
+           ) ;
+  (check (njson-ref root2 "mixed" 0) => 1)
+  (check (njson-ref root2 "mixed" 1) => "two")
+  (check (njson-ref root2 "mixed" 2) => #f)
+  (check (njson-ref root2 "mixed" 3) => 3.14)
+) ;let-njson
+
+
+(let-njson ((root (string->njson sample-json))
+            (root2 (njson-set root "nested" #(#(1 2) #(3 4))))
+           ) ;
+  (check (njson-ref root2 "nested" 0 0) => 1)
+  (check (njson-ref root2 "nested" 0 1) => 2)
+  (check (njson-ref root2 "nested" 1 0) => 3)
+  (check (njson-ref root2 "nested" 1 1) => 4)
+) ;let-njson
+
+
+(let-njson ((root (string->njson sample-json)) (root2 (njson-set root "empty" #())))
+  (check-true (njson-array? (njson-ref root2 "empty")))
+  (check (njson-size (njson-ref root2 "empty")) => 0)
+  (check-false (njson-contains-key? root "empty"))
 ) ;let-njson
 
 


### PR DESCRIPTION
## Summary
- 在 `scheme_to_njson_scalar_or_handle` 中增加对 Scheme `vector?` 的支持，递归转换为 JSON array
- `njson-set!`、`njson-set`、`njson-append!`、`njson-append` 四个函数同步支持 vector 类型 value
- 补充对应测试用例，覆盖 object/array 设置、嵌套 vector、混合类型 vector、空 vector 等场景

## Test plan
- [x] `bin/gf tests/liii/njson/njson-set-bang-test.scm` — 42 checks passed
- [x] `bin/gf tests/liii/njson/njson-set-test.scm` — 42 checks passed
- [x] `bin/gf tests/liii/njson/njson-append-test.scm` — 26 checks passed
- [x] `bin/gf tests/liii/njson/njson-append-bang-test.scm` — 23 checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)