### PR TITLE
[0021] 优化 utf8-make-string 性能

### DIFF
--- a/bench/utf8-make-string.scm
+++ b/bench/utf8-make-string.scm
@@ -1,0 +1,45 @@
+;; utf8-make-string 性能基准测试
+;; 收集优化前的性能数据，用于对比优化后的效果
+
+(import (liii timeit) (liii unicode) (scheme base))
+
+(define (bench name stmt-call number)
+  (let ((elapsed (timeit stmt-call '() number)))
+    (display name)
+    (display ": ")
+    (display elapsed)
+    (display " 秒 (")
+    (display number)
+    (display " 次)\n")
+  ) ;let
+) ;define
+
+(define (run-benchmarks)
+  (display "=== utf8-make-string 性能测试 ===\n\n")
+
+  (display "--- ASCII 字符 (\\#a, 1 字节) ---\n")
+  (bench "长度 1      " (lambda () (utf8-make-string 1 #\a)) 100000)
+  (bench "长度 10     " (lambda () (utf8-make-string 10 #\a)) 100000)
+  (bench "长度 100    " (lambda () (utf8-make-string 100 #\a)) 10000)
+  (bench "长度 1000   " (lambda () (utf8-make-string 1000 #\a)) 1000)
+  (bench "长度 10000  " (lambda () (utf8-make-string 10000 #\a)) 100)
+  (newline)
+
+  (display "--- 中文字符 (\\#中, 3 字节) ---\n")
+  (bench "长度 1      " (lambda () (utf8-make-string 1 #\中)) 100000)
+  (bench "长度 10     " (lambda () (utf8-make-string 10 #\中)) 100000)
+  (bench "长度 100    " (lambda () (utf8-make-string 100 #\中)) 10000)
+  (bench "长度 1000   " (lambda () (utf8-make-string 1000 #\中)) 1000)
+  (bench "长度 10000  " (lambda () (utf8-make-string 10000 #\中)) 100)
+  (newline)
+
+  (display "--- Emoji 字符 (\\#🚀, 4 字节) ---\n")
+  (bench "长度 1      " (lambda () (utf8-make-string 1 #\🚀)) 100000)
+  (bench "长度 10     " (lambda () (utf8-make-string 10 #\🚀)) 100000)
+  (bench "长度 100    " (lambda () (utf8-make-string 100 #\🚀)) 10000)
+  (bench "长度 1000   " (lambda () (utf8-make-string 1000 #\🚀)) 1000)
+  (bench "长度 10000  " (lambda () (utf8-make-string 10000 #\🚀)) 100)
+  (newline)
+) ;define
+
+(run-benchmarks)

--- a/devel/0021.md
+++ b/devel/0021.md
@@ -1,0 +1,44 @@
+# [0021] 优化 utf8-make-string 性能
+
+## 任务相关的代码文件
+- goldfish/liii/unicode.scm
+- tests/liii/unicode/utf8-make-string-test.scm
+- bench/utf8-make-string.scm
+
+## 如何测试
+```
+xmake b goldfish
+bin/gf fmt goldfish/liii/unicode.scm
+bin/gf fmt tests/liii/unicode/utf8-make-string-test.scm
+bin/gf tests/liii/unicode/utf8-make-string-test.scm
+bin/gf bench/utf8-make-string.scm
+```
+
+## 2026/05/11 优化 utf8-make-string 性能
+
+### What
+将 `utf8-make-string` 从循环 `bytevector-append` 拼接改为预分配 `make-bytevector` + `bytevector-u8-set!` 逐字节填充，消除 O(n²) 复杂度。
+
+1. 添加 `bench/utf8-make-string.scm` 性能基准测试
+2. 优化 `utf8-make-string` 实现，复杂度从 O(n²) 降为 O(n)
+3. 补充长度 100 的长字符串边界测试
+4. 记录优化前后的性能数据对比
+
+### Why
+原实现每次循环都调用 `bytevector-append` 创建新 bytevector 并复制全部已有内容，在长字符串场景下单次调用耗时随长度平方增长。作为构建 UTF-8 字符串的基础函数，这一瓶颈会显著影响上层代码性能。
+
+### How
+1. 先通过 `codepoint->utf8` 获取单字符的 UTF-8 字节向量
+2. 计算总字节数 `(* k unit-len)`，一次性 `make-bytevector` 预分配
+3. 用双层循环将单字符字节复制到结果向量的对应偏移位置
+4. 最后通过 `utf8->string` 转换返回
+
+### 性能数据对比（10000 长度）
+
+| 字符类型 | 优化前 (100次) | 优化后 (100次) | 提升倍数 |
+|---------|--------------|--------------|---------|
+| ASCII (#\a, 1字节) | 0.793 秒 | 0.387 秒 | ~2.05x |
+| 中文 (#\中, 3字节) | 1.767 秒 | 0.730 秒 | ~2.42x |
+| Emoji (#\🚀, 4字节) | 2.217 秒 | 0.890 秒 | ~2.49x |
+
+长字符串场景下性能提升明显，且随着长度增加 O(n) 优势会进一步扩大。

--- a/goldfish/liii/unicode.scm
+++ b/goldfish/liii/unicode.scm
@@ -66,15 +66,28 @@
           (unless (char? c)
             (error 'type-error "utf8-make-string: expected char" c)
           ) ;unless
-          (let ((utf8-bv (codepoint->utf8 (char->integer c))))
-            (let loop
-              ((i 0) (result (bytevector)))
+          (let* ((utf8-bv (codepoint->utf8 (char->integer c)))
+                 (unit-len (bytevector-length utf8-bv))
+                 (total-len (* k unit-len))
+                 (result (make-bytevector total-len))
+                ) ;
+            (let outer
+              ((i 0))
               (if (= i k)
                 (utf8->string result)
-                (loop (+ i 1) (bytevector-append result utf8-bv))
+                (let inner
+                  ((j 0) (offset (* i unit-len)))
+                  (if (= j unit-len)
+                    (outer (+ i 1))
+                    (begin
+                      (bytevector-u8-set! result offset (bytevector-u8-ref utf8-bv j))
+                      (inner (+ j 1) (+ offset 1))
+                    ) ;begin
+                  ) ;if
+                ) ;let
               ) ;if
             ) ;let
-          ) ;let
+          ) ;let*
         ) ;let
       ) ;if
     ) ;define

--- a/tests/liii/unicode/utf8-make-string-test.scm
+++ b/tests/liii/unicode/utf8-make-string-test.scm
@@ -53,6 +53,10 @@
   (check (utf8-string-length str) => 5)
   (check (string-ref str 0) => #\space)
 ) ;let
+(let ((str (utf8-make-string 100 #\中)))
+  (check (utf8-string-length str) => 100)
+  (check (bytevector-length (string->utf8 str)) => 300)
+) ;let
 (check-catch 'out-of-range (utf8-make-string -1 #\a))
 (check-catch 'out-of-range (utf8-make-string -1))
 (check-catch 'type-error (utf8-make-string 3 "a"))


### PR DESCRIPTION
## Summary
将 `utf8-make-string` 从循环 `bytevector-append` 拼接改为预分配 `make-bytevector` + `bytevector-u8-set!` 逐字节填充，复杂度从 O(n²) 降为 O(n)。

## Changes
1. 添加 `bench/utf8-make-string.scm` 性能基准测试
2. 优化 `utf8-make-string` 实现（`goldfish/liii/unicode.scm`）
3. 补充长字符串边界测试（`tests/liii/unicode/utf8-make-string-test.scm`）
4. 撰写 `devel/0021.md` 记录性能数据

## Performance

| 字符类型 | 优化前 (100次×10000长) | 优化后 | 提升 |
|---------|----------------------|--------|------|
| ASCII | 0.793s | 0.387s | ~2.05x |
| 中文 | 1.767s | 0.730s | ~2.42x |
| Emoji | 2.217s | 0.890s | ~2.49x |

## Test plan
- [x] `bin/gf tests/liii/unicode/utf8-make-string-test.scm` 通过 (20 correct, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)