### PR TITLE
[0037] Remove dead OS/filesystem functions from s7.c

### DIFF
--- a/devel/0037.md
+++ b/devel/0037.md
@@ -1,0 +1,126 @@
+# [0037] 清理 s7.c 中被条件编译屏蔽且已有替代的 OS/文件系统函数
+
+## 1. 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [s7_migration.md](../s7_migration.md) - s7.c 分组迁移策略
+
+## 2. 任务相关的代码文件
+- `src/s7.c` - 被条件编译包裹的 8 个 OS/文件系统函数
+- `src/goldfish.hpp` - Goldfish 已重新实现的替代函数
+- `xmake.lua` - 编译配置（`WITH_SYSTEM_EXTRAS=0`）
+- `goldfish/scheme/boot.scm` - Scheme 层对 `delete-file` / `file-exists?` 的封装
+- `goldfish/liii/os.scm` - `(liii os)` 模块
+- `goldfish/liii/path.scm` - `(liii path)` 模块
+
+## 3. 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b goldfish
+bin/gf tests/scheme/boot-test.scm
+bin/gf tests/liii/os-test.scm
+bin/gf tests/liii/path-test.scm
+bin/gf test --changed-since=main
+```
+
+### 3.2 关键验证点
+- 确认 `delete-file`、`system`、`access` 等功能在移除 s7.c 中的旧实现后仍正常工作
+- 确认 `(liii path)` 中的 `path-dir?`、`path-list`、`path-unlink` 等功能不受影响
+- 确认 `s7.c` 行数确实下降
+
+## 4. 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+bin/gf test --changed-since=main
+```
+
+## 5. 2026-05-27 清理 s7.c 中第 1 批无效的 OS/文件系统函数
+
+### 5.4 执行结果
+
+- **s7.c 行数变化**：93,402 行（移除前约 93,666 行）→ **减少约 264 行**
+- **编译状态**：✅ `xmake b goldfish` 通过（MSVC 2022, Windows x64）
+- **测试状态**：✅ `tests/scheme/boot-test.scm`、`tests/liii/os-test.scm`、`tests/liii/path-test.scm` 全部通过
+- **移除代码统计**：`git diff --stat` 显示 `src/s7.c | 268 +--------------, 4 insertions(+), 264 deletions(-)`
+
+**实际修改内容：**
+1. 移除 `#if WITH_SYSTEM_EXTRAS` 块（~185 行）：`#include <fcntl.h>`、`is_directory_b_7p`、`g_is_directory`、`file_probe`、`g_delete_file`、`g_system`、`directory_to_list_1`、`g_directory_to_list`、`g_file_mtime`
+2. 移除 `#if WITH_R7RS` 块中的 3 个函数（~35 行）：`g_time`、`g_unlink`、`g_access`
+3. 移除 struct `s7_scheme` 中的 8 个符号声明
+4. 移除 `r7rs_init` 中的函数注册和常量定义，保留空函数体（仅设置 `r7rs_inited = true`）
+5. 移除 `init_s7` 中的 `defun` 注册（5 个）和 `s7_set_b_7p_function` 注册（1 个）
+
+### 5.1 What
+
+从 `s7.c` 中移除 8 个 OS/文件系统相关的 C 函数。这些函数要么被 Goldfish 的编译配置显式屏蔽（`WITH_SYSTEM_EXTRAS=0`），要么在 `goldfish.hpp` / Scheme 层已有功能完全等价的替代实现，属于"死代码"。
+
+**移除清单（8 个函数全部移除，无迁移）：**
+
+| 函数名 | Scheme 名称 | 移除原因 |
+|--------|-------------|----------|
+| `g_is_directory` | `directory?` | 被 `WITH_SYSTEM_EXTRAS` 屏蔽；`goldfish.hpp` 中有 `g_isdir` + `(liii path)` 的 `path-dir?` 替代 |
+| `g_delete_file` | `delete-file` | 被 `WITH_SYSTEM_EXTRAS` 屏蔽；`goldfish.hpp` 中有 `g_delete-file` + `scheme/boot.scm` 封装替代 |
+| `g_system` | `system` | 被 `WITH_SYSTEM_EXTRAS` 屏蔽；`goldfish.hpp` 中有 `g_system` + `(liii os)` 的 `os-call` 替代 |
+| `g_directory_to_list` | `directory->list` | 被 `WITH_SYSTEM_EXTRAS` 屏蔽；`goldfish.hpp` 中有 `g_listdir` + `(liii path)` 的 `path-list` 替代 |
+| `g_file_mtime` | `file-mtime` | 被 `WITH_SYSTEM_EXTRAS` 屏蔽；Goldfish 中无任何地方使用 |
+| `g_time` | `time` | 虽被 `WITH_R7RS=1` 开启，但需要 `time_t*` 指针参数，Scheme 层无法直接使用；`(scheme time)` 使用 `g_get-time-of-day` 替代 |
+| `g_unlink` | `unlink` | 虽被 `WITH_R7RS=1` 开启，但 `(liii path)` 的 `path-unlink` 使用 `g_remove-file` 替代；Goldfish 中无任何地方直接使用 `unlink` |
+| `g_access` | `access` | 虽被 `WITH_R7RS=1` 开启，但 `goldfish.hpp` 中已重新实现 `g_access`；`scheme/boot.scm` 的 `file-exists?` 和 `(liii os)` 的 `access` 均使用 goldfish.hpp 版本 |
+
+### 5.2 Why
+
+**判断标准：**
+1. **需要开启编译选项才能使用的函数 → 直接移除**
+   - Goldfish 在 `xmake.lua` 中显式设置了 `WITH_SYSTEM_EXTRAS=0`
+   - 这意味着 `g_is_directory`、`g_delete_file`、`g_system`、`g_directory_to_list`、`g_file_mtime` 这 5 个函数虽然在 `s7.c` 源码中存在，但在 Goldfish 的实际编译产物中**永远不会被编译进去**
+   - 它们占据约 200 行代码，属于纯粹的"死代码"
+
+2. **`(liii os)` 和 `(liii path)` 中已经有实现了的函数 → 直接移除**
+   - `g_delete_file` → `goldfish.hpp: g_delete-file` / `scheme/boot.scm: delete-file`
+   - `g_system` → `goldfish.hpp: g_system` / `(liii os): os-call`
+   - `g_access` → `goldfish.hpp: g_access` / `(liii os): access`
+   - `g_is_directory` → `goldfish.hpp: g_isdir` / `(liii path): path-dir?`
+   - `g_directory_to_list` → `goldfish.hpp: g_listdir` / `(liii path): path-list`
+   - `g_unlink` → `goldfish.hpp: g_remove-file` / `(liii path): path-unlink`
+
+**为什么不迁移而是直接移除：**
+- 这 8 个函数在 Goldfish 生态中**均已有等价的替代实现**（C++ 层或 Scheme 层）
+- 迁移到新文件 `s7_os.c` 没有意义，因为没有任何调用方会用到 s7.c 中的这些旧实现
+- 直接移除可以同时削减 `s7.c` 的体积（约 200 行），并消除潜在的符号冲突风险（如 `g_access` 在 s7.c 和 goldfish.hpp 中均有定义）
+
+### 5.3 How
+
+**需要清理的位置：**
+
+1. **函数实现**（`src/s7.c` 约第 30707~30933 行）
+   - 移除 `#if WITH_SYSTEM_EXTRAS` 块内的全部 5 个函数（`g_is_directory`、`g_delete_file`、`g_system`、`g_directory_to_list`、`g_file_mtime`）
+   - 移除 `#if WITH_R7RS` 块内的全部 3 个函数（`g_time`、`g_unlink`、`g_access`）
+   - 注意：`g_directory_to_list` 和 `g_file_mtime` 还被 `#if !MS_WINDOWS` 包裹，需连同该条件编译一起移除
+
+2. **符号声明**（`src/s7.c` 中 struct s7_scheme 的定义附近）
+   - 移除 `WITH_SYSTEM_EXTRAS` 块内的 5 个 `s7_pointer` 符号声明
+   - 移除 `WITH_R7RS` 块内的 `unlink_symbol`、`access_symbol`、`time_symbol` 声明
+
+3. **函数注册**（`src/s7.c` 中 `init_s7` 或类似初始化函数附近）
+   - 移除 `WITH_SYSTEM_EXTRAS` 块内的 `defun` 注册（`directory?`、`delete-file`、`system`、`directory->list`、`file-mtime`）
+   - 移除 `WITH_R7RS` 块内的 `s7_define` 注册（`unlink`、`access`、`time`）
+
+4. **功能函数注册**（`src/s7.c` 中 `s7_set_b_7p_function` 等）
+   - 移除 `is_directory_b_7p` 的功能注册
+
+5. **feature 提供**（`src/s7.c` 中 `s7_provide` 调用）
+   - `system-extras` 的 provide 声明（`#if WITH_SYSTEM_EXTRAS` 块内）可以考虑保留，因为这是一个 feature 标记，其他代码可能检查它
+
+**无需修改的文件：**
+- `goldfish.hpp` - 替代实现已存在，无需改动
+- `goldfish/scheme/boot.scm` - 调用的是 goldfish.hpp 的版本，无需改动
+- `goldfish/liii/os.scm` / `goldfish/liii/path.scm` - 调用的是 goldfish.hpp 的版本，无需改动
+- `xmake.lua` - 编译选项保持不变
+
+**验证方法：**
+- 编译前 `wc -l src/s7.c` 记录行数
+- 执行清理后重新编译 `xmake b goldfish`
+- 运行测试套件确认无回归
+- 再次 `wc -l src/s7.c` 确认行数下降约 180~220 行

--- a/src/s7.c
+++ b/src/s7.c
@@ -1365,7 +1365,7 @@ struct s7_scheme {
              string_to_list_symbol, vector_length_symbol, vector_to_list_symbol;
 #endif
 #if WITH_R7RS
-  s7_pointer unlink_symbol, access_symbol, time_symbol, clock_gettime_symbol, uname_symbol;
+  s7_pointer clock_gettime_symbol, uname_symbol;
 #endif
   bool r7rs_inited;
   s7_pointer s7_symbol, r5rs_symbol, r7rs_symbol, global_is_eq, initial_is_eq, global_memq, initial_memq, global_assq, initial_assq;
@@ -1414,9 +1414,7 @@ struct s7_scheme {
              is_mutable_symbol, line_symbol, open_symbol, original_vector_symbol, pointer_symbol, port_type_symbol, position_symbol,
              sequence_symbol, size_symbol, source_symbol, weak_symbol;
 
-#if WITH_SYSTEM_EXTRAS
-  s7_pointer is_directory_symbol, delete_file_symbol, system_symbol, directory_to_list_symbol, file_mtime_symbol;
-#endif
+
   s7_pointer open_input_function_choices[S7_NUM_READ_CHOICES];
   s7_pointer closed_input_function, closed_output_function;
   s7_pointer vector_set_function, string_set_function, list_set_function, hash_table_set_function, let_set_function, c_object_set_function, last_function;
@@ -30704,233 +30702,6 @@ static s7_pointer format_chooser(s7_scheme *sc, s7_pointer func, int32_t args, s
 }
 
 
-#if WITH_SYSTEM_EXTRAS
-#include <fcntl.h>
-
-/* -------------------------------- directory? -------------------------------- */
-static bool is_directory_b_7p(s7_scheme *sc, s7_pointer p)
-{
-  if (!is_string(p))
-    sole_arg_wrong_type_error_nr(sc, sc->is_directory_symbol, p, sc->type_names[T_STRING]);
-  if (string_length(p) >= 2)
-    {
-      block_t *b = expand_filename(sc, string_value(p));
-      if (b)
-	{
-	  bool result = is_directory((char *)block_data(b));
-	  liberate(sc, b);
-	  return(result);
-	}}
-  return(is_directory(string_value(p)));
-}
-
-static s7_pointer g_is_directory(s7_scheme *sc, s7_pointer args)
-{
-  #define H_is_directory "(directory? str) returns #t if str is the name of a directory"
-  #define Q_is_directory s7_make_signature(sc, 2, sc->is_boolean_symbol, sc->is_string_symbol)
-  return(make_boolean(sc, is_directory_b_7p(sc, car(args))));
-}
-
-/* -------------------------------- file-exists? -------------------------------- */
-static bool file_probe(const char *arg)
-{
-#if !MS_WINDOWS
-  return(access(arg, F_OK) == 0);
-#else
-  int32_t fd = open(arg, O_RDONLY, 0);
-  if (fd == -1) return(false);
-  close(fd);
-  return(true);
-#endif
-}
-
-/* -------------------------------- delete-file -------------------------------- */
-static s7_pointer g_delete_file(s7_scheme *sc, s7_pointer args)
-{
-  #define H_delete_file "(delete-file filename) deletes the file filename."
-  #define Q_delete_file s7_make_signature(sc, 2, sc->is_integer_symbol, sc->is_string_symbol)
-
-  const s7_pointer name = car(args);
-  if (!is_string(name))
-    return(sole_arg_method_or_bust(sc, name, sc->delete_file_symbol, args, sc->type_names[T_STRING]));
-  if (string_length(name) > 2)
-    {
-      block_t *b = expand_filename(sc, string_value(name));
-      if (b)
-	{
-	  s7_int result = unlink((char *)block_data(b));
-	  liberate(sc, b);
-	  if ((result == -1) && (sc->scheme_version == sc->r7rs_symbol))
-	    file_error_nr(sc, "delete-file", strerror(errno), string_value(name));
-	  return(make_integer(sc, result));
-	}}
-  {
-    s7_int result = unlink(string_value(name));
-    if ((result == -1) && (sc->scheme_version == sc->r7rs_symbol))
-      file_error_nr(sc, "delete-file", strerror(errno), string_value(name));
-    return(make_integer(sc, result));
-  }
-}
-
-/* -------------------------------- system -------------------------------- */
-static s7_pointer g_system(s7_scheme *sc, s7_pointer args)
-{
-  #define H_system "(system command return-string) executes the command.  If the optional second argument is #t, \
-system captures the output as a string and returns it."
-  #define Q_system s7_make_signature(sc, 3, s7_make_signature(sc, 2, sc->is_integer_symbol, sc->is_string_symbol), sc->is_string_symbol, sc->is_boolean_symbol)
-
-#ifdef __EMSCRIPTEN__
-  return s7_nil(sc);
-#else
-  const s7_pointer name = car(args);
-  if (!is_string(name))
-    return(method_or_bust(sc, name, sc->system_symbol, args, sc->type_names[T_STRING], 2));
-  if (is_pair(cdr(args)))
-    {
-      const s7_pointer return_string = cadr(args);
-      if (return_string == sc->T)
-	{
-          #define BUF_SIZE 256
-	  char buf[BUF_SIZE];
-	  char *str = NULL;
-	  int32_t cur_len = 0, full_len = 0;
-	  FILE *fd = popen(string_value(name), "r");
-	  while (fgets(buf, BUF_SIZE, fd))
-	    {
-	      s7_int buf_len = safe_strlen(buf);
-	      if (cur_len + buf_len >= full_len)
-		{
-		  full_len += BUF_SIZE * 2;
-		  str = (str) ? (char *)Realloc(str, full_len) : (char *)Malloc(full_len);
-		}
-	      memcpy((void *)(str + cur_len), (void *)buf, buf_len);
-	      cur_len += buf_len;
-	    }
-	  pclose(fd);
-	  if (str)
-	    {
-	      block_t *b = mallocate_block(sc);
-	      block_data(b) = (void *)str;
-	      block_set_index(b, TOP_BLOCK_LIST);
-#if S7_DEBUGGING
-	      sc->blocks_mallocated[TOP_BLOCK_LIST]++;
-#endif
-	      return(block_to_string(sc, b, cur_len));
-	    }
-	  return(nil_string);
-	}
-      if (return_string != sc->F)
-	wrong_type_error_nr(sc, sc->system_symbol, 2, return_string, sc->type_names[T_BOOLEAN]);
-    }
-  return(make_integer(sc, system(string_value(name))));
-#endif
-}
-
-#if !MS_WINDOWS
-#include <dirent.h>
-
-/* -------------------------------- directory->list -------------------------------- */
-static s7_pointer directory_to_list_1(s7_scheme *sc, const char *dir_name)
-{
-  DIR *dpos;
-  begin_temp(sc->y, sc->nil);
-  if ((dpos = opendir(dir_name)))
-    {
-      struct dirent *dirp;
-      while ((dirp = readdir(dpos)))
-	sc->y = cons_unchecked(sc, s7_make_string(sc, dirp->d_name), sc->y);
-      closedir(dpos);
-    }
-  return_with_end_temp(sc->y);
-}
-
-static s7_pointer g_directory_to_list(s7_scheme *sc, s7_pointer args)
-{
-  #define H_directory_to_list "(directory->list directory) returns the contents of the directory as a list of strings (filenames)."
-  #define Q_directory_to_list s7_make_signature(sc, 2, sc->is_list_symbol, sc->is_string_symbol)   /* can return nil */
-
-  const s7_pointer name = car(args);
-  if (!is_string(name))
-    return(method_or_bust_p(sc, name, sc->directory_to_list_symbol, sc->type_names[T_STRING]));
-  if (string_length(name) >= 2)
-    {
-      block_t *b = expand_filename(sc, string_value(name));
-      if (b)
-	{
-	  s7_pointer result = directory_to_list_1(sc, (char *)block_data(b));
-	  liberate(sc, b);
-	  return(result);
-	}}
-  return(directory_to_list_1(sc, string_value(name)));
-}
-
-/* -------------------------------- file-mtime -------------------------------- */
-static s7_pointer g_file_mtime(s7_scheme *sc, s7_pointer args)
-{
-  #define H_file_mtime "(file-mtime file): return the write date of file"
-  #define Q_file_mtime s7_make_signature(sc, 2, sc->is_integer_symbol, sc->is_string_symbol)
-
-  struct stat statbuf;
-  int32_t err;
-  const s7_pointer name = car(args);
-
-  if (!is_string(name))
-    return(sole_arg_method_or_bust(sc, name, sc->file_mtime_symbol, args, sc->type_names[T_STRING]));
-  if (string_length(name) >= 2)
-    {
-      block_t *b = expand_filename(sc, string_value(name));
-      if (b)
-	{
-	  err = stat((char *)block_data(b), &statbuf);
-	  liberate(sc, b);
-	  if (err < 0)
-	    file_error_nr(sc, "file-mtime", strerror(errno), string_value(name));
-	  return(make_integer(sc, (s7_int)(statbuf.st_mtime)));
-	}}
-  err = stat(string_value(name), &statbuf);
-  if (err < 0)
-    file_error_nr(sc, "file-mtime", strerror(errno), string_value(name));
-  return(make_integer(sc, (s7_int)(statbuf.st_mtime)));
-}
-#endif /* !ms_windows */
-#endif /* with_system_extras */
-
-
-
-#if WITH_R7RS
-
-/* -------------------------------- time -------------------------------- */
-static s7_pointer g_time(s7_scheme *sc, s7_pointer args)
-{
-#if (!MS_WINDOWS)
-  s7_pointer arg = car(args);
-  time_t* time_val = (time_t*)s7_c_pointer_with_type(sc, arg, make_symbol(sc, "time_t*", 7), "time", 0); /* 0 = argnum */
-  return(make_integer(sc, (s7_int)time(time_val)));
-#else
-  return(minus_one);
-#endif
-}
-
-/* -------------------------------- unlink -------------------------------- */
-static s7_pointer g_unlink(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer arg = car(args);
-  if (!s7_is_string(arg))
-    sole_arg_wrong_type_error_nr(sc, sc->unlink_symbol, arg, sc->type_names[T_STRING]);
-  return(make_integer(sc, (s7_int)unlink((char*)string_value(arg))));
-}
-
-/* -------------------------------- access -------------------------------- */
-static s7_pointer g_access(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer path = car(args), mode = cadr(args);
-  if (!s7_is_string(path))
-    wrong_type_error_nr(sc, sc->access_symbol, 1, path, sc->type_names[T_STRING]);
-  if (!s7_is_integer(mode))
-    wrong_type_error_nr(sc, sc->access_symbol, 2, mode, sc->type_names[T_INTEGER]);
-  return(make_integer(sc, (s7_int)access((char *)string_value(path), (int)integer(mode))));
-}
-#endif
 
 
 /* -------------------------------- lists -------------------------------- */
@@ -90105,27 +89876,6 @@ static s7_pointer sl_set_history_enabled(s7_scheme *sc, s7_pointer sym, s7_point
 #if WITH_R7RS
 void r7rs_init(s7_scheme *sc)
 {
-  s7_pointer cur_env = sc->curlet; /* or rootlet? */
-
-  sc->access_symbol = make_symbol(sc, "access", 6);
-  sc->unlink_symbol = make_symbol(sc, "unlink", 6);
-  sc->time_symbol = make_symbol(sc, "time", 4);
-
-#ifdef CLOCK_REALTIME
-  s7_define(sc, cur_env, make_symbol(sc, "CLOCK_REALTIME", 14), make_integer(sc, (s7_int)CLOCK_REALTIME));
-#endif
-#ifdef F_OK
-  s7_define(sc, cur_env, make_symbol(sc, "F_OK", 4), make_integer(sc, (s7_int)F_OK));
-#endif
-  s7_define(sc, cur_env, sc->unlink_symbol,
-            s7_make_typed_function_with_environment(sc, "unlink", g_unlink, 1, 0, false, "int unlink(char*)",
-						    s7_make_signature(sc, 2, sc->is_integer_symbol, sc->is_string_symbol), cur_env));
-  s7_define(sc, cur_env, sc->access_symbol,
-            s7_make_typed_function_with_environment(sc, "access", g_access, 2, 0, false, "int access(char* int)",
-						    s7_make_signature(sc, 3, sc->is_integer_symbol, sc->is_string_symbol, sc->is_integer_symbol), cur_env));
-  s7_define(sc, cur_env, sc->time_symbol,
-            s7_make_typed_function_with_environment(sc, "time", g_time, 1, 0, false, "int time(time_t*)",
-						    s7_make_signature(sc, 2, sc->is_integer_symbol, make_symbol(sc, "time_t*", 7)), cur_env));
   sc->r7rs_inited = true;
 }
 
@@ -91040,9 +90790,7 @@ static void init_opt_functions(s7_scheme *sc)
   s7_set_p_p_function(sc, global_value(sc->outlet_symbol), outlet_p_p);
   s7_set_p_p_function(sc, global_value(sc->make_iterator_symbol), s7_make_iterator);
 
-#if WITH_SYSTEM_EXTRAS
-  s7_set_b_7p_function(sc, global_value(sc->is_directory_symbol), is_directory_b_7p);
-#endif
+
 
   s7_set_b_i_function(sc, global_value(sc->is_even_symbol), even_i);
   s7_set_b_i_function(sc, global_value(sc->is_odd_symbol), odd_i);
@@ -91936,15 +91684,7 @@ static void init_rootlet(s7_scheme *sc)
   sc->with_output_to_string_symbol =   semisafe_defun("with-output-to-string",   with_output_to_string,   1, 0, false);
   sc->with_output_to_file_symbol =     semisafe_defun("with-output-to-file",     with_output_to_file,     2, 0, false);
 
-#if WITH_SYSTEM_EXTRAS
-  sc->is_directory_symbol =          defun("directory?",	is_directory,		1, 0, false);
-  sc->delete_file_symbol =           defun("delete-file",	delete_file,		1, 0, false);
-  sc->system_symbol =                defun("system",		system,			1, 1, false);
-#if !MS_WINDOWS
-  sc->directory_to_list_symbol =     defun("directory->list",   directory_to_list,	1, 0, false);
-  sc->file_mtime_symbol =            defun("file-mtime",	file_mtime,		1, 0, false);
-#endif
-#endif
+
   sc->real_part_symbol =             s7_define_typed_function(sc, "real-part", g_real_part, 1, 0, false, "(real-part num) returns the real part of num", s7_make_signature(sc, 2, sc->is_real_symbol, sc->is_number_symbol));
   sc->imag_part_symbol =             s7_define_typed_function(sc, "imag-part", g_imag_part, 1, 0, false, "(imag-part num) returns the imaginary part of num", s7_make_signature(sc, 2, sc->is_real_symbol, sc->is_number_symbol));
   sc->numerator_symbol =             defun("numerator",	        numerator,		1, 0, false);


### PR DESCRIPTION
## Summary

Remove 8 C functions from  that are either blocked by  (Goldfish's build config) or have fully equivalent replacements in  / Scheme layer.

## Removed Functions

| Function | Blocked By | Replacement |
|----------|-----------|-------------|
|  /  |  |  /  |
|  |  |  /  |
|  |  |  /  |
|  /  |  |  /  |
|  |  | Unused in Goldfish |
|  |  (compiled but unusable) |  |
|  |  |  /  |
|  |  |  /  |

## Impact

- : **-264 lines** (93,666 → 93,402)
- No functional changes — all capabilities are provided by Goldfish's own implementations.
- Compiles cleanly on MSVC 2022 (Windows x64).
- Passes , , .

## Related

- Task doc: 