### PR TITLE
[0041] Migrate module system setters to s7_module.c and plan define-library C implementation

### DIFF
--- a/devel/0041.md
+++ b/devel/0041.md
@@ -1,0 +1,158 @@
+# [0041] s7.c 模块系统函数迁移（第二批）及 define-library C 层实现规划
+
+## 1. 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [s7_migration.md](../s7_migration.md) - s7.c 分组迁移策略
+
+## 2. 任务相关的代码文件
+- `src/s7.c` - 模块系统相关函数
+- `src/s7_module.c` - 新增：成功迁移的 setter 函数
+- `src/s7_module.h` - 新增：模块系统对外接口声明
+- `src/s7_internal_helpers.h` - 扩展内部 API 暴露
+- `xmake.lua` - 编译配置
+
+## 3. 如何测试
+
+```bash
+xmake b goldfish
+bin/gf tests/scheme/boot-test.scm
+bin/gf tests/liii/os-test.scm
+bin/gf tests/liii/path-test.scm
+bin/gf test --changed-since=main
+```
+
+## 4. 如何提交
+
+提交前执行：
+
+```bash
+bin/gf test --changed-since=main
+```
+
+## 5. 执行结果
+
+### 5.1 实际迁移范围
+
+由于 `s7_scheme` 为不透明类型，大量内部字段（`sc->autoload_table`、`sc->autoload_names`、`sc->cload_directory_symbol` 等）无法从子模块直接访问，本次实际迁移了 **3 个无内部字段依赖的 setter 函数**：
+
+| 函数名 | Scheme 名称 | 状态 |
+|--------|-------------|------|
+| `g_load_path_set` | `*load-path*` setter | ✅ 已迁移到 `s7_module.c` |
+| `g_features_set` | `*features*` setter | ✅ 已迁移到 `s7_module.c` |
+| `g_libraries_set` | `*libraries*` setter | ✅ 已迁移到 `s7_module.c` |
+
+**留在 `s7.c` 的函数**：
+- `g_load`：使用 `push_stack_op_let` 和内部 opcode
+- `g_require`：使用 `gc_protect_via_stack`、`stack_top_op`、`OP_GC_PROTECT`
+- `g_is_provided`、`g_provide`：依赖 let/slot 内部结构
+- `g_autoload`、`g_autoloader`：依赖 `sc->autoload_table`、`sc->autoload_names`
+- `g_cload_directory_set`：依赖 `sc->cload_directory_symbol`
+
+### 5.2 代码变更统计
+
+- `src/s7.c`：93142 行 → 93096 行（**-46 行**）
+- 新增 `src/s7_module.c`：68 行
+- 新增 `src/s7_module.h`：19 行
+- 扩展 `src/s7_internal_helpers.h`：暴露 `s7i_is_closure`、`s7i_is_closure_star`、`s7i_missing_key_value`、`s7i_find_autoload_name`
+
+### 5.3 关键发现
+
+通过本次迁移代码的深入分析，发现 s7 模块系统的核心数据结构：
+
+1. **`*features***`：符号列表，由 `provide`/`require`/`is_a_feature` 维护
+2. **`*libraries***`：`(string . let)` 列表，存储已加载库的文件名和环境
+3. **`autoload_table`**：hash-table，存储 `(symbol . file-or-function)` 映射
+4. **`autoload_names`**：预注册的自动加载名称数组，供 `find_autoload_name` 二分查找
+5. **`load` 机制**：`load_file_1` 读取文件为端口 → `s7_load_with_environment` 在指定 let 中求值
+
+---
+
+## 6. define-library C 层实现规划
+
+> 基于对 s7 内置模块系统代码的理解，规划后续使用 C 实现 `define-library`（R7RS 库系统）的方法。
+
+### 6.1 现状分析
+
+Goldfish 当前实际使用的模块系统是 `define-library`（Scheme 层实现），但 s7 内核只提供了最基础的机制：
+- `provide`/`require`：基于 `*features*` 的特性检查
+- `autoload`：基于符号的延迟加载
+- `load`：文件加载和求值
+- `*libraries*`：已加载库的 (文件名 . 环境) 列表
+
+这些机制**不足以原生支持 R7RS `define-library`** 的完整语义：
+- `export` 的名称控制（重命名、内部名称隐藏）
+- `import` 的 selective import、prefix、rename、only、except
+- 库的版本管理
+- 库的编译期隔离（宏展开环境）
+
+### 6.2 为什么需要 C 层实现
+
+1. **性能**：Scheme 层实现的 `define-library` 在每次导入时都需要运行时解析库声明、构建环境、处理 rename，开销大
+2. **正确性**：C 层可以更精确地控制环境隔离和宏展开时序
+3. **一致性**：让 `define-library` 的行为与 s7 的 `load`/`autoload` 机制深度融合
+
+### 6.3 实现思路
+
+#### 阶段 1：扩展 `s7_module.c` 为库管理子系统
+
+将 `s7_module.c` 从单纯的 setter 函数集合，升级为**库管理子系统**：
+
+```
+s7_module.c/h 职责：
+- 维护 *libraries* 和库索引
+- 提供库查找、加载、缓存的 C API
+- 提供 import 处理的 C API（only/except/prefix/rename）
+```
+
+#### 阶段 2：新增 `s7_library` 结构体
+
+在 `s7.c` 中（或 `s7_internals.h` 中）定义库的内部表示：
+
+```c
+typedef struct s7_library {
+  s7_pointer name;           /* 库名符号或列表，如 (scheme base) */
+  s7_pointer version;        /* 版本列表 */
+  s7_pointer exports;        /* 导出的 (name . internal-name) 列表 */
+  s7_pointer environment;    /* 库的 let */
+  s7_pointer imports;        /* import-set 列表 */
+  s7_pointer code;           /* begin 体 */
+  bool loaded;               /* 是否已加载 */
+} s7_library;
+```
+
+#### 阶段 3：实现核心 C 函数
+
+| C 函数 | Scheme 接口 | 说明 |
+|--------|-------------|------|
+| `g_define_library` | `define-library` | 解析库声明，注册到库表 |
+| `g_import` | `import` | 处理 import-set，将绑定导入当前环境 |
+| `s7_find_library` | 无 | 按名称和版本查找已注册的库 |
+| `s7_load_library` | 无 | 加载库文件，解析声明，构建环境 |
+| `s7_library_exports` | 无 | 返回库的实际导出绑定列表 |
+
+#### 阶段 4：与现有机制整合
+
+1. **库查找路径**：复用 `*load-path*`，增加库特定的搜索路径（如 `S7_LIBRARY_PATH`）
+2. **自动加载**：扩展 `autoload_names` 或 `autoload_table` 支持库名到文件的映射
+3. **缓存**：已加载的库存入 `*libraries*` 和一个全局的 `library_table` hash-table
+4. **与 cond-expand 整合**：`cond-expand` 检查 `*features*` 时，同时检查已注册库的名称
+
+#### 阶段 5：与 s7.c 内核的交互点
+
+需要 s7.c 暴露的内部 API（参考本次迁移的经验）：
+
+| 需求 | 所需内部 API | 当前状态 |
+|------|-------------|----------|
+| 创建隔离环境 | `make_let`、`let_set_outlet` | 内部宏，需暴露 |
+| 添加绑定到环境 | `add_slot_checked_with_id` | 内部函数，需暴露 |
+| 符号查找 | `symbol_to_local_slot`、`let_slots` | 内部宏，需暴露 |
+| 宏展开环境控制 | `set_curlet`、`eval` | 已有公共 API |
+| 读取库声明 | `s7_read`、`s7_open_input_file` | 已有公共 API |
+
+**结论**：实现完整的 C 层 `define-library` 需要先建立 `s7_internals.h`，暴露 let/slot 相关的内部 API。这是本次迁移过程中发现的最大瓶颈。
+
+### 6.4 建议路线图
+
+1. **短期**（当前 PR）：迁移 3 个无依赖的 setter 函数，建立 `s7_module.c` 框架
+2. **中期**：建立 `s7_internals.h`，暴露 let/slot/环境操作的核心宏和函数
+3. **长期**：在 `s7_module.c` 中实现 `g_define_library` 和 `g_import` 的 C 层版本，逐步替换 Scheme 层实现

--- a/src/s7.c
+++ b/src/s7.c
@@ -407,6 +407,7 @@
 #include "s7_liii_string.h"
 #include "s7_liii_hash_table.h"
 #include "s7_liii_vector.h"
+#include "s7_module.h"
 
 /* there is also apparently __STDC_NO_COMPLEX__ */
 #if WITH_CLANG_PP
@@ -24558,39 +24559,6 @@ s7_pointer s7_add_to_load_path(s7_scheme *sc, const char *dir)
   return(path);
 }
 
-static s7_pointer g_load_path_set(s7_scheme *sc, s7_pointer args)
-{
-  /* new value must be either () or a (proper?) list of strings */
-  s7_pointer strs;
-  if (is_null(cadr(args))) return(cadr(args));
-  if (!is_pair(cadr(args)))
-    error_nr(sc, sc->wrong_type_arg_symbol, set_elist_2(sc, wrap_string(sc, "can't set *load-path* to ~S", 27), cadr(args)));
-  for (strs = cadr(args); is_pair(strs); strs = cdr(strs))
-    if (!is_string(car(strs)))
-      error_nr(sc, sc->wrong_type_arg_symbol, set_elist_3(sc, wrap_string(sc, "can't set *load-path* to ~S, ~S is not a string", 47), cadr(args), car(strs)));
-  if ((S7_DEBUGGING) && (!is_null(strs))) fprintf(stderr, "%s[%d]: strs: %s\n", __func__, __LINE__, display(args));
-#if 0
-  if (!is_null(strs))
-    error_nr(sc, sc->wrong_type_arg_symbol, set_elist_2(sc, wrap_string(sc, "can't set *load-path* to ~S, it is not a proper list", 52), cadr(args)));
-#endif
-  return(cadr(args));
-}
-
-/* -------- *cload-directory* -------- */
-static s7_pointer g_cload_directory_set(s7_scheme *sc, s7_pointer args)
-{
-  /* this sets the directory for cload.scm's output */
-  const s7_pointer cl_dir = cadr(args);
-  if (!is_string(cl_dir))
-    error_nr(sc, sc->wrong_type_arg_symbol, set_elist_2(sc, wrap_string(sc, "can't set *cload-directory* to ~S", 33), cadr(args)));
-  s7_symbol_set_value(sc, sc->cload_directory_symbol, cl_dir);
-  if (string_length(cl_dir) > 0) /* was strlen(string_value)? */
-    s7_add_to_load_path(sc, (const char *)(string_value(cl_dir)));
-  /* should this remove the previous *cload-directory* name first? or not affect *load-path* at all? */
-  return(cl_dir);
-}
-
-
 /* ---------------- autoload ---------------- */
 #define INITIAL_AUTOLOAD_NAMES_SIZE 4
 
@@ -24636,7 +24604,7 @@ void s7_autoload_set_names(s7_scheme *sc, const char **names, s7_int size)
   sc->autoload_names_loc++;
 }
 
-static const char *find_autoload_name(s7_scheme *sc, s7_pointer symbol, bool *already_loaded, bool loading)
+const char *find_autoload_name(s7_scheme *sc, s7_pointer symbol, bool *already_loaded, bool loading)
 {
   s7_int libs = sc->autoload_names_loc;
   const char *name = symbol_name(symbol);
@@ -24680,14 +24648,30 @@ s7_pointer s7_autoload(s7_scheme *sc, s7_pointer symbol, s7_pointer file_or_func
   return(file_or_function);
 }
 
+bool s7i_is_closure(s7_pointer p) { return is_closure(p); }
+bool s7i_is_closure_star(s7_pointer p) { return is_closure_star(p); }
+s7_pointer s7i_missing_key_value(s7_scheme *sc) { return missing_key_value(sc); }
+const char *s7i_find_autoload_name(s7_scheme *sc, s7_pointer symbol, bool *already_loaded, bool loading)
+{
+  return find_autoload_name(sc, symbol, already_loaded, loading);
+}
+
+/* -------- *cload-directory* -------- */
+static s7_pointer g_cload_directory_set(s7_scheme *sc, s7_pointer args)
+{
+  /* this sets the directory for cload.scm's output */
+  const s7_pointer cl_dir = cadr(args);
+  if (!is_string(cl_dir))
+    error_nr(sc, sc->wrong_type_arg_symbol, set_elist_2(sc, wrap_string(sc, "can't set *cload-directory* to ~S", 33), cadr(args)));
+  s7_symbol_set_value(sc, sc->cload_directory_symbol, cl_dir);
+  if (string_length(cl_dir) > 0) /* was strlen(string_value)? */
+    s7_add_to_load_path(sc, (const char *)(string_value(cl_dir)));
+  /* should this remove the previous *cload-directory* name first? or not affect *load-path* at all? */
+  return(cl_dir);
+}
+
 static s7_pointer g_autoload(s7_scheme *sc, s7_pointer args)
 {
-  #define H_autoload "(autoload symbol file-or-function) adds the symbol to its table of autoloadable symbols. \
-If that symbol is encountered as an unbound variable, s7 either loads the file (following *load-path*), or calls \
-the function.  The function takes one argument, the calling environment.  Presumably the symbol is defined \
-in the file, or by the function."
-  #define Q_autoload s7_make_signature(sc, 3, sc->T, sc->is_symbol_symbol, sc->T)
-
   s7_pointer sym = car(args), value;
   if (is_string(sym))
     {
@@ -24717,13 +24701,9 @@ in the file, or by the function."
 #endif
 }
 
-
 /* -------------------------------- *autoload* -------------------------------- */
 static s7_pointer g_autoloader(s7_scheme *sc, s7_pointer args) /* the *autoload* function */
 {
-  #define H_autoloader "(*autoload* sym) returns the autoload info for the symbol sym, or #f."
-  #define Q_autoloader s7_make_signature(sc, 2, sc->T, sc->is_symbol_symbol)
-
   const s7_pointer sym = car(args);
   if (!is_symbol(sym))
     {
@@ -24744,7 +24724,6 @@ static s7_pointer g_autoloader(s7_scheme *sc, s7_pointer args) /* the *autoload*
     }
   return(sc->F);
 }
-
 
 /* ---------------- require ---------------- */
 static bool is_a_feature(const s7_pointer sym, s7_pointer lst) /* used only with *features* which (sigh) can be circular: (set-cdr! *features* *features*) */
@@ -24900,38 +24879,6 @@ static s7_pointer g_provide(s7_scheme *sc, s7_pointer args)
 }
 
 void s7_provide(s7_scheme *sc, const char *feature) {c_provide(sc, make_symbol_with_strlen(sc, feature));}
-
-
-static s7_pointer g_features_set(s7_scheme *sc, s7_pointer args) /* *features* setter */
-{
-  const s7_pointer new_features = cadr(args);
-  if (is_null(new_features)) return(sc->nil);
-  if (!is_pair(new_features))
-    error_nr(sc, sc->wrong_type_arg_symbol,
-	     set_elist_2(sc, wrap_string(sc, "can't set *features* to ~S (*features* must be a pair)", 54), new_features));
-  if (s7_list_length(sc, new_features) <= 0)
-    error_nr(sc, sc->wrong_type_arg_symbol,
-	     set_elist_2(sc, wrap_string(sc, "can't set *features* to an improper or circular list ~S", 55), new_features));
-  for (s7_pointer features = new_features; is_pair(features); features = cdr(features))
-    if (!is_symbol(car(features)))
-      error_nr(sc, sc->wrong_type_arg_symbol,
-	       set_elist_2(sc, wrap_string(sc, "can't set *features* to ~S (each feature should be a symbol)", 60), new_features));
-  return(new_features);
-}
-
-static s7_pointer g_libraries_set(s7_scheme *sc, s7_pointer args) /* *libraries* setter */
-{
-  const s7_pointer new_libraries = cadr(args);
-  if (is_null(new_libraries)) return(sc->nil);
-  if ((!is_pair(new_libraries)) || (s7_list_length(sc, new_libraries) <= 0))
-    error_nr(sc, sc->wrong_type_arg_symbol, set_elist_2(sc, wrap_string(sc, "can't set *libraries* to ~S", 27), new_libraries));
-  for (s7_pointer libraries = new_libraries; is_pair(libraries); libraries = cdr(libraries))
-    if ((!is_pair(car(libraries))) ||
-	(!is_string(caar(libraries))) ||
-	(!is_let(cdar(libraries))))
-      sole_arg_wrong_type_error_nr(sc, sc->libraries_symbol, car(libraries), wrap_string(sc, "a list of conses of the form (string . let)", 43));
-  return(new_libraries);
-}
 
 
 /* -------------------------------- eval-string -------------------------------- */
@@ -91963,6 +91910,11 @@ static void init_rootlet(s7_scheme *sc)
   sc->call_with_exit_symbol =        semisafe_defun("call-with-exit", call_with_exit,   1, 0, false); /* semisafe: see t101-6.scm, apply on stack */
 
   sc->load_symbol =                  semisafe_defun("load",	load,			1, 1, false);
+  #define H_autoload "(autoload symbol file-or-function) adds the symbol to its table of autoloadable symbols. \
+If that symbol is encountered as an unbound variable, s7 either loads the file (following *load-path*), or calls \
+the function.  The function takes one argument, the calling environment.  Presumably the symbol is defined \
+in the file, or by the function."
+  #define Q_autoload s7_make_signature(sc, 3, sc->T, sc->is_symbol_symbol, sc->T)
   sc->autoload_symbol =              defun("autoload",	        autoload,		2, 0, false);
   sc->eval_symbol =                  semisafe_defun("eval",	eval,			1, 1, false); set_func_is_definer(sc->eval_symbol);
   sc->eval_string_symbol =           semisafe_defun("eval-string", eval_string,		1, 1, false); set_func_is_definer(sc->eval_string_symbol);
@@ -92116,6 +92068,8 @@ static void init_rootlet(s7_scheme *sc)
 		s7_make_safe_function(sc, "#<set-*cload-directory*>", g_cload_directory_set, 2, 0, false, "*cload-directory* setter"));
 
   /* -------- *autoload* -------- this pretends to be a hash-table or environment, but it's actually a function */
+  #define H_autoloader "(*autoload* sym) returns the autoload info for the symbol sym, or #f."
+  #define Q_autoloader s7_make_signature(sc, 2, sc->T, sc->is_symbol_symbol)
   sc->autoloader_symbol = s7_define_typed_function(sc, "*autoload*", g_autoloader, 1, 0, false, H_autoloader, Q_autoloader);
   c_function_set_setter(global_value(sc->autoloader_symbol), global_value(sc->autoload_symbol)); /* (set! (*autoload* x) y) */
 

--- a/src/s7_internal_helpers.h
+++ b/src/s7_internal_helpers.h
@@ -59,6 +59,12 @@ s7_pointer s7i_make_vector_1(s7_scheme *sc, s7_pointer args, s7_pointer caller);
 s7_pointer s7i_vector_fill_1(s7_scheme *sc, s7_pointer caller, s7_pointer args);
 s7_pointer s7i_vector_append(s7_scheme *sc, s7_pointer args, uint8_t typ, s7_pointer caller);
 
+/* module system helpers */
+bool s7i_is_closure(s7_pointer p);
+bool s7i_is_closure_star(s7_pointer p);
+s7_pointer s7i_missing_key_value(s7_scheme *sc);
+const char *s7i_find_autoload_name(s7_scheme *sc, s7_pointer symbol, bool *already_loaded, bool loading);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/s7_module.c
+++ b/src/s7_module.c
@@ -1,0 +1,68 @@
+/* s7_module.c - module system implementations for s7 Scheme interpreter
+ *
+ * derived from s7, a Scheme interpreter
+ * SPDX-License-Identifier: 0BSD
+ *
+ * Bill Schottstaedt, bil@ccrma.stanford.edu
+ */
+
+#include "s7_module.h"
+#include "s7_internal_helpers.h"
+
+/* -------- *load-path* setter -------- */
+s7_pointer g_load_path_set(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer strs;
+  if (s7_is_null(sc, s7_cadr(args))) return s7_cadr(args);
+  if (!s7_is_pair(s7_cadr(args)))
+    return s7_error(sc, s7_make_symbol(sc, "wrong-type-arg"),
+                    s7_list(sc, 2, s7_make_string(sc, "can't set *load-path* to ~S"), s7_cadr(args)));
+  for (strs = s7_cadr(args); s7_is_pair(strs); strs = s7_cdr(strs))
+    if (!s7_is_string(s7_car(strs)))
+      return s7_error(sc, s7_make_symbol(sc, "wrong-type-arg"),
+                      s7_list(sc, 3,
+                              s7_make_string(sc, "can't set *load-path* to ~S, ~S is not a string"),
+                              s7_cadr(args), s7_car(strs)));
+  return s7_cadr(args);
+}
+
+/* -------- *features* setter -------- */
+s7_pointer g_features_set(s7_scheme *sc, s7_pointer args)
+{
+  const s7_pointer new_features = s7_cadr(args);
+  if (s7_is_null(sc, new_features)) return s7_nil(sc);
+  if (!s7_is_pair(new_features))
+    return s7_error(sc, s7_make_symbol(sc, "wrong-type-arg"),
+                    s7_list(sc, 2,
+                            s7_make_string(sc, "can't set *features* to ~S (*features* must be a pair)"),
+                            new_features));
+  if (s7_list_length(sc, new_features) <= 0)
+    return s7_error(sc, s7_make_symbol(sc, "wrong-type-arg"),
+                    s7_list(sc, 2,
+                            s7_make_string(sc, "can't set *features* to an improper or circular list ~S"),
+                            new_features));
+  for (s7_pointer features = new_features; s7_is_pair(features); features = s7_cdr(features))
+    if (!s7_is_symbol(s7_car(features)))
+      return s7_error(sc, s7_make_symbol(sc, "wrong-type-arg"),
+                      s7_list(sc, 2,
+                              s7_make_string(sc, "can't set *features* to ~S (each feature should be a symbol)"),
+                              new_features));
+  return new_features;
+}
+
+/* -------- *libraries* setter -------- */
+s7_pointer g_libraries_set(s7_scheme *sc, s7_pointer args)
+{
+  const s7_pointer new_libraries = s7_cadr(args);
+  if (s7_is_null(sc, new_libraries)) return s7_nil(sc);
+  if ((!s7_is_pair(new_libraries)) || (s7_list_length(sc, new_libraries) <= 0))
+    return s7_error(sc, s7_make_symbol(sc, "wrong-type-arg"),
+                    s7_list(sc, 2, s7_make_string(sc, "can't set *libraries* to ~S"), new_libraries));
+  for (s7_pointer libraries = new_libraries; s7_is_pair(libraries); libraries = s7_cdr(libraries))
+    if ((!s7_is_pair(s7_car(libraries))) ||
+        (!s7_is_string(s7_car(s7_car(libraries)))) ||
+        (!s7_is_let(s7_cdr(s7_car(libraries)))))
+      return s7_wrong_type_arg_error(sc, "set! *libraries*", 1, s7_car(libraries),
+                                     "a list of conses of the form (string . let)");
+  return new_libraries;
+}

--- a/src/s7_module.h
+++ b/src/s7_module.h
@@ -1,0 +1,26 @@
+/* s7_module.h - module system declarations for s7 Scheme interpreter
+ *
+ * derived from s7, a Scheme interpreter
+ * SPDX-License-Identifier: 0BSD
+ *
+ * Bill Schottstaedt, bil@ccrma.stanford.edu
+ */
+
+#ifndef S7_MODULE_H
+#define S7_MODULE_H
+
+#include "s7.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+s7_pointer g_load_path_set(s7_scheme *sc, s7_pointer args);
+s7_pointer g_features_set(s7_scheme *sc, s7_pointer args);
+s7_pointer g_libraries_set(s7_scheme *sc, s7_pointer args);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* S7_MODULE_H */

--- a/xmake.lua
+++ b/xmake.lua
@@ -111,6 +111,7 @@ target ("goldfish") do
     add_files ("src/s7_liii_string.c", {languages = "c11"})
     add_files ("src/s7_liii_hash_table.c", {languages = "c11"})
     add_files ("src/s7_liii_vector.c", {languages = "c11"})
+    add_files ("src/s7_module.c", {languages = "c11"})
     add_files ("src/s7_scheme_inexact.c", {languages = "c11"})
     add_files ("src/s7_scheme_base.c", {languages = "c11"})
     add_packages("tbox")


### PR DESCRIPTION
## What

Migrate 3 setter functions with no internal field dependencies from s7.c to s7_module.c:
- g_load_path_set (*load-path* setter)
- g_features_set (*features* setter)  
- g_libraries_set (*libraries* setter)

## Changes
- Add src/s7_module.c/h for module system operations
- Expose s7i_is_closure, s7i_is_closure_star, s7i_missing_key_value, s7i_find_autoload_name in s7_internal_helpers.h
- Keep H_/Q_ macros in s7.c for registration compatibility
- Update xmake.lua to include s7_module.c
- Add devel/0041.md with execution results and define-library C layer plan

## Stats
- s7.c: -46 lines (93142 -> 93096)

## Testing
- xmake b goldfish compiles successfully (MSVC 2022, Windows x64)
- bin/gf tests/scheme/boot-test.scm passes
- bin/gf tests/liii/os-test.scm passes
- bin/gf tests/liii/path-test.scm passes

## Related
- s7_migration.md - batch 2 module system migration strategy
- This PR also includes planning for future C-layer define-library implementation based on code understanding from the migration