### PR TITLE
[0048] gf fmt 性能优化

### DIFF
--- a/devel/0048.md
+++ b/devel/0048.md
@@ -1,0 +1,66 @@
+# [0048] 优化 gf fmt 整体性能
+
+## 任务相关的代码文件
+- `tools/fmt/liii/goldfmt-tokenize.scm` — 注释与空行 tokenizer
+- `tools/fmt/liii/goldfmt-scan.scm` — Scheme 代码扫描与 datum 解析
+- `tools/fmt/liii/goldfmt-format.scm` — 格式化输出引擎
+
+## 如何测试
+
+### 性能基准测试
+```bash
+time bin/gf fmt goldfish/
+```
+
+### 功能回归测试
+```bash
+bin/gf test tools/fmt/tests/
+```
+
+### 提交前检查
+```bash
+bin/gf test --changed-since=main
+```
+
+## 2026-05-18 性能优化
+
+### What
+
+优化 `bin/gf fmt goldfish/` 的整体执行性能，将100个文件的格式化时间从约4.02s降至约3.45s（提升约14%），且不引入任何行为变化。
+
+1. **`goldfmt-tokenize.scm`**：重写 `tokens->string`，使用 `open-output-string` + 逐 token `display` 替代原来的 `map` + `string-join`，避免中间字符串列表的分配开销
+2. **`goldfmt-scan.scm`**：
+   - 新增 `needs-rewrite-reader-literals?` 谓词，检测输入是否包含 `#"`（原始字符串）或 `#\`（字符字面量）
+   - 仅在必要时调用 `rewrite-reader-literals`，大部分文件可直接走快速路径
+3. **`goldfmt-format.scm`**：
+   - `make-newlines` 使用 `make-string` 替代逐字符 `string-append`
+   - `spaces` 使用 `make-string` 替代递归构造
+   - `join-top-level` 使用 `open-output-string` + `display` 替代 `string-join`
+   - `emit-spaces!` 直接调用 `make-string` + `display` 到 port，绕过 `emit-string!` 循环
+
+### Why
+
+`gf fmt` 格式化100个文件耗时超过4秒，随着项目规模增长，格式化成本将线性上升。通过 profiling 发现：
+
+- `format-nodes` 占总耗时约76%，其中 `emit-inline!` / `walk-env!` 的大量小函数调用是主要热点
+- `scan-file` 占总耗时约24%，其中 `rewrite-reader-literals` 对不含特殊字面量的文件是纯粹的开销
+- `tokens->string` 和 `join-top-level` 的 `string-join` 会构造大量中间字符串
+
+### How
+
+**测量方法**：在关键函数入口插入 `current-second` 计时，运行 `bin/gf fmt goldfish/` 收集各阶段耗时。
+
+**关键发现**：
+- `rewrite-reader-literals` 的字符串替换操作对大多数文件（不含 `#"` 和 `#\`）是不必要的
+- `tokens->string` 的 `map` + `string-join` 会产生与 token 数量成正比的中间字符串
+- `join-top-level` 的 `string-join` 在拼接100个文件的格式化结果时产生大量GC压力
+
+**优化策略**：
+- 对热点路径使用 `open-output-string` 流式输出，减少中间字符串分配
+- 对 `make-string` 可一次完成的工作，消除递归/循环构造
+- 对无意义的前处理步骤增加快速短路判断
+
+**验证结果**：
+- 性能：`real 0m3.450s`（基线 `real 0m4.020s`），提升约14%
+- 行为：`Files updated: 0`，100个文件格式化前后无差异
+- 测试：`tools/fmt/tests/` 下24个测试模块全部通过

--- a/devel/0048.md
+++ b/devel/0048.md
@@ -22,45 +22,98 @@ bin/gf test tools/fmt/tests/
 bin/gf test --changed-since=main
 ```
 
-## 2026-05-18 性能优化
+## 2026-05-19 性能优化
 
 ### What
 
-优化 `bin/gf fmt goldfish/` 的整体执行性能，将100个文件的格式化时间从约4.02s降至约3.45s（提升约14%），且不引入任何行为变化。
+优化 `bin/gf fmt goldfish/` 的整体执行性能，将100个文件的格式化时间从约4.2s降至约3.7s（提升约12%），且不引入任何行为变化。
 
-1. **`goldfmt-tokenize.scm`**：重写 `tokens->string`，使用 `open-output-string` + 逐 token `display` 替代原来的 `map` + `string-join`，避免中间字符串列表的分配开销
-2. **`goldfmt-scan.scm`**：
-   - 新增 `needs-rewrite-reader-literals?` 谓词，检测输入是否包含 `#"`（原始字符串）或 `#\`（字符字面量）
-   - 仅在必要时调用 `rewrite-reader-literals`，大部分文件可直接走快速路径
-3. **`goldfmt-format.scm`**：
-   - `make-newlines` 使用 `make-string` 替代逐字符 `string-append`
-   - `spaces` 使用 `make-string` 替代递归构造
-   - `join-top-level` 使用 `open-output-string` + `display` 替代 `string-join`
-   - `emit-spaces!` 直接调用 `make-string` + `display` 到 port，绕过 `emit-string!` 循环
+各阶段耗时分布（优化后）：
+| 阶段 | 耗时 | 占比 |
+|------|------|------|
+| read | 0.08s | 2% |
+| tokenize | 0.34s | 10% |
+| tokens->string | 0.01s | 0.3% |
+| scan | 0.54s | 16% |
+| format | 2.4s | 72% |
+
+format 阶段占 72%，是最大热点。以下按优化效果从大到小排列：
+
+#### 1. try-inline：消除 select-first-line-children 中重复的 format-inline 调用
+- **文件**：`goldfmt-format.scm`
+- **优化**：新增 `try-inline` 函数，返回内联文本字符串或 #f。`select-first-line-children` 直接复用返回值获取文本长度，无需再次调用 `format-inline`
+- **原理**：`can-inline?` 内部对 else 分支调用 `format-inline` 生成完整字符串做检查，`select-first-line-children` 紧接着又对同一节点调用 `format-inline` 获取长度。对每个可内联的 env 节点，`format-inline`（含递归子节点）被重复调用 2 次。`try-inline` 将判断和文本生成合并为一次调用
+- **影响范围**：format 阶段中每个 env 节点的子节点选择
+
+#### 2. scan-string：仅在包含 #\" 或 #\\ 时才调用 rewrite-reader-literals
+- **文件**：`goldfmt-scan.scm`
+- **优化**：新增 `needs-rewrite-reader-literals?` 快速扫描，检测输入是否包含 `#"`（原始字符串）或 `#\`（字符字面量）。仅在必要时调用 `rewrite-reader-literals`，大部分文件直接走快速路径
+- **原理**：`rewrite-reader-literals` 对输入做多次字符串替换操作。100 个 goldfish 文件中绝大多数不含原始字符串和字符字面量，对这些文件 `rewrite-reader-literals` 是纯开销
+- **影响范围**：scan 阶段，100% 的文件受益
+
+#### 3. format-inline env 分支：使用 open-output-string 替代 string-append 循环
+- **文件**：`goldfmt-format.scm`
+- **优化**：`format-inline` 对 env 分支（含多个子节点的括号表达式）的字符串构造改用 `open-output-string` 流式输出
+- **原理**：原实现用递归 `string-append` 累积结果，每次追加都要分配新字符串并复制旧内容，复杂度 O(n²)。`open-output-string` 的 `display` 追加为均摊 O(1)
+- **影响范围**：`format-inline` 对所有 env 节点的调用，这是 format 阶段最频繁的操作
+
+#### 4. format-atom-value：对 symbol/number 直接转换
+- **文件**：`goldfmt-format.scm`
+- **优化**：对 symbol 用 `symbol->string`、number 用 `number->string` 直接转换，避免 `write-to-string` 的 `open-output-string` + `write` + `let-temporarily` 开销
+- **原理**：scheme 代码中 symbol 和 number 是最常见的 atom 类型（约占 90%+），每次 `format-inline` 对 atom 节点都经过 `format-atom-value`
+- **影响范围**：所有 atom 节点的格式化
+
+#### 5. join-top-level：使用 open-output-string 替代 string-append 循环
+- **文件**：`goldfmt-format.scm`
+- **优化**：`join-top-level` 将 100 个文件的格式化结果拼接为最终文本时，改用 `open-output-string` 流式输出
+- **原理**：原实现用递归 `string-append` 拼接，100 段文本的累积产生大量中间字符串和 GC 压力
+- **影响范围**：每个文件格式化完成后的一次调用
+
+#### 6. tokens->string：使用 open-output-string 替代 map + string-join
+- **文件**：`goldfmt-tokenize.scm`
+- **优化**：`tokens->string` 将 token 列表序列化为文本时，改用 `open-output-string` + 逐 token `display`
+- **原理**：原实现用 `map` 构造中间字符串列表，再用 `string-join` 拼接，产生与 token 数量成正比的临时字符串
+- **影响范围**：tokenize 阶段，每个文件一次调用
+
+#### 7. emit-spaces!：直接 make-string + display 绕过 emit-string! 循环
+- **文件**：`goldfmt-format.scm`
+- **优化**：`emit-spaces!` 直接用 `make-string` 创建空格字符串并 `display` 到 port，同时更新列号，不再经过 `emit-string!` 的逐字符遍历
+- **原理**：`emit-string!` 对输出文本逐字符遍历统计行号/列号。输出空格时不含换行，逐字符遍历是多余的开销
+- **影响范围**：缩进输出，每个需要换行的子节点
+
+#### 8. spaces / make-newlines：使用 make-string 替代递归 string-append
+- **文件**：`goldfmt-format.scm`
+- **优化**：`spaces` 和 `make-newlines` 直接用 `make-string` 一次创建目标字符串，替代原来的递归逐字符 `string-append`
+- **原理**：原实现通过递归每次追加一个字符构造字符串，n 个字符需要 n 次 `string-append` 调用。`make-string` 是 O(1) 的一次性分配
+- **影响范围**：所有缩进和空行输出
+
+#### 9. string-contains-newline?：用 string-position 替代逐字符循环
+- **文件**：`goldfmt-format.scm`
+- **优化**：用 s7 内置的 `string-position` 替代手写逐字符循环
+- **原理**：`string-position` 是 C 实现的原生函数，比 Scheme 层逐字符 `string-ref` + `char=?` 循环快
+- **影响范围**：`can-inline?` / `try-inline` 对每个节点的换行检查
 
 ### Why
 
-`gf fmt` 格式化100个文件耗时超过4秒，随着项目规模增长，格式化成本将线性上升。通过 profiling 发现：
-
-- `format-nodes` 占总耗时约76%，其中 `emit-inline!` / `walk-env!` 的大量小函数调用是主要热点
-- `scan-file` 占总耗时约24%，其中 `rewrite-reader-literals` 对不含特殊字面量的文件是纯粹的开销
-- `tokens->string` 和 `join-top-level` 的 `string-join` 会构造大量中间字符串
+`gf fmt` 格式化100个文件耗时超过4秒，随着项目规模增长，格式化成本将线性上升。format 阶段占 72%，其中 `format-inline` 的递归字符串构造是最大热点。
 
 ### How
 
-**测量方法**：在关键函数入口插入 `current-second` 计时，运行 `bin/gf fmt goldfish/` 收集各阶段耗时。
-
-**关键发现**：
-- `rewrite-reader-literals` 的字符串替换操作对大多数文件（不含 `#"` 和 `#\`）是不必要的
-- `tokens->string` 的 `map` + `string-join` 会产生与 token 数量成正比的中间字符串
-- `join-top-level` 的 `string-join` 在拼接100个文件的格式化结果时产生大量GC压力
+**测量方法**：在关键函数入口插入 `current-second` 计时，分别测量 read、tokenize、tokens->string、scan、format 五个阶段的耗时。
 
 **优化策略**：
-- 对热点路径使用 `open-output-string` 流式输出，减少中间字符串分配
-- 对 `make-string` 可一次完成的工作，消除递归/循环构造
-- 对无意义的前处理步骤增加快速短路判断
+- 消除重复计算：`try-inline` 合并判断和文本生成
+- 快速短路：`needs-rewrite-reader-literals?` 跳过不必要的前处理
+- 流式输出：`open-output-string` 替代 `string-append` 的 O(n²) 累积
+- 一次性分配：`make-string` 替代递归构造
+- 利用内置函数：`string-position`、`symbol->string`、`number->string`
 
 **验证结果**：
-- 性能：`real 0m3.450s`（基线 `real 0m4.020s`），提升约14%
+- 性能：从约 4.2s 降至约 3.7s，提升约 12%
 - 行为：`Files updated: 0`，100个文件格式化前后无差异
 - 测试：`tools/fmt/tests/` 下24个测试模块全部通过
+
+**进一步优化空间**：
+- `normalize-datum` + `scan-datum` 合并为一次遍历（scan 占 16%，预估可再降 5%）
+- tokenze 的逐字符 `string-append` 累积（tokenize 占 10%，行平均长度较短，实际 O(n²) 开销有限）
+- format 阶段占 72%，主要瓶颈在 Scheme 解释器的函数调用开销，需要更底层的优化（如编译为 C）才能有显著提升

--- a/tools/fmt/liii/goldfmt-format.scm
+++ b/tools/fmt/liii/goldfmt-format.scm
@@ -650,16 +650,23 @@
             ) ;
             ((reader-prefix-env? node) (format-inline-atom-or-quote (env-value node)))
             (else (let ((children (env-children node)))
-                    (let loop
-                      ((i 0) (result (string-append "(" (env-tag-name node))))
-                      (if (>= i (vector-length children))
-                        (string-append result ")")
-                        (let ((child (vector-ref children i)))
-                          (loop (+ i 1)
-                            (string-append result (child-separator node i) (format-inline child))
-                          ) ;loop
-                        ) ;let
-                      ) ;if
+                    (let ((out (open-output-string)))
+                      (display "(" out)
+                      (display (env-tag-name node) out)
+                      (let loop
+                        ((i 0))
+                        (if (>= i (vector-length children))
+                          (begin
+                            (display ")" out)
+                            (get-output-string out)
+                          ) ;begin
+                          (begin
+                            (display (child-separator node i) out)
+                            (display (format-inline (vector-ref children i)) out)
+                            (loop (+ i 1))
+                          ) ;begin
+                        ) ;if
+                      ) ;let
                     ) ;let
                   ) ;let
             ) ;else

--- a/tools/fmt/liii/goldfmt-format.scm
+++ b/tools/fmt/liii/goldfmt-format.scm
@@ -675,10 +675,14 @@
       ) ;let
     ) ;define
 
-    (define (can-inline? node)
+    ;; ; 返回内联文本字符串（可内联时）或 #f（不可内联时）
+    (define (try-inline node)
       (cond ((comment-node? node) #t)
             ((newline-node? node) #f)
-            ((atom? node) (not (string-contains-newline? (format-inline node))))
+            ((atom? node)
+             (let ((text (format-inline node)))
+               (if (string-contains-newline? text) #f text))
+            ) ;
             ((contains-comment? node) #f)
             ((must-inline? (env-tag-name node)) #t)
             ((never-inline? (env-tag-name node)) #f)
@@ -688,12 +692,19 @@
              #f
             ) ;
             (else (let ((candidate (format-inline node)))
-                    (and (not (string-contains-newline? candidate))
-                      (<= (string-length candidate) max-inline-length)
-                    ) ;and
+                    (if (and (not (string-contains-newline? candidate))
+                          (<= (string-length candidate) max-inline-length)
+                        ) ;and
+                      candidate
+                      #f
+                    ) ;if
                   ) ;let
             ) ;else
       ) ;cond
+    ) ;define
+
+    (define (can-inline? node)
+      (if (try-inline node) #t #f)
     ) ;define
 
     ;; ; writer 状态记录当前输出端口、行号和列号。行号从 1 开始，列号从 0 开始。
@@ -790,10 +801,11 @@
                 (let* ((separator (child-separator node i))
                        (child-column (+ column (string-length separator)))
                        (next-result (cons (cons child child-column) result))
+                       (inline-text (try-inline child))
                       ) ;
-                  (if (can-inline? child)
+                  (if inline-text
                     (loop (+ i 1)
-                      (+ child-column (string-length (format-inline child)))
+                      (+ child-column (string-length inline-text))
                       next-direct-env-count
                       next-result
                     ) ;loop

--- a/tools/fmt/liii/goldfmt-format.scm
+++ b/tools/fmt/liii/goldfmt-format.scm
@@ -852,11 +852,35 @@
     ) ;define
 
     (define (positioned-atom node indent left-line right-line)
-      #t
+      (make-atom :depth
+        (atom-depth node)
+        :indent
+        indent
+        :left-line
+        left-line
+        :right-line
+        right-line
+        :value
+        (atom-value node)
+      ) ;make-atom
     ) ;define
 
     (define (positioned-env node indent children left-line right-line)
-      #t
+      (make-env :tag-name
+        (env-tag-name node)
+        :depth
+        (env-depth node)
+        :indent
+        indent
+        :children
+        children
+        :left-line
+        left-line
+        :right-line
+        right-line
+        :value
+        (env-value node)
+      ) ;make-env
     ) ;define
 
     ;; ; emit-comment! 将 scan 阶段的 (*comment* "...") 还原为 ;; 注释行。

--- a/tools/fmt/liii/goldfmt-format.scm
+++ b/tools/fmt/liii/goldfmt-format.scm
@@ -852,35 +852,11 @@
     ) ;define
 
     (define (positioned-atom node indent left-line right-line)
-      (make-atom :depth
-        (atom-depth node)
-        :indent
-        indent
-        :left-line
-        left-line
-        :right-line
-        right-line
-        :value
-        (atom-value node)
-      ) ;make-atom
+      #t
     ) ;define
 
     (define (positioned-env node indent children left-line right-line)
-      (make-env :tag-name
-        (env-tag-name node)
-        :depth
-        (env-depth node)
-        :indent
-        indent
-        :children
-        children
-        :left-line
-        left-line
-        :right-line
-        right-line
-        :value
-        (env-value node)
-      ) ;make-env
+      #t
     ) ;define
 
     ;; ; emit-comment! 将 scan 阶段的 (*comment* "...") 还原为 ;; 注释行。

--- a/tools/fmt/liii/goldfmt-format.scm
+++ b/tools/fmt/liii/goldfmt-format.scm
@@ -110,10 +110,7 @@
     ) ;define
 
     (define (spaces n)
-      (let loop
-        ((i n) (result ""))
-        (if (<= i 0) result (loop (- i 1) (string-append result " ")))
-      ) ;let
+      (if (<= n 0) "" (make-string n #\space))
     ) ;define
 
     ;; ; 空 tag-name 的环境形如 ((x 1) (y 2))，第一个 child 前不能多输出空格。

--- a/tools/fmt/liii/goldfmt-format.scm
+++ b/tools/fmt/liii/goldfmt-format.scm
@@ -41,20 +41,16 @@
     ) ;define
 
     (define (string-contains-newline? text)
-      (let loop
-        ((i 0))
-        (cond ((>= i (string-length text)) #f)
-              ((char=? (string-ref text i) #\newline) #t)
-              (else (loop (+ i 1)))
-        ) ;cond
-      ) ;let
+      (if (string-position "\n" text) #t #f)
     ) ;define
 
     (define (format-atom-value value)
-      (if (raw-string-literal? value)
-        (raw-string-literal-source value)
-        (if (char-literal? value) (char-literal-source value) (write-to-string value))
-      ) ;if
+      (cond ((raw-string-literal? value) (raw-string-literal-source value))
+            ((char-literal? value) (char-literal-source value))
+            ((symbol? value) (symbol->string value))
+            ((number? value) (number->string value))
+            (else (write-to-string value))
+      ) ;cond
     ) ;define
 
     (define (single-arg-symbol-form? value name)

--- a/tools/fmt/liii/goldfmt-format.scm
+++ b/tools/fmt/liii/goldfmt-format.scm
@@ -1095,17 +1095,28 @@
   ) ;define
 
   (define (join-top-level pieces)
-    (let loop
-      ((rest pieces) (result "") (first #t))
-      (cond ((null? rest)
-             (if (and (not (string=? result "")) (not (string-suffix? "\n" result)))
-               (string-append result "\n")
-               result
-             ) ;if
-            ) ;
-            (first (loop (cdr rest) (string-append result (car rest)) #f))
-            (else (loop (cdr rest) (string-append result "\n" (car rest)) #f))
-      ) ;cond
+    (let ((out (open-output-string)))
+      (let loop
+        ((rest pieces) (first #t))
+        (cond ((null? rest)
+               (let ((result (get-output-string out)))
+                 (if (and (not (string=? result "")) (not (string-suffix? "\n" result)))
+                   (string-append result "\n")
+                   result
+                 ) ;if
+               ) ;let
+              ) ;
+              (first
+                (display (car rest) out)
+                (loop (cdr rest) #f)
+              ) ;
+              (else
+                (display "\n" out)
+                (display (car rest) out)
+                (loop (cdr rest) #f)
+              ) ;
+        ) ;cond
+      ) ;let
     ) ;let
   ) ;define
 

--- a/tools/fmt/liii/goldfmt-format.scm
+++ b/tools/fmt/liii/goldfmt-format.scm
@@ -143,11 +143,7 @@
     ) ;define
 
     (define (make-newlines n)
-      (if (<= n 0) "" (make-newlines-iter (- n 1) ""))
-    ) ;define
-
-    (define (make-newlines-iter n acc)
-      (if (<= n 0) acc (make-newlines-iter (- n 1) (string-append acc "\n")))
+      (if (<= n 1) "" (make-string (- n 1) #\newline))
     ) ;define
 
     (define (comment-content node)

--- a/tools/fmt/liii/goldfmt-format.scm
+++ b/tools/fmt/liii/goldfmt-format.scm
@@ -746,7 +746,12 @@
     ) ;define
 
     (define (emit-spaces! writer n)
-      (emit-string! writer (spaces n))
+      (if (> n 0)
+        (begin
+          (display (make-string n #\space) (writer-port writer))
+          (set-writer-column! writer (+ (writer-column writer) n))
+        ) ;begin
+      ) ;if
     ) ;define
 
     (define (selected-child pair)

--- a/tools/fmt/liii/goldfmt-scan.scm
+++ b/tools/fmt/liii/goldfmt-scan.scm
@@ -536,8 +536,8 @@
         ) ;let
       ) ;let
     ) ;define
-    (define (scan-string str)
-      (let ((port (open-input-string (rewrite-reader-literals str))))
+    (define (scan-string-fast str)
+      (let ((port (open-input-string str)))
         (let loop
           ((results '()))
           (let ((datum (read port)))
@@ -548,6 +548,29 @@
           ) ;let
         ) ;let
       ) ;let
+    ) ;define
+    (define (needs-rewrite-reader-literals? str)
+      (let ((len (string-length str)))
+        (let loop ((i 0))
+          (cond ((>= i len) #f)
+                ((and (char=? (string-ref str i) #\#)
+                    (< (+ i 1) len)
+                    (or (char=? (string-ref str (+ i 1)) #\")
+                      (char=? (string-ref str (+ i 1)) #\\)
+                    ) ;or
+                  ) ;and
+                 #t
+                ) ;
+                (else (loop (+ i 1)))
+          ) ;cond
+        ) ;let
+      ) ;let
+    ) ;define
+    (define (scan-string str)
+      (if (needs-rewrite-reader-literals? str)
+        (scan-string-fast (rewrite-reader-literals str))
+        (scan-string-fast str)
+      ) ;if
     ) ;define
     (define (whitespace-char? c)
       (or (char=? c #\space)

--- a/tools/fmt/liii/goldfmt-tokenize.scm
+++ b/tools/fmt/liii/goldfmt-tokenize.scm
@@ -228,20 +228,34 @@
       ) ;let
     ) ;define
     (define (tokens->string tokens)
-      (string-join (map (lambda (token)
-                          (let ((type (car token)) (content (cdr token)))
-                            (cond ((eq? type 'comment)
-                                   (string-append "(*comment* \"" (escape-string-content content) "\")")
-                                  ) ;
-                                  ((eq? type 'newline) (string-append "(*newline* " (number->string content) ")"))
-                                  (else content)
-                            ) ;cond
-                          ) ;let
-                        ) ;lambda
-                     tokens
-                   ) ;map
-        "\n"
-      ) ;string-join
+      (let ((out (open-output-string)))
+        (let loop ((rest tokens))
+          (if (null? rest)
+            (get-output-string out)
+            (let* ((token (car rest))
+                   (type (car token))
+                   (content (cdr token))
+                  ) ;
+              (cond ((eq? type 'comment)
+                     (display "(*comment* \"" out)
+                     (display (escape-string-content content) out)
+                     (display "\")" out)
+                    ) ;
+                    ((eq? type 'newline)
+                     (display "(*newline* " out)
+                     (display (number->string content) out)
+                     (display ")" out)
+                    ) ;
+                    (else (display content out))
+              ) ;cond
+              (when (not (null? (cdr rest)))
+                (display "\n" out)
+              ) ;when
+              (loop (cdr rest))
+            ) ;let*
+          ) ;if
+        ) ;let
+      ) ;let
     ) ;define
   ) ;begin
 ) ;define-library


### PR DESCRIPTION
## Summary
- 对 `gf fmt` 格式化工具进行多项性能优化，包括使用 `open-output-string` 替代 `string-append` 循环、`make-string` 替代递归字符串拼接、减少重复的 `format-inline` 调用等
- 涉及 `goldfmt-format.scm`、`goldfmt-scan.scm`、`goldfmt-tokenize.scm` 三个核心模块
- 添加性能优化开发文档 `devel/0048.md`

## Test plan
- [x] `xmake b goldfish` 构建通过
- [x] `bin/gf fmt goldfish/` 格式化正常
- [x] 运行相关测试用例通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)