### PR TITLE
[0048] 优化 gf fmt 性能

### DIFF
--- a/goldfish/srfi/srfi-13.scm
+++ b/goldfish/srfi/srfi-13.scm
@@ -412,9 +412,8 @@
     ) ;define
 
     (define (string-contains str sub-str)
-      (if (= (string-length sub-str) 0)
-        #t
-        (if (string-position sub-str str) #t #f)))
+      (if (= (string-length sub-str) 0) #t (if (string-position sub-str str) #t #f))
+    ) ;define
 
     (define (string-count str char/pred? . start+end)
       (when (not (string? str))

--- a/tools/fmt/liii/goldfmt-format.scm
+++ b/tools/fmt/liii/goldfmt-format.scm
@@ -377,12 +377,16 @@
     ) ;define
 
     (define (format-reader-vector-inline datum)
-      (let ((prefix (if (byte-vector? datum) "#u8(" "#(")))
-        (let loop
-          ((i 0) (pieces '()))
+      (let ((out (open-output-string)))
+        (display (if (byte-vector? datum) "#u8(" "#(") out)
+        (let loop ((i 0))
           (if (>= i (vector-length datum))
-            (string-append prefix (string-join (reverse pieces) " ") ")")
-            (loop (+ i 1) (cons (format-reader-datum-inline (vector-ref datum i)) pieces))
+            (begin (display ")" out) (get-output-string out))
+            (begin
+              (if (> i 0) (display " " out))
+              (display (format-reader-datum-inline (vector-ref datum i)) out)
+              (loop (+ i 1))
+            ) ;begin
           ) ;if
         ) ;let
       ) ;let
@@ -452,30 +456,40 @@
     ) ;define
 
     (define (format-reader-pair-inline datum)
-      (let loop
-        ((current datum) (pieces '()))
-        (cond ((pair? current)
-               (loop (cdr current) (cons (format-reader-datum-inline (car current)) pieces))
-              ) ;
-              ((null? current) (string-append "(" (string-join (reverse pieces) " ") ")"))
-              (else (string-append "("
-                      (string-join (reverse pieces) " ")
-                      " . "
-                      (format-reader-datum-inline current)
-                      ")"
-                    ) ;string-append
-              ) ;else
-        ) ;cond
+      (let ((out (open-output-string)))
+        (display "(" out)
+        (let loop
+          ((current datum) (first #t))
+          (cond ((pair? current)
+                 (if first
+                   (begin (display (format-reader-datum-inline (car current)) out) (loop (cdr current) #f))
+                   (begin (display " " out) (display (format-reader-datum-inline (car current)) out) (loop (cdr current) #f))
+                 ) ;if
+                ) ;
+                ((null? current) (display ")" out) (get-output-string out))
+                (else (display " . " out)
+                  (display (format-reader-datum-inline current) out)
+                  (display ")" out)
+                  (get-output-string out)
+                ) ;else
+          ) ;cond
+        ) ;let
       ) ;let
     ) ;define
 
     (define (reader-append-selected result selected)
-      (let loop
-        ((items selected) (text result))
-        (if (null? items)
-          text
-          (loop (cdr items) (string-append text " " (reader-selected-text (car items))))
-        ) ;if
+      (let ((out (open-output-string)))
+        (display result out)
+        (let loop ((items selected))
+          (if (null? items)
+            (get-output-string out)
+            (begin
+              (display " " out)
+              (display (reader-selected-text (car items)) out)
+              (loop (cdr items))
+            ) ;begin
+          ) ;if
+        ) ;let
       ) ;let
     ) ;define
 
@@ -497,41 +511,43 @@
     ) ;define
 
     (define (reader-append-rest current result rest-indent prefix-ready? close-indent)
-      (cond ((pair? current)
-             (let ((item (car current)))
-               (if (newline-marker-datum? item)
-                 (reader-append-rest (cdr current)
-                   (string-append result (reader-newlines (cadr item)) (spaces rest-indent))
-                   rest-indent
-                   #t
-                   close-indent
-                 ) ;reader-append-rest
-                 (reader-append-rest (cdr current)
-                   (string-append result
-                     (if prefix-ready? "" (string-append "\n" (spaces rest-indent)))
-                     (format-reader-datum-at item
-                       (if prefix-ready? (last-line-column result) rest-indent)
-                     ) ;format-reader-datum-at
-                   ) ;string-append
-                   rest-indent
-                   #f
-                   close-indent
-                 ) ;reader-append-rest
-               ) ;if
-             ) ;let
-            ) ;
-            ((null? current) (reader-append-close result close-indent))
-            (else (reader-append-close (let* ((prefix (if prefix-ready? "" (string-append "\n" (spaces rest-indent))))
-                                              (before-tail (string-append result prefix ". "))
-                                             ) ;
-                                         (string-append before-tail
-                                           (format-reader-datum-at current (last-line-column before-tail))
-                                         ) ;string-append
-                                       ) ;let*
-                    close-indent
-                  ) ;reader-append-close
-            ) ;else
-      ) ;cond
+      (let ((out (open-output-string)))
+        (display result out)
+        (let loop ((current current) (prefix-ready? prefix-ready?) (last-result result))
+          (cond ((pair? current)
+                 (let ((item (car current)))
+                   (if (newline-marker-datum? item)
+                     (begin
+                       (display (reader-newlines (cadr item)) out)
+                       (display (spaces rest-indent) out)
+                       (loop (cdr current) #t (spaces rest-indent))
+                     ) ;begin
+                     (let ((prefix (if prefix-ready? "" (string-append "\n" (spaces rest-indent)))))
+                       (display prefix out)
+                       (let ((text (format-reader-datum-at item
+                                     (if prefix-ready? (last-line-column last-result) rest-indent))))
+                         (display text out)
+                         (loop (cdr current) #f text)
+                       ) ;let
+                     ) ;let
+                   ) ;if
+                 ) ;let
+                ) ;
+                ((null? current)
+                 (reader-append-close (get-output-string out) close-indent))
+                (else
+                 (let* ((prefix (if prefix-ready? "" (string-append "\n" (spaces rest-indent))))
+                        (before-tail (string-append (get-output-string out) prefix ". "))
+                       ) ;
+                   (reader-append-close
+                     (string-append before-tail
+                       (format-reader-datum-at current (last-line-column before-tail)))
+                     close-indent)
+                 ) ;let*
+                ) ;else
+          ) ;cond
+        ) ;let
+      ) ;let
     ) ;define
 
     (define (format-reader-pair-multiline datum indent)

--- a/tools/fmt/liii/goldfmt-format.scm
+++ b/tools/fmt/liii/goldfmt-format.scm
@@ -754,17 +754,22 @@
 
     (define (emit-string! writer text)
       (display text (writer-port writer))
-      (let loop
-        ((i 0) (line (writer-line writer)) (column (writer-column writer)))
-        (if (>= i (string-length text))
-          (begin
-            (set-writer-line! writer line)
-            (set-writer-column! writer column)
-          ) ;begin
-          (if (char=? (string-ref text i) #\newline)
-            (loop (+ i 1) (+ line 1) 0)
-            (loop (+ i 1) line (+ column 1))
-          ) ;if
+      (let ((nl (string-position "\n" text)))
+        (if nl
+          (let loop
+            ((i 0) (line (writer-line writer)) (column (writer-column writer)))
+            (if (>= i (string-length text))
+              (begin
+                (set-writer-line! writer line)
+                (set-writer-column! writer column)
+              ) ;begin
+              (if (char=? (string-ref text i) #\newline)
+                (loop (+ i 1) (+ line 1) 0)
+                (loop (+ i 1) line (+ column 1))
+              ) ;if
+            ) ;if
+          ) ;let
+          (set-writer-column! writer (+ (writer-column writer) (string-length text)))
         ) ;if
       ) ;let
     ) ;define

--- a/tools/fmt/liii/goldfmt-record.scm
+++ b/tools/fmt/liii/goldfmt-record.scm
@@ -71,32 +71,6 @@
 
     ;; ; 使用具名参数构造 atom
     (define* (make-atom (depth 0) (indent -1) (left-line 0) (right-line 0) (value #f))
-      ;; ; 参数校验
-      (when (not (integer? depth))
-        (value-error "make-atom in liii/goldfmt-record: depth must be an integer")
-      ) ;when
-      (when (< depth 0)
-        (value-error "make-atom in liii/goldfmt-record: depth must be non-negative")
-      ) ;when
-      (when (not (integer? indent))
-        (value-error "make-atom in liii/goldfmt-record: indent must be an integer")
-      ) ;when
-      (when (< indent -1)
-        (value-error "make-atom in liii/goldfmt-record: indent must be >= -1")
-      ) ;when
-      (when (not (integer? left-line))
-        (value-error "make-atom in liii/goldfmt-record: left-line must be an integer")
-      ) ;when
-      (when (< left-line 0)
-        (value-error "make-atom in liii/goldfmt-record: left-line must be non-negative")
-      ) ;when
-      (when (not (integer? right-line))
-        (value-error "make-atom in liii/goldfmt-record: right-line must be an integer")
-      ) ;when
-      (when (< right-line 0)
-        (value-error "make-atom in liii/goldfmt-record: right-line must be non-negative"
-        ) ;value-error
-      ) ;when
       (%make-atom depth indent left-line right-line value)
     ) ;define*
 
@@ -108,14 +82,6 @@
     ) ;define-record-type
 
     (define* (make-raw-string-literal (source "") (value ""))
-      (when (not (string? source))
-        (value-error "make-raw-string-literal in liii/goldfmt-record: source must be a string"
-        ) ;value-error
-      ) ;when
-      (when (not (string? value))
-        (value-error "make-raw-string-literal in liii/goldfmt-record: value must be a string"
-        ) ;value-error
-      ) ;when
       (%make-raw-string-literal source value)
     ) ;define*
 
@@ -127,13 +93,6 @@
     ) ;define-record-type
 
     (define* (make-char-literal (source "") (value #\space))
-      (when (not (string? source))
-        (value-error "make-char-literal in liii/goldfmt-record: source must be a string"
-        ) ;value-error
-      ) ;when
-      (when (not (char? value))
-        (value-error "make-char-literal in liii/goldfmt-record: value must be a char")
-      ) ;when
       (%make-char-literal source value)
     ) ;define*
 
@@ -146,37 +105,6 @@
                (right-line 0)
                (value #f)
              ) ;make-env
-      ;; ; 参数校验
-      (when (not (or (string? tag-name) (eq? tag-name #f)))
-        (value-error "make-env in liii/goldfmt-record: tag-name must be a string or #f")
-      ) ;when
-      (when (not (integer? depth))
-        (value-error "make-env in liii/goldfmt-record: depth must be an integer")
-      ) ;when
-      (when (< depth 0)
-        (value-error "make-env in liii/goldfmt-record: depth must be non-negative")
-      ) ;when
-      (when (not (integer? indent))
-        (value-error "make-env in liii/goldfmt-record: indent must be an integer")
-      ) ;when
-      (when (< indent -1)
-        (value-error "make-env in liii/goldfmt-record: indent must be >= -1")
-      ) ;when
-      (when (not (or (vector? children) (eq? children #f)))
-        (value-error "make-env in liii/goldfmt-record: children must be a vector or #f")
-      ) ;when
-      (when (not (integer? left-line))
-        (value-error "make-env in liii/goldfmt-record: left-line must be an integer")
-      ) ;when
-      (when (< left-line 0)
-        (value-error "make-env in liii/goldfmt-record: left-line must be non-negative")
-      ) ;when
-      (when (not (integer? right-line))
-        (value-error "make-env in liii/goldfmt-record: right-line must be an integer")
-      ) ;when
-      (when (< right-line 0)
-        (value-error "make-env in liii/goldfmt-record: right-line must be non-negative")
-      ) ;when
       (%make-env tag-name depth indent children left-line right-line value)
     ) ;define*
 

--- a/tools/fmt/liii/goldfmt-scan.scm
+++ b/tools/fmt/liii/goldfmt-scan.scm
@@ -15,7 +15,7 @@
 ;;
 
 (define-library (liii goldfmt-scan)
-  (export scan scan-string scan-file)
+  (export scan scan-string scan-file scan-content)
   (import (liii base)
     (liii path)
     (liii raw-string)
@@ -718,9 +718,8 @@
         "\n"
       ) ;string-join
     ) ;define
-    (define (scan-file path)
-      (let* ((raw-content (path-read-text path))
-             (scanned (source-tokenize raw-content))
+    (define (scan-content raw-content)
+      (let* ((scanned (source-tokenize raw-content))
              (leading-blanks (let loop
                                ((i 0) (count 0))
                                (if (>= i (string-length raw-content))
@@ -750,5 +749,8 @@
         (scan-string processed-content)
       ) ;let*
     ) ;define
+
+    (define (scan-file path)
+      (scan-content (path-read-text path)))
   ) ;begin
 ) ;define-library

--- a/tools/fmt/liii/goldfmt-tokenize.scm
+++ b/tools/fmt/liii/goldfmt-tokenize.scm
@@ -8,8 +8,8 @@
 ;; http://www.apache.org/licenses/LICENSE-2.0
 ;;
 ;; Unless required by applicable law or agreed to in writing, software
-;; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-;; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 ;; License for the specific language governing permissions and limitations
 ;; under the License.
 ;;
@@ -63,9 +63,15 @@
             (raw-delimiter "")
             (raw-delimiter-match 0)
            ) ;
-        (define (process-char i)
+        (define (flush-run! start end)
+          (if (< start end)
+            (set! current-line (string-append current-line (substring content start end)))
+          ) ;if
+        ) ;define
+        (define (process-char i run-start)
           (if (>= i len)
             (begin
+              (flush-run! run-start i)
               (if (and (not (string-null? current-line))
                     (not (string-every (lambda (c)
                                          (or (char=? c #\space)
@@ -85,27 +91,41 @@
             (let ((c (string-ref content i))
                   (next-c (if (< (+ i 1) len) (string-ref content (+ i 1)) #\nul))
                  ) ;
-              (cond (in-string (set! current-line (string-append current-line (string c)))
-                      (cond (string-escaped (set! string-escaped #f) (process-char (+ i 1)))
-                            ((char=? c #\\) (set! string-escaped #t) (process-char (+ i 1)))
-                            ((char=? c #\") (set! in-string #f) (process-char (+ i 1)))
-                            (else (process-char (+ i 1)))
-                      ) ;cond
+              (cond (in-string (cond (string-escaped
+                                      (flush-run! run-start i)
+                                      (set! current-line (string-append current-line (string c)))
+                                      (set! string-escaped #f)
+                                      (process-char (+ i 1) (+ i 1))
+                                     ) ;
+                                     ((char=? c #\\)
+                                      (flush-run! run-start i)
+                                      (set! current-line (string-append current-line (string c)))
+                                      (set! string-escaped #t)
+                                      (process-char (+ i 1) (+ i 1))
+                                     ) ;
+                                     ((char=? c #\")
+                                      (flush-run! run-start (+ i 1))
+                                      (set! in-string #f)
+                                      (process-char (+ i 1) (+ i 1))
+                                     ) ;
+                                     (else (process-char (+ i 1) run-start))
+                               ) ;cond
                     ) ;in-string
                     (in-block-comment (cond ((and (char=? c #\|) (char=? next-c #\#))
+                                             (flush-run! run-start i)
                                              (set! in-block-comment #f)
-                                             (process-char (+ i 2))
+                                             (process-char (+ i 2) (+ i 2))
                                             ) ;
-                                            (else (process-char (+ i 1)))
+                                            (else (process-char (+ i 1) run-start))
                                       ) ;cond
                     ) ;in-block-comment
-                    (in-raw-string (set! current-line (string-append current-line (string c)))
+                    (in-raw-string
                       (cond ((and (= (string-length raw-delimiter) 0) (char=? c #\") (char=? next-c #\"))
-                             (set! current-line (string-append current-line "\""))
+                             (flush-run! run-start (+ i 2))
                              (set! in-raw-string #f)
                              (set! raw-delimiter "")
                              (set! raw-delimiter-match 0)
-                             (process-char (+ i 2))
+                             (process-char (+ i 2) (+ i 2))
                             ) ;
                             ((and (< raw-delimiter-match (string-length raw-delimiter))
                                (char=? c (string-ref raw-delimiter raw-delimiter-match))
@@ -114,28 +134,37 @@
                              (if (>= raw-delimiter-match (string-length raw-delimiter))
                                (if (and (< (+ i 1) len) (char=? (string-ref content (+ i 1)) #\"))
                                  (begin
-                                   (set! current-line (string-append current-line "\""))
+                                   (flush-run! run-start (+ i 2))
                                    (set! in-raw-string #f)
                                    (set! raw-delimiter "")
                                    (set! raw-delimiter-match 0)
-                                   (process-char (+ i 2))
+                                   (process-char (+ i 2) (+ i 2))
                                  ) ;begin
-                                 (process-char (+ i 1))
+                                 (process-char (+ i 1) run-start)
                                ) ;if
-                               (process-char (+ i 1))
+                               (process-char (+ i 1) run-start)
                              ) ;if
                             ) ;
-                            ((char=? c #\newline) (set! raw-delimiter-match 0) (process-char (+ i 1)))
-                            (else (set! raw-delimiter-match 0) (process-char (+ i 1)))
+                            ((char=? c #\newline)
+                             (flush-run! run-start (+ i 1))
+                             (set! raw-delimiter-match 0)
+                             (process-char (+ i 1) (+ i 1))
+                            ) ;
+                            (else
+                             (set! raw-delimiter-match 0)
+                             (process-char (+ i 1) run-start)
+                            ) ;else
                       ) ;cond
                     ) ;in-raw-string
 
                     (else (cond ((and (char=? c #\#) (char=? next-c #\|))
+                                 (flush-run! run-start i)
                                  (set! in-block-comment #t)
-                                 (process-char (+ i 2))
+                                 (process-char (+ i 2) (+ i 2))
                                 ) ;
 
                                 ((and (char=? c #\#) (char=? next-c #\"))
+                                 (flush-run! run-start i)
                                  (let ((delim-end (string-index content #\" (+ i 2))))
                                    (if delim-end
                                      (begin
@@ -143,22 +172,24 @@
                                        (set! raw-delimiter (substring content (+ i 2) delim-end))
                                        (set! raw-delimiter-match 0)
                                        (set! current-line (string-append current-line "#\"" raw-delimiter "\""))
-                                       (process-char (+ delim-end 1))
+                                       (process-char (+ delim-end 1) (+ delim-end 1))
                                      ) ;begin
                                      (begin
                                        (set! current-line (string-append current-line (string c)))
-                                       (process-char (+ i 1))
+                                       (process-char (+ i 1) (+ i 1))
                                      ) ;begin
                                    ) ;if
                                  ) ;let
                                 ) ;
 
                                 ((char=? c #\")
+                                 (flush-run! run-start i)
                                  (set! in-string #t)
                                  (set! current-line (string-append current-line (string c)))
-                                 (process-char (+ i 1))
+                                 (process-char (+ i 1) (+ i 1))
                                 ) ;
                                 ((and (char=? c #\;) (char=? next-c #\;))
+                                 (flush-run! run-start i)
                                  (if (and (not (string-null? current-line))
                                        (not (string-every (lambda (c) (or (char=? c #\space) (char=? c #\tab)))
                                               current-line
@@ -177,23 +208,24 @@
                                    (if newline-pos
                                      (begin
                                        (set! current-line "")
-                                       (process-char (+ newline-pos 1))
+                                       (process-char (+ newline-pos 1) (+ newline-pos 1))
                                      ) ;begin
                                      (reverse tokens)
                                    ) ;if
                                  ) ;let*
                                 ) ;
                                 ((char=? c #\newline)
+                                 (flush-run! run-start i)
                                  (if (and (not (string-null? current-line)) (not (blank-line? current-line)))
                                    (begin
                                      (set! tokens (cons (cons 'code current-line) tokens))
                                      (set! current-line "")
-                                     (process-char (+ i 1))
+                                     (process-char (+ i 1) (+ i 1))
                                    ) ;begin
                                    (if (null? tokens)
                                      (begin
                                        (set! current-line "")
-                                       (process-char (+ i 1))
+                                       (process-char (+ i 1) (+ i 1))
                                      ) ;begin
                                      (let count-loop
                                        ((pos (+ i 1)) (blank-count (if (blank-line? current-line) 1 0)))
@@ -206,7 +238,7 @@
                                                          (set! tokens (cons (cons 'newline blank-count) tokens))
                                                        ) ;when
                                                    (set! current-line "")
-                                                   (process-char pos)
+                                                   (process-char pos pos)
                                                  ) ;else
                                            ) ;cond
                                          ) ;let
@@ -215,16 +247,14 @@
                                    ) ;if
                                  ) ;if
                                 ) ;
-                                (else (set! current-line (string-append current-line (string c)))
-                                  (process-char (+ i 1))
-                                ) ;else
+                                (else (process-char (+ i 1) run-start))
                           ) ;cond
                     ) ;else
               ) ;cond
             ) ;let
           ) ;if
         ) ;define
-        (process-char 0)
+        (process-char 0 0)
       ) ;let
     ) ;define
     (define (tokens->string tokens)

--- a/tools/fmt/liii/goldfmt-tokenize.scm
+++ b/tools/fmt/liii/goldfmt-tokenize.scm
@@ -112,7 +112,6 @@
                                ) ;cond
                     ) ;in-string
                     (in-block-comment (cond ((and (char=? c #\|) (char=? next-c #\#))
-                                             (flush-run! run-start i)
                                              (set! in-block-comment #f)
                                              (process-char (+ i 2) (+ i 2))
                                             ) ;

--- a/tools/fmt/liii/goldfmt.scm
+++ b/tools/fmt/liii/goldfmt.scm
@@ -94,7 +94,10 @@
 
     ;; ; 格式化单个文件（dry-run 模式，输出到终端）
     (define (format-file-dry-run path-str)
-      (let* ((nodes (scan-file path-str)) (formatted (format-nodes nodes)))
+      (let* ((raw-content (path-read-text (path path-str)))
+             (nodes (scan-content raw-content))
+             (formatted (format-nodes nodes))
+            ) ;
         (display formatted)
       ) ;let*
     ) ;define
@@ -104,7 +107,7 @@
     (define (format-file path-str)
       (let* ((p (path path-str))
              (original-content (path-read-text p))
-             (nodes (scan-file path-str))
+             (nodes (scan-content original-content))
              (formatted (format-nodes nodes))
             ) ;
         (if (string=? original-content formatted)


### PR DESCRIPTION
## Summary
- 用 `open-output-string` 替代 `string-append` 优化格式化字符串拼接
- 优化 `emit-string!` 跳过无换行字符串的逐字符扫描
- 优化 `tokenize` 用 `substring` 批量拷贝替代逐字符 `string-append`
- 移除 `make-atom`/`make-env` 的参数校验以减少热路径开销
- 提取 `scan-content` 避免 `format-file` 中重复读取文件

## Test plan
- [x] `xmake b goldfish` 构建通过
- [x] `bin/gf fmt` 格式化功能正常
- [x] 相关测试用例通过