### PR TITLE
[0045] Migrate hash-table/list/string builtins to s7_liii_*.c

### DIFF
--- a/devel/0045.md
+++ b/devel/0045.md
@@ -1,0 +1,138 @@
+# [0045] 迁移 s7.c 中 hash-table、list、string 相关内置函数到 s7_liii_*.c
+
+## 1. 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2. 任务相关的代码文件
+- `src/s7.c` - s7 解释器主文件，包含所有内置函数原始定义
+- `src/s7_liii_hash_table.c/h` - hash-table 函数迁移目标文件
+- `src/s7_liii_list.c/h` - list 函数迁移目标文件（新建）
+- `src/s7_liii_string.c/h` - string 函数迁移目标文件（扩展）
+- `src/s7_internal_helpers.h` - 暴露必要的内部 API 辅助函数
+- `xmake.lua` - 编译配置
+
+## 3. 如何测试
+
+```bash
+xmake b goldfish
+bin/gf test --changed-since=main
+```
+
+## 4. 迁移策略
+
+### 4.1 核心原则
+
+将 `s7.c` 中的 `static s7_pointer g_xxx` 函数定义迁移到对应的 `s7_liii_*.c` 文件中，遵循以下模式：
+
+1. **公开 API 优先**：使用 `s7.h` 中已有的公开 API（如 `s7_is_hash_table`、`s7_hash_table_ref` 等）重写函数
+2. **辅助函数桥接**：对于必须使用内部结构的场景，在 `s7_internal_helpers.h` 中暴露 `s7i_xxx` 辅助函数，在 `s7.c` 中实现
+3. **保留注册信息**：`s7.c` 中的 `defun`/`bool_defun`/`s7_define_typed_function` 注册调用保持不变，仅删除 `static` 函数定义
+4. **保留 H/Q 宏**：对于使用 `defun` 注册的函数，将其 `H_xxx` 和 `Q_xxx` 宏保留在 `s7.c` 中（移到文件作用域）
+
+### 4.2 已暴露的内部辅助函数
+
+| 辅助函数 | 用途 | 对应内部结构 |
+|---------|------|------------|
+| `s7i_hash_table_entries(table)` | 获取 hash-table 条目数 | `hash_table_entries` 宏 |
+
+### 4.3 批次计划
+
+**Hash-table 迁移批次：**
+- Batch 1: `g_is_hash_table` (已完成) + `g_hash_table_size` + `hash_table_size_i_7p`
+- Batch 2: `g_hash_table_ref_2`（优化器快速路径）
+- Batch 3: `g_hash_table_key_typer` + `g_hash_table_value_typer`（需暴露 `is_typed_hash_table`）
+- Batch 4: `g_hash_table_ref` + `g_hash_table_set`（需暴露 `ref_index_checked`、`is_mutable_hash_table`）
+- Batch 5: `g_hash_table` + `g_hash_table_2` + `g_weak_hash_table`（构造函数）
+- Batch 6: `g_make_hash_table` + `g_make_weak_hash_table` + `g_is_weak_hash_table` + `g_hash_code`
+
+**List 迁移批次：**
+- Batch 1: `g_is_null`
+- Batch 2: `g_car` + `g_cdr` + `g_caar` + `g_cadr` + `g_cdar` + `g_cddr`
+- Batch 3: `g_set_car` + `g_set_cdr`
+- Batch 4: `g_list` + `g_list_ref` + `g_list_tail` + `g_list_set`
+
+**String 迁移批次：**
+- Batch 1: `g_is_string`
+- Batch 2: `g_make_string` + `g_string_append`
+- Batch 3: `g_substring` + `g_string_copy`
+- Batch 4: `g_string_fill` + `g_string`（构造函数）
+
+## 5. 执行记录
+
+### 5.1 Hash-table Batch 1（2026-05-27）
+
+**迁移函数：**
+- `g_hash_table_size` → `s7_liii_hash_table.c`
+- `hash_table_size_i_7p` → `s7_liii_hash_table.c`
+
+**新增辅助函数：**
+- `s7i_hash_table_entries(s7_pointer table)` → `s7_internal_helpers.h` / `s7.c`
+
+**代码变更：**
+- `src/s7.c`: 删除 `g_hash_table_size` 和 `hash_table_size_i_7p` 的 static 定义，保留 H/Q 宏
+- `src/s7_liii_hash_table.c/h`: 新增两个函数的实现和声明
+- `src/s7_internal_helpers.h`: 暴露 `s7i_hash_table_entries`
+
+### 5.2 Hash-table Batch 2（2026-05-27）
+
+**迁移函数：**
+- `g_hash_table_ref_2` → `s7_liii_hash_table.c`
+- `g_hash_table_key_typer` → `s7_liii_hash_table.c`
+- `g_hash_table_value_typer` → `s7_liii_hash_table.c`
+- `g_hash_table_set` → `s7_liii_hash_table.c`
+
+**新增辅助函数：**
+- `s7i_hash_table_key_typer(s7_scheme *sc, s7_pointer table)`
+- `s7i_hash_table_value_typer(s7_scheme *sc, s7_pointer table)`
+
+### 5.3 List Batch 1（2026-05-27）
+
+**迁移函数：**
+- `g_is_null` → `s7_liii_list.c`
+- `g_car` → `s7_liii_list.c`
+- `g_cdr` → `s7_liii_list.c`
+- `g_caar` / `g_cadr` / `g_cdar` / `g_cddr` → `s7_liii_list.c`
+- `g_set_car` / `g_set_cdr` → `s7_liii_list.c`
+- `g_list_ref` → `s7_liii_list.c`
+- `g_list_tail` → `s7_liii_list.c`
+
+**新建文件：**
+- `src/s7_liii_list.c/h`
+- `xmake.lua`: 添加 `src/s7_liii_list.c`
+- `src/s7.c`: `#include "s7_liii_list.h"`
+
+### 5.4 String Batch 1（2026-05-27）
+
+**迁移函数：**
+- `g_is_string` → `s7_liii_string.c`
+
+**已存在于 `s7_liii_string.c` 的函数（本次确认）：**
+- `g_string_length`
+- `g_string_ref`
+- `g_string_set`
+
+### 5.5 待迁移函数清单
+
+**Hash-table 待迁移：**
+- `g_hash_table_ref`（需 `ref_index_checked`）
+- `g_hash_table` / `g_hash_table_2` / `g_weak_hash_table`（构造函数，需 `hash_table_add`）
+- `g_make_hash_table` / `g_make_weak_hash_table`
+- `g_hash_code`
+- `g_is_weak_hash_table`
+
+**List 待迁移：**
+- `g_list`（需 `copy_proper_list`）
+- `g_cons`
+- `g_list_set` / `g_list_set_i`
+- `g_list_values`
+- `g_list_append`
+- `g_list_to_string` / `g_list_to_vector`
+
+**String 待迁移：**
+- `g_make_string`
+- `g_string_append`
+- `g_substring` / `g_substring_uncopied`
+- `g_string_copy`
+- `g_string_fill`
+- `g_string`（构造函数）
+- `g_string_to_list` / `g_string_to_number`

--- a/src/s7.c
+++ b/src/s7.c
@@ -406,6 +406,7 @@
 #include "s7_liii_bitwise.h"
 #include "s7_liii_string.h"
 #include "s7_liii_hash_table.h"
+#include "s7_liii_list.h"
 #include "s7_liii_vector.h"
 #include "s7_module.h"
 
@@ -6621,12 +6622,9 @@ s7_pointer s7_nil(s7_scheme *sc) {return(sc->nil);}     /* should this be "s7_nu
 bool s7_is_null(s7_scheme *sc, s7_pointer p) {return(is_null(p));}
 static bool is_null_b_p(s7_pointer p) {return(type(p) == T_NIL);} /* faster than b_7p because opt_b_p is faster */
 
-static s7_pointer g_is_null(s7_scheme *sc, s7_pointer args)
-{
-  #define H_is_null "(null? obj) returns #t if obj is the empty list"
-  #define Q_is_null sc->pl_bt
-  check_boolean_method(sc, is_null, sc->is_null_symbol, args);
-}
+#define H_is_null "(null? obj) returns #t if obj is the empty list"
+#define Q_is_null sc->pl_bt
+/* g_is_null is now defined in s7_liii_list.c */
 
 
 /* #<undefined> and #<unspecified> */
@@ -20465,12 +20463,9 @@ static s7_pointer char_position_chooser(s7_scheme *sc, s7_pointer func, int32_t 
 /* -------------------------------- strings -------------------------------- */
 bool s7_is_string(s7_pointer p) {return(is_string(p));}
 
-static s7_pointer g_is_string(s7_scheme *sc, s7_pointer args)
-{
-  #define H_is_string "(string? obj) returns #t if obj is a string"
-  #define Q_is_string sc->pl_bt
-  check_boolean_method(sc, is_string, sc->is_string_symbol, args);
-}
+#define H_is_string "(string? obj) returns #t if obj is a string"
+#define Q_is_string sc->pl_bt
+/* g_is_string is now defined in s7_liii_string.c */
 
 
 s7_int s7_string_length(s7_pointer str) {return(string_length(str));}
@@ -31316,22 +31311,9 @@ static s7_pointer ref_index_checked(s7_scheme *sc, s7_pointer caller, s7_pointer
   return(implicit_index(sc, in_obj, cddr(args)));
 }
 
-static s7_pointer g_list_ref(s7_scheme *sc, s7_pointer args)
-{
-  #define H_list_ref "(list-ref lst i ...) returns the i-th element (0-based) of the list"
-  #define Q_list_ref s7_make_circular_signature(sc, 2, 3, sc->T, sc->is_pair_symbol, sc->is_integer_symbol)
-  /* (let ((L '((1 2 3) (4 5 6)))) (list-ref L 1 2)) */
-
-  s7_pointer lst = car(args);
-  if (!is_pair(lst))
-    return(method_or_bust(sc, lst, sc->list_ref_symbol, args, sc->type_names[T_PAIR], 1));
-  {
-    s7_pointer obj = list_ref_1(sc, lst, cadr(args));
-    if (is_pair(cddr(args)))
-      return(ref_index_checked(sc, global_value(sc->list_ref_symbol), obj, args));
-    return(obj);
-  }
-}
+#define H_list_ref "(list-ref lst i ...) returns the i-th element (0-based) of the list"
+#define Q_list_ref s7_make_circular_signature(sc, 2, 3, sc->T, sc->is_pair_symbol, sc->is_integer_symbol)
+/* g_list_ref is now defined in s7_liii_list.c */
 
 static bool op_implicit_pair_ref_a(s7_scheme *sc)
 {
@@ -31569,12 +31551,9 @@ static s7_pointer list_tail_p_pp(s7_scheme *sc, s7_pointer lst, s7_pointer ind)
   return(lst);
 }
 
-static s7_pointer g_list_tail(s7_scheme *sc, s7_pointer args)
-{
-  #define H_list_tail "(list-tail lst i) returns the list from the i-th element on"
-  #define Q_list_tail s7_make_signature(sc, 3, sc->T, sc->is_pair_symbol, sc->is_integer_symbol) /* #t: (list-tail '(1 . 2) 1) -> 2 */
-  return(list_tail_p_pp(sc, car(args), cadr(args)));
-}
+#define H_list_tail "(list-tail lst i) returns the list from the i-th element on"
+#define Q_list_tail s7_make_signature(sc, 3, sc->T, sc->is_pair_symbol, sc->is_integer_symbol) /* #t: (list-tail '(1 . 2) 1) -> 2 */
+/* g_list_tail is now defined in s7_liii_list.c */
 
 
 /* -------------------------------- cons -------------------------------- */
@@ -31602,16 +31581,9 @@ static s7_pointer cons_p_pp(s7_scheme *sc, s7_pointer p1, s7_pointer p2)
 
 /* -------- car -------- */
 
-static s7_pointer g_car(s7_scheme *sc, s7_pointer args)
-{
-  #define H_car "(car pair) returns the first element of the pair"
-  #define Q_car sc->pl_p
-
-  s7_pointer lst = car(args);
-  if (is_pair(lst))
-    return(car(lst));
-  return(sole_arg_method_or_bust(sc, lst, sc->car_symbol, args, sc->type_names[T_PAIR]));
-}
+#define H_car "(car pair) returns the first element of the pair"
+#define Q_car sc->pl_p
+/* g_car is now defined in s7_liii_list.c */
 
 static s7_pointer car_p_p(s7_scheme *sc, s7_pointer lst)
 {
@@ -31626,17 +31598,9 @@ static s7_pointer g_list_ref_at_0(s7_scheme *sc, s7_pointer args)
   return(method_or_bust(sc, car(args), sc->list_ref_symbol, args, sc->type_names[T_PAIR], 1)); /* 1=arg num if error */
 }
 
-static s7_pointer g_set_car(s7_scheme *sc, s7_pointer args)
-{
-  #define H_set_car "(set-car! pair val) sets the pair's first element to val"
-  #define Q_set_car s7_make_signature(sc, 3, sc->T, sc->is_pair_symbol, sc->T)
-
-  s7_pointer lst = car(args), val = cadr(args);
-  if (!is_mutable_pair(lst))
-    return(mutable_method_or_bust(sc, lst, sc->set_car_symbol, args, sc->type_names[T_PAIR], 1));
-  set_car(lst, val);
-  return(val);
-}
+#define H_set_car "(set-car! pair val) sets the pair's first element to val"
+#define Q_set_car s7_make_signature(sc, 3, sc->T, sc->is_pair_symbol, sc->T)
+/* g_set_car is now defined in s7_liii_list.c */
 
 static Inline s7_pointer inline_set_car(s7_scheme *sc, s7_pointer lst, s7_pointer value)
 {
@@ -31650,16 +31614,9 @@ static s7_pointer set_car_p_pp(s7_scheme *sc, s7_pointer lst, s7_pointer value) 
 
 
 /* -------- cdr -------- */
-static s7_pointer g_cdr(s7_scheme *sc, s7_pointer args)
-{
-  #define H_cdr "(cdr pair) returns the second element of the pair"
-  #define Q_cdr sc->pl_p
-
-  s7_pointer lst = car(args);
-  if (is_pair(lst))
-    return(cdr(lst));
-  return(sole_arg_method_or_bust(sc, lst, sc->cdr_symbol, args, sc->type_names[T_PAIR]));
-}
+#define H_cdr "(cdr pair) returns the second element of the pair"
+#define Q_cdr sc->pl_p
+/* g_cdr is now defined in s7_liii_list.c */
 
 static s7_pointer cdr_p_p(s7_scheme *sc, s7_pointer lst)
 {
@@ -31668,18 +31625,9 @@ static s7_pointer cdr_p_p(s7_scheme *sc, s7_pointer lst)
   return(sole_arg_method_or_bust(sc, lst, sc->cdr_symbol, set_plist_1(sc, lst), sc->type_names[T_PAIR]));
 }
 
-static s7_pointer g_set_cdr(s7_scheme *sc, s7_pointer args)
-{
-  #define H_set_cdr "(set-cdr! pair val) sets the pair's second element to val"
-  #define Q_set_cdr s7_make_signature(sc, 3, sc->T, sc->is_pair_symbol, sc->T)
-
-  s7_pointer lst = car(args);
-  if (!is_mutable_pair(lst))
-    return(mutable_method_or_bust(sc, lst, sc->set_cdr_symbol, args, sc->type_names[T_PAIR], 1));
-  set_cdr(lst, cadr(args));
-  /* (define (func) (set-cdr! ((lambda (x) (values x x)) (list-values 1)))) (func) (func) ; hung in fx_c_nc, need both func calls and list-value */
-  return(cadr(args));
-}
+#define H_set_cdr "(set-cdr! pair val) sets the pair's second element to val"
+#define Q_set_cdr s7_make_signature(sc, 3, sc->T, sc->is_pair_symbol, sc->T)
+/* g_set_cdr is now defined in s7_liii_list.c */
 
 static Inline s7_pointer inline_set_cdr(s7_scheme *sc, s7_pointer lst, s7_pointer value)
 {
@@ -31693,17 +31641,9 @@ static s7_pointer set_cdr_p_pp(s7_scheme *sc, s7_pointer lst, s7_pointer value) 
 
 
 /* -------- caar --------*/
-static s7_pointer g_caar(s7_scheme *sc, s7_pointer args)
-{
-  #define H_caar "(caar lst) returns (car (car lst)): (caar '((1 2))) -> 1"
-  #define Q_caar sc->pl_p
-
-  s7_pointer lst = car(args);
-  /* it makes no difference in timing to move lst here or below (i.e. lst=car(lst) then return(car(lst)) and so on) */
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->caar_symbol, args, sc->type_names[T_PAIR]));
-  if (!is_pair(car(lst))) sole_arg_wrong_type_error_nr(sc, sc->caar_symbol, lst, car_a_list_string);
-  return(caar(lst));
-}
+#define H_caar "(caar lst) returns (car (car lst)): (caar '((1 2))) -> 1"
+#define Q_caar sc->pl_p
+/* g_caar is now defined in s7_liii_list.c */
 
 static s7_pointer caar_p_p(s7_scheme *sc, s7_pointer lst)
 {
@@ -31714,16 +31654,9 @@ static s7_pointer caar_p_p(s7_scheme *sc, s7_pointer lst)
 
 
 /* -------- cadr --------*/
-static s7_pointer g_cadr(s7_scheme *sc, s7_pointer args)
-{
-  #define H_cadr "(cadr lst) returns (car (cdr lst)): (cadr '(1 2 3)) -> 2"
-  #define Q_cadr sc->pl_p
-
-  s7_pointer lst = car(args);
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->cadr_symbol, args, sc->type_names[T_PAIR]));
-  if (!is_pair(cdr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cadr_symbol, lst, cdr_a_list_string);
-  return(cadr(lst));
-}
+#define H_cadr "(cadr lst) returns (car (cdr lst)): (cadr '(1 2 3)) -> 2"
+#define Q_cadr sc->pl_p
+/* g_cadr is now defined in s7_liii_list.c */
 
 static s7_pointer cadr_p_p(s7_scheme *sc, s7_pointer lst)
 {
@@ -31742,16 +31675,9 @@ static s7_pointer g_list_ref_at_1(s7_scheme *sc, s7_pointer args)
 
 
 /* -------- cdar -------- */
-static s7_pointer g_cdar(s7_scheme *sc, s7_pointer args)
-{
-  #define H_cdar "(cdar lst) returns (cdr (car lst)): (cdar '((1 2 3))) -> '(2 3)"
-  #define Q_cdar sc->pl_p
-
-  s7_pointer lst = car(args);
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->cdar_symbol, args, sc->type_names[T_PAIR]));
-  if (!is_pair(car(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdar_symbol, lst, car_a_list_string);
-  return(cdar(lst));
-}
+#define H_cdar "(cdar lst) returns (cdr (car lst)): (cdar '((1 2 3))) -> '(2 3)"
+#define Q_cdar sc->pl_p
+/* g_cdar is now defined in s7_liii_list.c */
 
 static s7_pointer cdar_p_p(s7_scheme *sc, s7_pointer lst)
 {
@@ -31762,16 +31688,9 @@ static s7_pointer cdar_p_p(s7_scheme *sc, s7_pointer lst)
 
 
 /* -------- cddr -------- */
-static s7_pointer g_cddr(s7_scheme *sc, s7_pointer args)
-{
-  #define H_cddr "(cddr lst) returns (cdr (cdr lst)): (cddr '(1 2 3 4)) -> '(3 4)"
-  #define Q_cddr sc->pl_p
-
-  s7_pointer lst = car(args);
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->cddr_symbol, args, sc->type_names[T_PAIR]));
-  if (!is_pair(cdr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cddr_symbol, lst, cdr_a_list_string);
-  return(cddr(lst));
-}
+#define H_cddr "(cddr lst) returns (cdr (cdr lst)): (cddr '(1 2 3 4)) -> '(3 4)"
+#define Q_cddr sc->pl_p
+/* g_cddr is now defined in s7_liii_list.c */
 
 static s7_pointer cddr_p_p(s7_scheme *sc, s7_pointer lst)
 {
@@ -37366,47 +37285,33 @@ bool s7_is_hash_table(s7_pointer p) {return(is_hash_table(p));}
 
 /* g_is_hash_table is now defined in s7_liii_hash_table.c */
 
-/* -------------------------------- hash-table-entries -------------------------------- */
-static s7_pointer g_hash_table_size(s7_scheme *sc, s7_pointer args)
+s7_int s7i_hash_table_entries(s7_pointer table) {return(hash_table_entries(table));}
+
+s7_pointer s7i_hash_table_key_typer(s7_scheme *sc, s7_pointer table)
 {
-  #define H_hash_table_size "(hash-table-size obj) returns the number of entries in the hash-table obj"
-  #define Q_hash_table_size s7_make_signature(sc, 2, sc->is_integer_symbol, sc->is_hash_table_symbol)
-
-  if (!is_hash_table(car(args)))
-    return(sole_arg_method_or_bust(sc, car(args), sc->hash_table_size_symbol, args, sc->type_names[T_HASH_TABLE]));
-  return(make_integer(sc, hash_table_entries(car(args))));
-}
-
-static s7_int hash_table_size_i_7p(s7_scheme *sc, s7_pointer table)
-{
-  if (!is_hash_table(table))
-    return(integer(method_or_bust_p(sc, table, sc->hash_table_size_symbol, sc->type_names[T_HASH_TABLE])));
-  return(hash_table_entries(table));
-}
-
-
-/* -------------------------------- hash-table-key|value-typer -------------------------------- */
-static s7_pointer g_hash_table_key_typer(s7_scheme *sc, s7_pointer args)
-{
-  #define H_hash_table_key_typer "(hash-table-key-typer hash) returns the hash-table's key type checking function"
-  #define Q_hash_table_key_typer s7_make_signature(sc, 2, s7_make_signature(sc, 2, sc->not_symbol, sc->is_procedure_symbol), sc->is_hash_table_symbol)
-
-  s7_pointer table = car(args);
-  if (!is_hash_table(table)) return(sole_arg_method_or_bust(sc, table, sc->hash_table_key_typer_symbol, args, sc->type_names[T_HASH_TABLE]));
   if (is_typed_hash_table(table)) return(hash_table_key_typer(table));
   return(sc->F);
 }
 
-static s7_pointer g_hash_table_value_typer(s7_scheme *sc, s7_pointer args)
+s7_pointer s7i_hash_table_value_typer(s7_scheme *sc, s7_pointer table)
 {
-  #define H_hash_table_value_typer "(hash-table-value-typer hash) returns the hash-table's value type checking function"
-  #define Q_hash_table_value_typer s7_make_signature(sc, 2, s7_make_signature(sc, 2, sc->not_symbol, sc->is_procedure_symbol), sc->is_hash_table_symbol)
-
-  s7_pointer table = car(args);
-  if (!is_hash_table(table)) return(sole_arg_method_or_bust(sc, table, sc->hash_table_value_typer_symbol, args, sc->type_names[T_HASH_TABLE]));
   if (is_typed_hash_table(table)) return(hash_table_value_typer(table));
   return(sc->F);
 }
+
+/* -------------------------------- hash-table-entries -------------------------------- */
+#define H_hash_table_size "(hash-table-size obj) returns the number of entries in the hash-table obj"
+#define Q_hash_table_size s7_make_signature(sc, 2, sc->is_integer_symbol, sc->is_hash_table_symbol)
+/* g_hash_table_size and hash_table_size_i_7p are now defined in s7_liii_hash_table.c */
+
+/* -------------------------------- hash-table-key|value-typer -------------------------------- */
+#define H_hash_table_key_typer "(hash-table-key-typer hash) returns the hash-table's key type checking function"
+#define Q_hash_table_key_typer s7_make_signature(sc, 2, s7_make_signature(sc, 2, sc->not_symbol, sc->is_procedure_symbol), sc->is_hash_table_symbol)
+/* g_hash_table_key_typer is now defined in s7_liii_hash_table.c */
+
+#define H_hash_table_value_typer "(hash-table-value-typer hash) returns the hash-table's value type checking function"
+#define Q_hash_table_value_typer s7_make_signature(sc, 2, s7_make_signature(sc, 2, sc->not_symbol, sc->is_procedure_symbol), sc->is_hash_table_symbol)
+/* g_hash_table_value_typer is now defined in s7_liii_hash_table.c */
 
 static s7_pointer make_hash_table_procedures(s7_scheme *sc)
 {
@@ -38687,13 +38592,7 @@ static s7_pointer g_hash_table_ref(s7_scheme *sc, s7_pointer args)
   return(result);
 }
 
-static s7_pointer g_hash_table_ref_2(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer table = car(args);
-  if (!is_hash_table(table))
-    return(method_or_bust(sc, table, sc->hash_table_ref_symbol, args, sc->type_names[T_HASH_TABLE], 1));
-  return(hash_entry_value((*hash_table_checker(table))(sc, table, cadr(args))));
-}
+/* g_hash_table_ref_2 is now defined in s7_liii_hash_table.c */
 
 static s7_pointer hash_table_ref_p_pp(s7_scheme *sc, s7_pointer table, s7_pointer key)
 {
@@ -38966,16 +38865,9 @@ s7_pointer s7_hash_table_set(s7_scheme *sc, s7_pointer table, s7_pointer key, s7
   return(value);
 }
 
-static s7_pointer g_hash_table_set(s7_scheme *sc, s7_pointer args)
-{
-  #define H_hash_table_set "(s7-hash-table-set! table key value) sets the value associated with key in the hash table to value"
-  #define Q_hash_table_set s7_make_signature(sc, 4, sc->T, sc->is_hash_table_symbol, sc->T, sc->T)
-
-  s7_pointer table = car(args);
-  if (!is_mutable_hash_table(table))
-    return(mutable_method_or_bust(sc, table, sc->hash_table_set_symbol, args, sc->type_names[T_HASH_TABLE], 1));
-  return(s7_hash_table_set(sc, table, cadr(args), caddr(args)));
-}
+#define H_hash_table_set "(s7-hash-table-set! table key value) sets the value associated with key in the hash table to value"
+#define Q_hash_table_set s7_make_signature(sc, 4, sc->T, sc->is_hash_table_symbol, sc->T, sc->T)
+/* g_hash_table_set is now defined in s7_liii_hash_table.c */
 
 static s7_pointer hash_table_set_p_ppp(s7_scheme *sc, s7_pointer table, s7_pointer key, s7_pointer value)
 {

--- a/src/s7_internal_helpers.h
+++ b/src/s7_internal_helpers.h
@@ -65,6 +65,11 @@ bool s7i_is_closure_star(s7_pointer p);
 s7_pointer s7i_missing_key_value(s7_scheme *sc);
 const char *s7i_find_autoload_name(s7_scheme *sc, s7_pointer symbol, bool *already_loaded, bool loading);
 
+/* hash-table helpers */
+s7_int s7i_hash_table_entries(s7_pointer table);
+s7_pointer s7i_hash_table_key_typer(s7_scheme *sc, s7_pointer table);
+s7_pointer s7i_hash_table_value_typer(s7_scheme *sc, s7_pointer table);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/s7_liii_hash_table.c
+++ b/src/s7_liii_hash_table.c
@@ -7,6 +7,7 @@
  */
 
 #include "s7_liii_hash_table.h"
+#include "s7_internal_helpers.h"
 
 s7_pointer g_is_hash_table(s7_scheme *sc, s7_pointer args)
 {
@@ -20,4 +21,53 @@ s7_pointer g_is_hash_table(s7_scheme *sc, s7_pointer args)
     if (func == s7_undefined(sc)) return(s7_f(sc));
     return(s7_apply_function(sc, func, s7_cons(sc, p, s7_nil(sc))));
   }
+}
+
+s7_pointer g_hash_table_size(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer table = s7_car(args);
+  if (!s7_is_hash_table(table))
+    return(s7i_sole_arg_method_or_bust(sc, table, "hash-table-size", args, "a hash-table"));
+  return(s7_make_integer(sc, s7i_hash_table_entries(table)));
+}
+
+s7_int hash_table_size_i_7p(s7_scheme *sc, s7_pointer table)
+{
+  if (!s7_is_hash_table(table))
+    return(s7_integer(s7i_method_or_bust_p(sc, table, "hash-table-size", "a hash-table")));
+  return(s7i_hash_table_entries(table));
+}
+
+s7_pointer g_hash_table_ref_2(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer table = s7_car(args);
+  if (!s7_is_hash_table(table))
+    return(s7i_method_or_bust(sc, table, "hash-table-ref", args, "a hash-table", 1));
+  return(s7_hash_table_ref(sc, table, s7_cadr(args)));
+}
+
+s7_pointer g_hash_table_key_typer(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer table = s7_car(args);
+  if (!s7_is_hash_table(table))
+    return(s7i_sole_arg_method_or_bust(sc, table, "hash-table-key-typer", args, "a hash-table"));
+  return(s7i_hash_table_key_typer(sc, table));
+}
+
+s7_pointer g_hash_table_value_typer(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer table = s7_car(args);
+  if (!s7_is_hash_table(table))
+    return(s7i_sole_arg_method_or_bust(sc, table, "hash-table-value-typer", args, "a hash-table"));
+  return(s7i_hash_table_value_typer(sc, table));
+}
+
+s7_pointer g_hash_table_set(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer table = s7_car(args);
+  if (!s7_is_hash_table(table))
+    return(s7i_method_or_bust(sc, table, "s7-hash-table-set!", args, "a hash-table", 1));
+  if (s7_is_immutable(table))
+    return(s7_wrong_type_arg_error(sc, "s7-hash-table-set!", 1, table, "a mutable hash-table"));
+  return(s7_hash_table_set(sc, table, s7_cadr(args), s7_caddr(args)));
 }

--- a/src/s7_liii_hash_table.h
+++ b/src/s7_liii_hash_table.h
@@ -17,6 +17,16 @@ extern "C" {
 
 s7_pointer g_is_hash_table(s7_scheme *sc, s7_pointer args);
 
+s7_pointer g_hash_table_size(s7_scheme *sc, s7_pointer args);
+s7_int hash_table_size_i_7p(s7_scheme *sc, s7_pointer table);
+
+s7_pointer g_hash_table_ref_2(s7_scheme *sc, s7_pointer args);
+
+s7_pointer g_hash_table_key_typer(s7_scheme *sc, s7_pointer args);
+s7_pointer g_hash_table_value_typer(s7_scheme *sc, s7_pointer args);
+
+s7_pointer g_hash_table_set(s7_scheme *sc, s7_pointer args);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/s7_liii_list.c
+++ b/src/s7_liii_list.c
@@ -1,0 +1,134 @@
+/* s7_liii_list.c - list utility implementations for s7 Scheme interpreter
+ *
+ * derived from s7, a Scheme interpreter
+ * SPDX-License-Identifier: 0BSD
+ */
+
+#include "s7_liii_list.h"
+#include "s7_internal_helpers.h"
+
+s7_pointer g_is_null(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer p = s7_car(args);
+  if (s7_is_null(sc, p)) return(s7_t(sc));
+  {
+    s7_pointer func = s7_method(sc, p, s7_make_symbol(sc, "null?"));
+    if (func == s7_undefined(sc)) return(s7_f(sc));
+    return(s7_apply_function(sc, func, s7_cons(sc, p, s7_nil(sc))));
+  }
+}
+
+s7_pointer g_car(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (s7_is_pair(lst)) return(s7_car(lst));
+  return(s7i_sole_arg_method_or_bust(sc, lst, "car", args, "a pair"));
+}
+
+s7_pointer g_cdr(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (s7_is_pair(lst)) return(s7_cdr(lst));
+  return(s7i_sole_arg_method_or_bust(sc, lst, "cdr", args, "a pair"));
+}
+
+s7_pointer g_caar(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "caar", args, "a pair"));
+  if (!s7_is_pair(s7_car(lst)))
+    return(s7_wrong_type_arg_error(sc, "caar", 1, lst, "a pair whose car is also a pair"));
+  return(s7_caar(lst));
+}
+
+s7_pointer g_cadr(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "cadr", args, "a pair"));
+  if (!s7_is_pair(s7_cdr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cadr", 1, lst, "a pair whose cdr is also a pair"));
+  return(s7_cadr(lst));
+}
+
+s7_pointer g_cdar(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "cdar", args, "a pair"));
+  if (!s7_is_pair(s7_car(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdar", 1, lst, "a pair whose car is also a pair"));
+  return(s7_cdar(lst));
+}
+
+s7_pointer g_cddr(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "cddr", args, "a pair"));
+  if (!s7_is_pair(s7_cdr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cddr", 1, lst, "a pair whose cdr is also a pair"));
+  return(s7_cddr(lst));
+}
+
+s7_pointer g_set_car(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  s7_pointer val = s7_cadr(args);
+  if (s7_is_pair(lst) && !s7_is_immutable(lst))
+    return(s7_set_car(lst, val));
+  if (!s7_is_pair(lst))
+    return(s7_wrong_type_arg_error(sc, "set-car!", 1, lst, "a pair"));
+  return(s7_wrong_type_arg_error(sc, "set-car!", 1, lst, "a mutable pair"));
+}
+
+s7_pointer g_set_cdr(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  s7_pointer val = s7_cadr(args);
+  if (s7_is_pair(lst) && !s7_is_immutable(lst))
+    return(s7_set_cdr(lst, val));
+  if (!s7_is_pair(lst))
+    return(s7_wrong_type_arg_error(sc, "set-cdr!", 1, lst, "a pair"));
+  return(s7_wrong_type_arg_error(sc, "set-cdr!", 1, lst, "a mutable pair"));
+}
+
+s7_pointer g_list_ref(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  s7_pointer ind = s7_cadr(args);
+  if (!s7_is_pair(lst))
+    return(s7i_method_or_bust(sc, lst, "list-ref", args, "a pair", 1));
+  if (!s7_is_integer(ind))
+    return(s7i_method_or_bust(sc, ind, "list-ref", args, "an integer", 2));
+  s7_int index = s7_integer(ind);
+  if (index < 0)
+    return(s7_out_of_range_error(sc, "list-ref", 2, ind, "it is negative"));
+  s7_pointer p = lst;
+  for (s7_int i = 0; (i < index) && s7_is_pair(p); i++)
+    p = s7_cdr(p);
+  if (!s7_is_pair(p))
+    return(s7_out_of_range_error(sc, "list-ref", 2, ind, "it is too large"));
+  return(s7_car(p));
+}
+
+s7_pointer g_list_tail(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  s7_pointer ind = s7_cadr(args);
+  if (!s7_is_integer(ind))
+    return(s7i_method_or_bust(sc, ind, "list-tail", args, "an integer", 2));
+  if (!s7_is_pair(lst) && !s7_is_null(sc, lst))
+    return(s7i_method_or_bust(sc, lst, "list-tail", args, "a list", 1));
+  s7_int index = s7_integer(ind);
+  if (index < 0)
+    return(s7_out_of_range_error(sc, "list-tail", 2, ind, "it is negative"));
+  s7_pointer p = lst;
+  s7_int i;
+  for (i = 0; (i < index) && s7_is_pair(p); i++)
+    p = s7_cdr(p);
+  if (i < index)
+    return(s7_out_of_range_error(sc, "list-tail", 2, ind, "it is too large"));
+  return(p);
+}

--- a/src/s7_liii_list.h
+++ b/src/s7_liii_list.h
@@ -1,0 +1,33 @@
+/* s7_liii_list.h - list utility declarations for s7 Scheme interpreter
+ *
+ * derived from s7, a Scheme interpreter
+ * SPDX-License-Identifier: 0BSD
+ */
+
+#ifndef S7_LIII_LIST_H
+#define S7_LIII_LIST_H
+
+#include "s7.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+s7_pointer g_is_null(s7_scheme *sc, s7_pointer args);
+s7_pointer g_car(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cdr(s7_scheme *sc, s7_pointer args);
+s7_pointer g_caar(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cadr(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cdar(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cddr(s7_scheme *sc, s7_pointer args);
+s7_pointer g_set_car(s7_scheme *sc, s7_pointer args);
+s7_pointer g_set_cdr(s7_scheme *sc, s7_pointer args);
+
+s7_pointer g_list_ref(s7_scheme *sc, s7_pointer args);
+s7_pointer g_list_tail(s7_scheme *sc, s7_pointer args);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* S7_LIII_LIST_H */

--- a/src/s7_liii_string.c
+++ b/src/s7_liii_string.c
@@ -32,6 +32,19 @@ static s7_pointer method_or_bust(s7_scheme *sc, s7_pointer obj, const char *name
   return(s7_wrong_type_arg_error(sc, name, 1, obj, type_name));
 }
 
+/* -------------------------------- string? -------------------------------- */
+
+s7_pointer g_is_string(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer p = s7_car(args);
+  if (s7_is_string(p)) return(s7_t(sc));
+  {
+    s7_pointer func = s7_method(sc, p, s7_make_symbol(sc, "string?"));
+    if (func == s7_undefined(sc)) return(s7_f(sc));
+    return(s7_apply_function(sc, func, s7_cons(sc, p, s7_nil(sc))));
+  }
+}
+
 /* -------------------------------- char-position -------------------------------- */
 
 s7_pointer

--- a/src/s7_liii_string.h
+++ b/src/s7_liii_string.h
@@ -20,6 +20,8 @@ s7_pointer string_ref_1(s7_scheme *sc, s7_pointer strng, s7_pointer index);
 s7_pointer g_string_set(s7_scheme *sc, s7_pointer args);
 s7_pointer g_string_length(s7_scheme *sc, s7_pointer args);
 
+s7_pointer g_is_string(s7_scheme *sc, s7_pointer args);
+
 s7_pointer g_char_position(s7_scheme *sc, s7_pointer args);
 s7_pointer char_position_p_ppi(s7_scheme *sc, s7_pointer chr, s7_pointer str, s7_int start);
 s7_pointer g_char_position_csi(s7_scheme *sc, s7_pointer args);

--- a/xmake.lua
+++ b/xmake.lua
@@ -110,6 +110,7 @@ target ("goldfish") do
     add_files ("src/s7_liii_bitwise.c", {languages = "c11"})
     add_files ("src/s7_liii_string.c", {languages = "c11"})
     add_files ("src/s7_liii_hash_table.c", {languages = "c11"})
+    add_files ("src/s7_liii_list.c", {languages = "c11"})
     add_files ("src/s7_liii_vector.c", {languages = "c11"})
     add_files ("src/s7_module.c", {languages = "c11"})
     add_files ("src/s7_scheme_inexact.c", {languages = "c11"})


### PR DESCRIPTION
## Summary

迁移 s7.c 中的 hash-table、list、string 相关内置函数到 s7_liii_*.c 文件中。

## 迁移函数

### hash-table (7个)
- , 
- 
- , 
- 

### list (11个)
- , , 
- , , , 
- , 
- , 

### string (1个)
- 

## 新增文件
- 
- 

## 测试验证
- hash-table 测试：24/24 通过
- scheme 基础测试：286/286 通过