### PR TITLE
[0040] 修复 s7.c 中 memmove 编译警告

### DIFF
--- a/devel/0040.md
+++ b/devel/0040.md
@@ -1,0 +1,38 @@
+# [0040] 修复 s7.c 中 memmove 编译警告
+
+## 任务相关的代码文件
+- `src/s7.c`
+
+## 如何测试
+```bash
+# 1. 清理并重新构建
+xmake f -c && xmake b goldfish
+
+# 2. 确认警告消失（不应再出现 -Wstringop-overflow 警告）
+```
+
+## 2026-05-17 修复 memmove 编译警告
+
+### What
+修复 `src/s7.c:14298` 处 GCC 的 `-Wstringop-overflow` 编译警告：
+
+```
+src/s7.c:14298:3: warning: 'memmove' specified bound between 9223372036854775808 and
+18446744073709551615 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
+14298 |   memmove((void *)(sc->num_to_str + spaces), (const void *)src, len);
+      |   ^~
+```
+
+在 `insert_spaces` 函数开头添加边界检查，消除警告。
+
+### Why
+虽然所有调用者都已保证 `width > len`，但 GCC 静态分析器无法跨函数完全推导出 `len` 始终为非负数。当编译器考虑 `len` 为负值的可能性时，发现其转换为 `size_t` 后会变成巨大的无符号值，从而触发 `-Wstringop-overflow` 警告。这个无害的警告可能掩盖其他真正的溢出问题，并且在启用 `-Werror` 时会导致编译失败。
+
+### How
+在 `insert_spaces` 函数内添加显式的提前返回：
+
+```c
+if ((spaces <= 0) || (len <= 0)) return;
+```
+
+这样编译器可以静态推导出：进入后续代码时，`spaces > 0`（指针运算安全）且 `len > 0`（传给 `memmove` 的 size 参数为正），从而消除警告。

--- a/src/s7.c
+++ b/src/s7.c
@@ -14289,6 +14289,7 @@ static char *floatify(char *str, s7_int *nlen)
 static void insert_spaces(s7_scheme *sc, const char *src, s7_int width, s7_int len)
 {
   s7_int spaces = width - len;
+  if ((spaces <= 0) || (len <= 0)) return;
   if (width >= sc->num_to_str_size)
     {
       sc->num_to_str_size = width + 1;


### PR DESCRIPTION
## Summary
- 修复 `src/s7.c:14298` 处 GCC 的 `-Wstringop-overflow` 编译警告
- 新增开发文档 `devel/0040.md`

## What
在 `insert_spaces` 函数开头添加边界检查：
```c
if ((spaces <= 0) || (len <= 0)) return;
```

## Why
虽然所有调用者都已保证 `width > len`，但 GCC 静态分析器无法跨函数完全推导出 `len` 始终为非负数。当编译器考虑 `len` 为负值的可能性时，发现其转换为 `size_t` 后会变成巨大的无符号值，从而触发 `-Wstringop-overflow` 警告。这个无害的警告可能掩盖其他真正的溢出问题，并且在启用 `-Werror` 时会导致编译失败。

## Test plan
- [x] `xmake b goldfish` 编译通过，警告消失

🤖 Generated with [Claude Code](https://claude.com/claude-code)