### PR TITLE
[0050] 将 string-position 实现迁移到 s7_liii_string.c

### DIFF
--- a/devel/0050.md
+++ b/devel/0050.md
@@ -5,6 +5,9 @@
 - goldfish/srfi/srfi-13.scm
 - tests/liii/string/string-position-test.scm
 - bench/string-contains-bench.scm
+- src/s7_liii_string.c
+- src/s7_liii_string.h
+- src/s7.c
 
 ## 如何测试
 
@@ -32,6 +35,29 @@ bin/gf bench/string-contains-bench.scm
 ```bash
 bin/gf test --changed-since=main
 ```
+
+## 2026-05-19 将 string-position 实现迁移到 s7_liii_string.c
+
+### What
+1. 将 g_string_position 从 s7.c 迁移到 s7_liii_string.c
+2. 将 s7.c 内部 API 替换为公开 API（s7_is_string, s7_string, s7_string_length 等）
+3. 在 s7_liii_string.h 中添加函数声明
+4. 从 s7.c 中删除原实现
+
+### Why
+string-position 与 string-ref、string-set!、string-length、char-position 同属字符串操作，应统一放在 s7_liii_string.c 中。
+
+### How
+g_string_position 原本使用 s7.c 内部宏（is_string, car, cadr, method_or_bust, string_length, string_value, make_integer, wrong_type_error_nr），迁移时替换为对应的公开 API：
+- is_string -> s7_is_string
+- car/cadr -> s7_car/s7_cadr
+- method_or_bust -> s7_liii_string.c 中已有的 method_or_bust 辅助函数（但签名不同，需适配）
+- string_length -> s7_string_length
+- string_value -> s7_string
+- make_integer -> s7_make_integer
+- wrong_type_error_nr -> s7_wrong_type_arg_error
+
+s7.c 中的注册代码（defun、set_function_chooser、string_position_symbol）保持不变，仅将函数实现移出。H_string_position 和 Q_string_position 宏定义在函数体内，迁移时移除（文档字符串由注册处提供）。
 
 ## 2026-05-19 用 string-position 优化 srfi-13 string-contains
 

--- a/src/s7.c
+++ b/src/s7.c
@@ -20456,38 +20456,10 @@ static s7_pointer char_position_chooser(s7_scheme *sc, s7_pointer func, int32_t 
 
 
 /* -------------------------------- string-position -------------------------------- */
-static s7_pointer g_string_position(s7_scheme *sc, s7_pointer args)
-{
-  #define H_string_position "(string-position str1 str2 (start 0)) returns the starting position of str1 in str2 or #f"
-  #define Q_string_position s7_make_signature(sc, 4, \
-                              s7_make_signature(sc, 2, sc->is_integer_symbol, sc->not_symbol), \
-                              sc->is_string_symbol, sc->is_string_symbol, sc->is_integer_symbol)
-  s7_int start = 0;
-  const s7_pointer str1 = car(args), str2 = cadr(args);
-
-  if (!is_string(str1))
-    return(method_or_bust(sc, str1, sc->string_position_symbol, args, sc->type_names[T_STRING], 1));
-  if (!is_string(str2))
-    return(method_or_bust(sc, str2, sc->string_position_symbol, args, sc->type_names[T_STRING], 2));
-
-  if (is_pair(cddr(args)))
-    {
-      const s7_pointer arg3 = caddr(args);
-      if (!s7_is_integer(arg3))
-	return(method_or_bust(sc, arg3, sc->string_position_symbol, args, sc->type_names[T_INTEGER], 3));
-      start = s7_integer_clamped_if_gmp(sc, arg3);
-      if (start < 0)
-	wrong_type_error_nr(sc, sc->string_position_symbol, 3, caddr(args), a_non_negative_integer_string);
-    }
-  if (string_length(str1) == 0) return(sc->F);
-  if (start >= string_length(str2)) return(sc->F);
-  {
-    const char *s1 = string_value(str1);
-    const char *s2 = string_value(str2);
-    const char *p2 = strstr((const char *)(s2 + start), s1); /* g++ insists on const */
-    return((p2) ? make_integer(sc, p2 - s2) : sc->F);
-  }
-}
+#define H_string_position "(string-position str1 str2 (start 0)) returns the starting position of str1 in str2 or #f"
+#define Q_string_position s7_make_signature(sc, 4, \
+                            s7_make_signature(sc, 2, sc->is_integer_symbol, sc->not_symbol), \
+                            sc->is_string_symbol, sc->is_string_symbol, sc->is_integer_symbol)
 
 
 /* -------------------------------- strings -------------------------------- */

--- a/src/s7_liii_string.c
+++ b/src/s7_liii_string.c
@@ -109,6 +109,37 @@ g_char_position_csi (s7_scheme* sc, s7_pointer args) {
   return p ? s7_make_integer (sc, (s7_int) (p - porig)) : s7_f (sc);
 }
 
+/* -------------------------------- string-position -------------------------------- */
+
+s7_pointer g_string_position(s7_scheme *sc, s7_pointer args)
+{
+  const s7_pointer str1 = s7_car(args), str2 = s7_cadr(args);
+
+  if (!s7_is_string(str1))
+    return method_or_bust(sc, str1, "string-position", "a string");
+  if (!s7_is_string(str2))
+    return method_or_bust(sc, str2, "string-position", "a string");
+
+  s7_int start = 0;
+  if (s7_is_pair(s7_cddr(args)))
+    {
+      const s7_pointer arg3 = s7_caddr(args);
+      if (!s7_is_integer(arg3))
+        return method_or_bust(sc, arg3, "string-position", "an integer");
+      start = s7_integer(arg3);
+      if (start < 0)
+        return s7_wrong_type_arg_error(sc, "string-position", 3, arg3, "a non-negative integer");
+    }
+
+  if (s7_string_length(str1) == 0) return s7_f(sc);
+  if (start >= s7_string_length(str2)) return s7_f(sc);
+
+  const char *s1 = s7_string(str1);
+  const char *s2 = s7_string(str2);
+  const char *p2 = strstr((const char *)(s2 + start), s1);
+  return p2 ? s7_make_integer(sc, (s7_int)(p2 - s2)) : s7_f(sc);
+}
+
 /* -------------------------------- string-ref -------------------------------- */
 
 s7_pointer string_ref_1(s7_scheme *sc, s7_pointer strng, s7_pointer index)

--- a/src/s7_liii_string.h
+++ b/src/s7_liii_string.h
@@ -24,6 +24,8 @@ s7_pointer g_char_position(s7_scheme *sc, s7_pointer args);
 s7_pointer char_position_p_ppi(s7_scheme *sc, s7_pointer chr, s7_pointer str, s7_int start);
 s7_pointer g_char_position_csi(s7_scheme *sc, s7_pointer args);
 
+s7_pointer g_string_position(s7_scheme *sc, s7_pointer args);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary
- 将 `g_string_position` 从 `s7.c` 迁移到 `s7_liii_string.c`，与 string-ref、string-set!、string-length、char-position 统一管理
- 使用公开 API（s7_is_string, s7_string, s7_string_length 等）替换 s7.c 内部宏
- 更新 devel/0050.md 添加迁移记录

## Test plan
- [x] `xmake b goldfish` 构建通过
- [x] `bin/gf tests/liii/string/string-position-test.scm` 5/5 通过
- [x] `bin/gf tests/liii/string/char-position-test.scm` 8/8 通过
- [x] `bin/gf tests/liii/string-cursor/string-contains-test.scm` 14/14 通过
- [x] `bin/gf tests/liii/case-test.scm` 52/52 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)