### PR TITLE
[0056] gf fix 添加基于文件系统的缓存机制

### DIFF
--- a/devel/0056.md
+++ b/devel/0056.md
@@ -1,0 +1,30 @@
+# [0056] gf fix 添加基于文件系统的缓存机制
+
+## 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [0054.md](0054.md) - gf fmt 缓存机制
+
+## 任务相关的代码文件
+- tools/fix/liii/goldfix.scm
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf fix goldfish/liii/os.scm
+# 第二次运行应显示 Files cached: 1
+bin/gf fix goldfish/liii/os.scm
+```
+
+## 2026-05-20 gf fix 添加基于文件系统的缓存机制
+### What
+1. 添加基于 sha256 文件哈希的缓存机制（与 gf fmt 一致）
+2. 缓存目录位于 `~/.cache/goldfish/fix/<version>/`
+3. 修复括号后，内容无变化时标记缓存
+4. 汇总输出增加 Files cached 统计
+
+### Why
+gf fix 对大量文件递归修复括号时，每次都重新处理未变更的文件，性能较差。通过文件哈希缓存已处理过的文件，避免重复处理。
+
+### How
+- 参照 goldfmt.scm 的缓存实现，在 goldfix.scm 中添加相同的缓存逻辑
+- 缓存在 fix-file-core 层面生效，修复括号后内容不变才 touch cache

--- a/tools/fix/liii/goldfix.scm
+++ b/tools/fix/liii/goldfix.scm
@@ -4,6 +4,7 @@
     (liii sys)
     (liii path)
     (liii argparse)
+    (liii hashlib)
     (liii os)
     (srfi srfi-13)
     (liii goldfix-repair)
@@ -11,6 +12,38 @@
   ) ;import
 
   (begin
+
+    (define (fix-cache-base-dir)
+      (path->string (path-join (path-home) ".cache" "goldfish" "fix" (version)))
+    ) ;define
+
+    (define (fix-cache-path file-path)
+      (let* ((hash (sha256-by-file file-path))
+             (prefix (substring hash 0 2))
+             (rest (substring hash 2))
+             (base (fix-cache-base-dir))
+            ) ;
+        (path->string (path-join base prefix rest))
+      ) ;let*
+    ) ;define
+
+    (define (fix-cache-hit? file-path)
+      (let ((cache (fix-cache-path file-path)))
+        (file-exists? cache)
+      ) ;let
+    ) ;define
+
+    (define (fix-cache-touch file-path)
+      (let* ((cache (fix-cache-path file-path))
+             (cache-dir (path->string (path-parent (path cache))))
+            ) ;
+        (unless (path-dir? (path cache-dir))
+          (g_mkdir cache-dir)
+        ) ;unless
+        (path-touch (path cache))
+      ) ;let*
+    ) ;define
+
     (define (display-help)
       (display "Usage: gf fix [options] [path]")
       (newline)
@@ -77,21 +110,38 @@
       ) ;let
     ) ;define
 
-    (define (fix-file-core path-str)
-      (let* ((p (path path-str))
-             (source (path-read-text p))
-             (repaired (repair-source source))
-            ) ;
-        (if (string=? source repaired) #f (begin (path-write-text p repaired) #t))
-      ) ;let*
-    ) ;define
+    (define* (fix-file-core path-str (use-cache? #t))
+      (if (and use-cache? (fix-cache-hit? path-str))
+        'cached
+        (let* ((p (path path-str))
+               (source (path-read-text p))
+               (repaired (repair-source source))
+              ) ;
+          (if (string=? source repaired)
+            (begin
+              (when use-cache?
+                (fix-cache-touch path-str)
+              ) ;when
+              #f
+            ) ;begin
+            (begin
+              (path-write-text p repaired)
+              (when use-cache?
+                (fix-cache-touch path-str)
+              ) ;when
+              #t
+            ) ;begin
+          ) ;if
+        ) ;let*
+      ) ;if
+    ) ;define*
 
-    (define (fix-file path-str)
+    (define* (fix-file path-str (use-cache? #t))
       (let ((fmt-cmd (string-append (executable) " fmt " path-str)))
         (os-call fmt-cmd)
       ) ;let
-      (fix-file-core path-str)
-    ) ;define
+      (fix-file-core path-str use-cache?)
+    ) ;define*
 
     (define (fix-directory dir-path)
       (let ((fmt-cmd (string-append (executable) " fmt " dir-path)))
@@ -99,37 +149,36 @@
       ) ;let
       (let ((entries (path-list-path (path dir-path))))
         (let loop
-          ((i 0) (total 0) (updated 0))
+          ((i 0) (total 0) (updated 0) (cached 0))
           (if (>= i (vector-length entries))
-            (values total updated)
+            (values total updated cached)
             (let ((entry (vector-ref entries i)))
               (cond ((path-file? entry)
                      (let ((entry-str (path->string entry)))
                        (if (string-suffix? ".scm" entry-str)
-                         (begin
-                           (display (string-append "Fixing: " entry-str))
-                           (newline)
-                           (if (fix-file-core entry-str)
-                             (begin
-                               (display (string-append "  Updated: " entry-str))
-                               (newline)
-                               (loop (+ i 1) (+ total 1) (+ updated 1))
-                             ) ;begin
-                             (loop (+ i 1) (+ total 1) updated)
-                           ) ;if
-                         ) ;begin
-                         (loop (+ i 1) total updated)
+                         (let ((result (fix-file-core entry-str)))
+                           (cond ((eq? result 'cached)
+                                  (loop (+ i 1) (+ total 1) updated (+ cached 1)))
+                                 (result (display (string-append "  Updated: " entry-str))
+                                   (newline)
+                                   (loop (+ i 1) (+ total 1) (+ updated 1) cached))
+                                 (else (display (string-append "Fixing: " entry-str))
+                                   (newline)
+                                   (loop (+ i 1) (+ total 1) updated cached))
+                           ) ;cond
+                         ) ;let
+                         (loop (+ i 1) total updated cached)
                        ) ;if
                      ) ;let
                     ) ;
                     ((path-dir? entry)
                      (call-with-values (lambda () (fix-directory (path->string entry)))
-                       (lambda (sub-total sub-updated)
-                         (loop (+ i 1) (+ total sub-total) (+ updated sub-updated))
+                       (lambda (sub-total sub-updated sub-cached)
+                         (loop (+ i 1) (+ total sub-total) (+ updated sub-updated) (+ cached sub-cached))
                        ) ;lambda
                      ) ;call-with-values
                     ) ;
-                    (else (loop (+ i 1) total updated))
+                    (else (loop (+ i 1) total updated cached))
               ) ;cond
             ) ;let
           ) ;if
@@ -174,18 +223,15 @@
                 ((path-file? (path path-str))
                  (if dry-run
                    (fix-file-dry-run path-str)
-                   (let ((changed? (fix-file path-str)))
-                     (display (string-append "Fixing: " path-str))
-                     (newline)
-                     (if changed?
-                       (begin
-                         (display (string-append "  Updated: " path-str))
-                         (newline)
-                       ) ;begin
-                       '()
-                     ) ;if
+                   (let ((result (fix-file path-str)))
+                     (cond ((eq? result 'cached) #f)
+                           (result (display (string-append "  Updated: " path-str)) (newline))
+                           (else (display (string-append "Fixing: " path-str)) (newline))
+                     ) ;cond
                      (display (string-append "Total files fixed: 1, Files updated: "
-                                (if changed? "1" "0")
+                                (if (eq? result #t) "1" "0")
+                                ", Files cached: "
+                                (if (eq? result 'cached) "1" "0")
                               ) ;string-append
                      ) ;display
                      (newline)
@@ -201,11 +247,13 @@
                      (exit 1)
                    ) ;begin
                    (call-with-values (lambda () (fix-directory path-str))
-                     (lambda (total updated)
+                     (lambda (total updated cached)
                        (display (string-append "Total files fixed: "
                                   (number->string total)
                                   ", Files updated: "
                                   (number->string updated)
+                                  ", Files cached: "
+                                  (number->string cached)
                                 ) ;string-append
                        ) ;display
                        (newline)


### PR DESCRIPTION
## Summary
- 为 gf fix 添加与 gf fmt 一致的基于 SHA256 文件哈希的缓存机制
- 缓存目录：`~/.cache/goldfish/fix/<version>/`
- 修复括号后内容无变化时标记缓存，避免重复处理
- 单文件和目录模式均支持，汇总输出增加 `Files cached` 统计

## Test plan
- [x] `xmake b goldfish` 构建成功
- [x] 单文件首次运行 `bin/gf fix goldfish/liii/os.scm` — cached: 0
- [x] 单文件第二次运行 — cached: 1，缓存命中
- [x] 目录模式第二次运行 — 56 个文件全部缓存命中

🤖 Generated with [Claude Code](https://claude.com/claude-code)