### PR TITLE
[0027] 修复 gf fmt 对纯分号注释和开头空行的格式化问题

### DIFF
--- a/devel/0027.md
+++ b/devel/0027.md
@@ -1,0 +1,113 @@
+# [0027] 修复 gf fmt 对纯分号注释分隔线的格式化问题
+
+## 任务相关的代码文件
+- `tools/fmt/liii/goldfmt-format.scm`
+- `tools/fmt/tests/liii/goldfmt-format/format-string-test.scm`
+
+## 如何测试
+```bash
+# 构建
+xmake b goldfish
+
+# 运行相关测试
+bin/gf test tools/fmt/tests/liii/goldfmt-format/format-string-test.scm
+
+# 验证纯分号注释保持原样
+bin/gf fmt --dry-run tests/fmt_comment_test.scm
+```
+
+## 2026-05-11 修复纯分号注释分隔线的格式化
+
+### What
+修复 `gf fmt` 对以分号开头的注释内容（包括纯分号分隔线和 `;;;` 开头的注释）的格式化问题。
+
+原行为：
+```
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;  →  ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; certain Scheme versions do not define 'filter'  →  ;; ; certain Scheme versions do not define 'filter'
+```
+
+格式化后在 `;;` 和后续分号之间插入了空格，破坏了视觉分隔线的效果，也把 `;;;` 注释拆散了。
+
+修复后行为：
+```
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;  →  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; certain Scheme versions do not define 'filter'  →  ;;; certain Scheme versions do not define 'filter'
+```
+
+以分号开头的注释内容保持连续输出，不在中间插入空格。
+
+### Why
+纯分号行通常用作代码中的视觉分隔线或装饰线。`;;;` 开头的注释也是常见的 Scheme 注释风格（通常用于文件级或节级注释）。在 `;;` 和内容之间加空格会破坏这些视觉效果，因此需要特殊处理。
+
+### How
+修改 `tools/fmt/liii/goldfmt-format.scm` 中的 `format-comment-content` 函数：
+
+当注释内容以 `;` 字符开头时，不再在 `;;` 和内容之间插入空格，而是直接拼接为 `;;` + content。
+
+```scheme
+(define (format-comment-content content)
+  (if (or (string=? content "")
+          (char=? (string-ref content 0) #\space)
+          (char=? (string-ref content 0) #\;)
+        )
+    (string-append ";;" content)
+    (string-append ";; " content)
+  )
+)
+```
+
+### 2026-05-11 修复文件开头空行被移除的问题
+
+#### What
+修复 `gf fmt` 格式化时，文件开头的空行（如换行后紧跟注释）会被意外移除的问题。
+
+原行为：
+```
+\n;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;  →  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+```
+
+格式化后丢失了文件开头的空行。
+
+修复后行为：
+```
+\n;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;  →  \n;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+```
+
+文件开头的空行被正确保留。
+
+#### Why
+某些文件在协议头或注释之前会有意保留空行，以形成视觉分隔。格式化工具不应擅自移除这些空行。
+
+#### How
+修改 `tools/fmt/liii/goldfmt-format.scm` 中的 `join-top-level` 函数：
+
+原实现会跳过开头的空字符串 piece，导致空行丢失。修改为使用 `first` 标志跟踪是否处于第一个 piece，对第一个 piece 直接拼接而不前置换行符，从而正确保留开头的空行。
+
+```scheme
+(define (join-top-level pieces)
+  (let loop
+    ((rest pieces) (result "") (first #t))
+    (cond ((null? rest)
+           (if (and (not (string=? result "")) (not (string-suffix? "\n" result)))
+             (string-append result "\n")
+             result
+           )
+          )
+          (first
+            (loop (cdr rest) (string-append result (car rest)) #f)
+          )
+          (else (loop (cdr rest) (string-append result "\n" (car rest)) #f))
+    )
+  )
+)
+```
+
+同时移除了 `format-top-level-nodes` 中针对首个 newline 节点的特殊处理（`make-newlines (+ n 1)`），因为现在 `join-top-level` 能正确处理开头的空 piece。
+
+补充了 5 个单元测试：
+1. 纯分号分隔线注释保持原样
+2. 内容以分号开头的注释保持连续分号（对应原始 `;;;` 输入）
+3. 空注释保持原样
+4. 三个分号开头的注释保持原样
+5. 文件开头空行后紧跟注释，空行应被保留

--- a/tools/fmt/liii/goldfmt-format.scm
+++ b/tools/fmt/liii/goldfmt-format.scm
@@ -19,6 +19,7 @@
     format-datum+node
     format-node
     format-string
+    format-nodes
     format-inline
     can-inline?
   ) ;export
@@ -146,7 +147,10 @@
     ) ;define
 
     (define (format-comment-content content)
-      (if (or (string=? content "") (char=? (string-ref content 0) #\space))
+      (if (or (string=? content "")
+              (char=? (string-ref content 0) #\space)
+              (char=? (string-ref content 0) #\;)
+            )
         (string-append ";;" content)
         (string-append ";; " content)
       ) ;if
@@ -1058,15 +1062,17 @@
 
   (define (join-top-level pieces)
     (let loop
-      ((rest pieces) (result ""))
+      ((rest pieces) (result "") (first #t))
       (cond ((null? rest)
              (if (and (not (string=? result "")) (not (string-suffix? "\n" result)))
                (string-append result "\n")
                result
              ) ;if
             ) ;
-            ((string=? result "") (loop (cdr rest) (car rest)))
-            (else (loop (cdr rest) (string-append result "\n" (car rest))))
+            (first
+              (loop (cdr rest) (string-append result (car rest)) #f)
+            ) ;
+            (else (loop (cdr rest) (string-append result "\n" (car rest)) #f))
       ) ;cond
     ) ;let
   ) ;define
@@ -1138,10 +1144,8 @@
         (reverse result)
         (let ((node (vector-ref nodes i)))
           (if (newline-node? node)
-            (if is-first
-              (loop (+ i 1) #t result)
-              (loop (+ i 1) #f (cons (make-newlines (newline-count node)) result))
-            ) ;if
+            (loop (+ i 1) #f (cons (make-newlines (newline-count node)) result))
+            ;if
             (call-with-values (lambda () (format-node node 0))
               (lambda (formatted positioned-node)
                 (let ((next-result (if (and (define-node? node) (not is-first))
@@ -1164,5 +1168,9 @@
     (let* ((nodes (scan-string source)) (pieces (format-top-level-nodes nodes)))
       (join-top-level pieces)
     ) ;let*
+  ) ;define
+
+  (define (format-nodes nodes)
+    (join-top-level (format-top-level-nodes nodes))
   ) ;define
 ) ;define-library

--- a/tools/fmt/liii/goldfmt-format.scm
+++ b/tools/fmt/liii/goldfmt-format.scm
@@ -1148,12 +1148,18 @@
             ;if
             (call-with-values (lambda () (format-node node 0))
               (lambda (formatted positioned-node)
-                (let ((next-result (if (and (define-node? node) (not is-first))
-                                     (cons formatted (cons "" result))
-                                     (cons formatted result)
-                                   ) ;if
-                      ) ;next-result
-                     ) ;
+                (let* ((prev-node (if (> i 0) (vector-ref nodes (- i 1)) #f))
+                       (needs-blank (and (define-node? node)
+                                         (not is-first)
+                                         (not (and prev-node (newline-node? prev-node)))
+                                       )
+                       ) ;needs-blank
+                       (next-result (if needs-blank
+                                      (cons formatted (cons "" result))
+                                      (cons formatted result)
+                                    ) ;if
+                       ) ;next-result
+                      ) ;
                   (loop (+ i 1) #f next-result)
                 ) ;let
               ) ;lambda

--- a/tools/fmt/liii/goldfmt-scan.scm
+++ b/tools/fmt/liii/goldfmt-scan.scm
@@ -697,15 +697,32 @@
     ) ;define
     (define (scan-file path)
       (let* ((raw-content (path-read-text path))
-             (tokens (let ((scanned (source-tokenize raw-content)))
-                       (if (and (not (null? scanned))
+             (scanned (source-tokenize raw-content))
+             ;; 处理文件开头空行
+             (leading-blanks (let loop ((i 0) (count 0))
+                               (if (>= i (string-length raw-content))
+                                 count
+                                 (let ((c (string-ref raw-content i)))
+                                   (cond ((char=? c #\newline) (loop (+ i 1) (+ count 1)))
+                                         ((char=? c #\return) (loop (+ i 1) count))
+                                         ((or (char=? c #\space) (char=? c #\tab)) (loop (+ i 1) count))
+                                         (else count)
+                                   ) ;cond
+                                 ) ;let
+                               ) ;if
+                             ) ;let
+                           )
+             (tokens-with-leading (if (> leading-blanks 0)
+                                    (cons (cons 'newline leading-blanks) scanned)
+                                    scanned))
+             ;; 处理文件末尾换行符
+             (tokens (if (and (not (null? tokens-with-leading))
                              (> (string-length raw-content) 0)
-                             (char=? (string-ref raw-content (- (string-length raw-content) 1)) #\newline)
-                           ) ;and
-                         (append scanned (list (cons 'newline 1)))
-                         scanned
-                       ) ;if
-                     ) ;let
+                             (char=? (string-ref raw-content (- (string-length raw-content) 1)) #\newline))
+                            ;and
+                         (append tokens-with-leading (list (cons 'newline 1)))
+                         tokens-with-leading)
+                        ;if
              ) ;tokens
              (processed-content (source-tokens->string tokens))
             ) ;

--- a/tools/fmt/liii/goldfmt.scm
+++ b/tools/fmt/liii/goldfmt.scm
@@ -94,30 +94,11 @@
 
     ;; ; 格式化单个文件（dry-run 模式，输出到终端）
     (define (format-file-dry-run path-str)
-      (let* ((nodes (scan-file path-str)))
-        (let loop
-          ((i 0))
-          (if (>= i (vector-length nodes))
-            (values)
-            (let ((node (vector-ref nodes i)))
-              (call-with-values (lambda () (format-node node 0))
-                (lambda (text positioned-node)
-                  (display (ensure-trailing-newline text))
-                  (loop (+ i 1))
-                ) ;lambda
-              ) ;call-with-values
-            ) ;let
-          ) ;if
-        ) ;let
+      (let* ((nodes (scan-file path-str))
+             (formatted (format-nodes nodes))
+            ) ;
+        (display formatted)
       ) ;let*
-    ) ;define
-
-    ;; ; 辅助函数：确保字符串以换行符结尾
-    (define (ensure-trailing-newline str)
-      (if (or (string=? str "") (string-suffix? "\n" str))
-        str
-        (string-append str "\n")
-      ) ;if
     ) ;define
 
     ;; ; 格式化单个文件（覆盖原文件）
@@ -126,29 +107,15 @@
       (let* ((p (path path-str))
              (original-content (path-read-text p))
              (nodes (scan-file path-str))
-             (results '())
+             (formatted (format-nodes nodes))
             ) ;
-        (let loop
-          ((i 0) (acc '()))
-          (if (>= i (vector-length nodes))
-            (let* ((joined (string-join (reverse acc) "\n"))
-                   (formatted (ensure-trailing-newline joined))
-                  ) ;
-              (if (string=? original-content formatted)
-                #f
-                (begin
-                  (path-write-text p formatted)
-                  #t
-                ) ;begin
-              ) ;if
-            ) ;let*
-            (let ((node (vector-ref nodes i)))
-              (call-with-values (lambda () (format-node node 0))
-                (lambda (text positioned-node) (loop (+ i 1) (cons text acc)))
-              ) ;call-with-values
-            ) ;let
-          ) ;if
-        ) ;let
+        (if (string=? original-content formatted)
+          #f
+          (begin
+            (path-write-text p formatted)
+            #t
+          ) ;begin
+        ) ;if
       ) ;let*
     ) ;define
 

--- a/tools/fmt/tests/liii/goldfmt-format/format-string-test.scm
+++ b/tools/fmt/tests/liii/goldfmt-format/format-string-test.scm
@@ -1,6 +1,7 @@
 (import (liii check)
   (liii goldfmt-format)
   (liii goldfmt-scan)
+  (liii goldfmt-record)
   (liii os)
   (liii raw-string)
   (srfi srfi-13)
@@ -215,6 +216,48 @@
        ) ;format-string
   =>
   "(check (f '((\"messages\"\n             . #(((\"role\" . \"user\")\n                  (\"content\"\n                   . #(((\"text\" . \"1\") (\"type\" . \"text\"))\n                       ((\"text\" . \"2\") (\"type\" . \"text\"))\n                     ) ;#\n                  ))\n                 ((\"role\" . \"user\") (\"content\" . \"中文\"))\n               ) ;#\n            ))\n       ) ;f\n  =>\n  \"ok\"\n) ;check\n"
+) ;check
+
+;; 纯分号分隔线注释不应在中间插入空格
+(let ((semicolon-line (make-env :tag-name "*comment*" :children (vector (make-atom :value ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;")))))
+  (check (call-with-values (lambda () (format-node semicolon-line 0))
+           (lambda (text positioned-node) text))
+    =>
+    ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;"
+  ) ;check
+) ;let
+
+;; 内容以分号开头的注释（对应原始输入 ;;; ...）应保持连续分号
+(let ((mixed-comment (make-env :tag-name "*comment*" :children (vector (make-atom :value "; not all semicolons")))))
+  (check (call-with-values (lambda () (format-node mixed-comment 0))
+           (lambda (text positioned-node) text))
+    =>
+    ";;; not all semicolons"
+  ) ;check
+) ;let
+
+;; 空注释
+(let ((empty-comment (make-env :tag-name "*comment*" :children (vector (make-atom :value "")))))
+  (check (call-with-values (lambda () (format-node empty-comment 0))
+           (lambda (text positioned-node) text))
+    =>
+    ";;"
+  ) ;check
+) ;let
+
+;; 三个分号开头的注释应保持原样
+(let ((triple-comment (make-env :tag-name "*comment*" :children (vector (make-atom :value "; certain Scheme versions do not define 'filter'")))))
+  (check (call-with-values (lambda () (format-node triple-comment 0))
+           (lambda (text positioned-node) text))
+    =>
+    ";;; certain Scheme versions do not define 'filter'"
+  ) ;check
+) ;let
+
+;; 测试文件开头空行后紧跟注释，空行应被保留
+(check (format-string "(*newline* 1)\n(*comment* \";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;\")\n")
+  =>
+  "\n;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;\n"
 ) ;check
 
 (check-report)


### PR DESCRIPTION
## Summary
- 修复 `gf fmt` 对以分号开头的注释内容（纯分号分隔线和 `;;;` 注释）格式化时错误插入空格的问题
- 修复 `gf fmt` 格式化时文件开头空行被意外移除的问题

## Changes
- `tools/fmt/liii/goldfmt-format.scm`:
  - `format-comment-content`: 注释内容以 `;` 开头时不插入空格
  - `join-top-level`: 正确处理开头的空 piece，保留文件开头空行
  - `format-top-level-nodes`: 移除首个 newline 节点的特殊处理
- `tools/fmt/liii/goldfmt-scan.scm`: 处理文件开头空行和末尾换行符
- `tools/fmt/liii/goldfmt.scm`: 使用 `format-nodes` 统一格式化输出
- `tools/fmt/tests/liii/goldfmt-format/format-string-test.scm`: 补充 5 个单元测试
- `devel/0027.md`: 添加开发文档

## Test plan
- [x] `bin/gf test tools/fmt/tests/liii/goldfmt-format/format-string-test.scm`
- [x] `bin/gf test tools/fmt/tests/liii/goldfmt-scan/`
- [x] `bin/gf test tools/fmt/tests/liii/goldfmt-tokenize/`
- [x] `bin/gf test tools/fmt/tests/liii/goldfmt-rule/`
- [x] `bin/gf test tools/fmt/tests/liii/goldfmt-record/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)