### PR TITLE
[0045] 迁移 hash-table/list/string 内置函数到 s7_liii_*.c (Part 3)

### DIFF
--- a/devel/0045.md
+++ b/devel/0045.md
@@ -167,6 +167,11 @@ bin/gf test --changed-since=main
 - `g_is_null`, `g_car`/`g_cdr`/`g_caar`/`g_cadr`/`g_cdar`/`g_cddr`
 - `g_set_car`/`g_set_cdr`, `g_list_ref`, `g_list_tail`
 - `g_cons`, `g_list`
+- `g_list_to_string`（2026-05-27）
+- `g_list_set` / `g_list_set_i`（2026-05-27）
+- `g_list_values` — 保留在 s7.c（与 quasiquote 深度耦合）
+- `g_list_append` — 保留在 s7.c（依赖 GC 栈保护）
+- `g_list_to_vector` — 已在 `s7_liii_vector.c`
 
 ### 5.9 剩余函数迁移方案（从易到难）
 
@@ -185,24 +190,25 @@ bin/gf test --changed-since=main
   - `list_set_p_pip_unchecked` / `list_set_p_pip`（快速路径，被 opt 调用，**保留在 s7.c**）
 - **要点**：`g_list_set` 是 `g_list_set_1` 的薄封装；`g_list_set_i` 是独立实现（处理 mutable check 和索引循环）
 
-**第 3 步：`g_list_values`（较复杂）**
+**第 3 步：`g_list_values`（已评估，保留在 s7.c）**
 - **位置**：`src/s7.c:63777`
-- **目标**：`s7_liii_list.c`
-- **依赖的内部函数**：
-  - `copy_tree`, `copy_tree_with_type`（宏/函数，用于清除优化位）
-  - `splice_out_values`（处理 `no_value` 的 splice 逻辑）
-  - `is_checked`, `is_unquoted_pair`, `tree_is_cyclic` 等内部状态宏
-- **策略**：该函数与 quasiquote 宏展开深度耦合，内部使用了大量 `sc->` 字段和状态宏。评估是否适合迁移——若内部依赖过多，可能保留在 s7.c 中。
+- **评估结论**：**保留在 s7.c，不迁移**。内部依赖过多且无可用的公开 API 替代：
+  - `is_checked`（优化器内部状态位）、`sc->no_value`（多值内部表示）
+  - `begin_temp` / `end_temp` / `check_free_heap_size`（GC 内部机制）
+  - `tree_is_cyclic`、`copy_tree`、`copy_tree_with_type`（宏展开树复制）
+  - `is_unquoted_pair`、`splice_out_values`（quasiquote 内部逻辑）
+  - `cons_unchecked`（无检查 cons）
+  - 该函数注释明确标注为 "internal to quasiquote"，是 s7 核心实现细节。
 
-**第 4 步：`g_list_append`（较复杂）**
+**第 4 步：`g_list_append`（已评估，保留在 s7.c）**
 - **位置**：`src/s7.c:32826`
-- **目标**：`s7_liii_list.c`
-- **依赖的内部函数**：
-  - `gc_protect_via_stack` / `unstack_gc_protect`（GC 保护）
-  - `has_active_methods`, `find_method_with_let`（方法查找，已有 `s7i_has_active_methods`, `s7i_find_method_with_let`）
-  - `is_sequence`, `sequence_length`, `s7_copy_1`（已有 `s7i_is_sequence`, `s7i_sequence_length`, `s7i_copy_1`）
-  - `make_safe_list` / `sc->safe_lists`（内部安全列表缓存）
-- **策略**：核心逻辑可用已暴露的辅助函数重写，但 `gc_protect_via_stack` 和 `safe_lists` 缓存需要评估是否暴露或绕过。
+- **评估结论**：**保留在 s7.c，不迁移**。虽然部分依赖（`has_active_methods`、`find_method_with_let`、`s7_copy_1`、`position_of`）已有 `s7i_` 辅助函数，但核心机制无法替代：
+  - `gc_protect_via_stack` / `unstack_gc_protect`（栈式 GC 保护，无公开 API）
+  - `make_list`、`list_1`（内部列表构造函数，依赖 `sc->` 字段）
+  - `sc->temp8` / `sc->unused`（内部临时字段）
+  - `is_sequence`、`sequence_length`、`sequence_is_empty`（序列抽象内部宏）
+  - `set_plist_2`（内部参数列表构造）
+  - 在 s7.c 中被 `g_append` 多处直接调用（43676、43677、43699）
 
 ### 5.10 迁移原则补充
 1. **快速路径保留**：`_p_pii`、`_p_pip` 等被内部 opt 代码直接调用的快速路径函数，保留在 `s7.c` 中不动。

--- a/devel/0045.md
+++ b/devel/0045.md
@@ -153,17 +153,58 @@ bin/gf test --changed-since=main
 - `s7i_max_list_length(sc)`
 - `s7i_string_append_1(sc, args, caller)` / `s7i_string_1(sc, args, sym)` / `s7i_string_c1(sc, args)`
 
-### 5.8 待迁移函数清单
+### 5.8 已完成迁移
 
-**Hash-table 待迁移：**
-- 已全部完成
+**Hash-table：** 已全部完成（Batch 1-6）。
 
-**List 待迁移：**
-- `g_list_set` / `g_list_set_i`
-- `g_list_values`
-- `g_list_append`
-- `g_list_to_string` / `g_list_to_vector`（`g_list_to_vector` 已在 `s7_liii_vector.c`）
+**String：**
+- `g_is_string`, `g_string_length`, `g_string_ref`, `g_string_set`
+- `g_make_string`, `g_string_to_number`, `g_substring`, `g_string_copy`
+- `g_string_fill`, `g_string_to_list`, `g_string_append`, `g_string`
+- `g_substring_uncopied`（2026-05-27）
 
-**String 待迁移：**
-- `g_substring_uncopied`
-- `g_string_to_list` 已完成
+**List：**
+- `g_is_null`, `g_car`/`g_cdr`/`g_caar`/`g_cadr`/`g_cdar`/`g_cddr`
+- `g_set_car`/`g_set_cdr`, `g_list_ref`, `g_list_tail`
+- `g_cons`, `g_list`
+
+### 5.9 剩余函数迁移方案（从易到难）
+
+**第 1 步：`g_list_to_string`（简单）**
+- **位置**：`src/s7.c:21529`
+- **目标**：`s7_liii_string.c`（依赖 `s7i_string_1`，已在同文件）
+- **要点**：函数体仅调用 `s7i_string_1`，无复杂内部依赖
+- **辅助函数**：无需新增
+
+**第 2 步：`g_list_set` / `g_list_set_i`（中等）**
+- **位置**：`src/s7.c:31311`, `31344`
+- **目标**：`s7_liii_list.c`
+- **依赖的内部函数**：
+  - `g_list_set_1`（主逻辑，需一并迁移）
+  - `list_set_index_check_nr`（错误处理，可用公开 API 重写）
+  - `list_set_p_pip_unchecked` / `list_set_p_pip`（快速路径，被 opt 调用，**保留在 s7.c**）
+- **要点**：`g_list_set` 是 `g_list_set_1` 的薄封装；`g_list_set_i` 是独立实现（处理 mutable check 和索引循环）
+
+**第 3 步：`g_list_values`（较复杂）**
+- **位置**：`src/s7.c:63777`
+- **目标**：`s7_liii_list.c`
+- **依赖的内部函数**：
+  - `copy_tree`, `copy_tree_with_type`（宏/函数，用于清除优化位）
+  - `splice_out_values`（处理 `no_value` 的 splice 逻辑）
+  - `is_checked`, `is_unquoted_pair`, `tree_is_cyclic` 等内部状态宏
+- **策略**：该函数与 quasiquote 宏展开深度耦合，内部使用了大量 `sc->` 字段和状态宏。评估是否适合迁移——若内部依赖过多，可能保留在 s7.c 中。
+
+**第 4 步：`g_list_append`（较复杂）**
+- **位置**：`src/s7.c:32826`
+- **目标**：`s7_liii_list.c`
+- **依赖的内部函数**：
+  - `gc_protect_via_stack` / `unstack_gc_protect`（GC 保护）
+  - `has_active_methods`, `find_method_with_let`（方法查找，已有 `s7i_has_active_methods`, `s7i_find_method_with_let`）
+  - `is_sequence`, `sequence_length`, `s7_copy_1`（已有 `s7i_is_sequence`, `s7i_sequence_length`, `s7i_copy_1`）
+  - `make_safe_list` / `sc->safe_lists`（内部安全列表缓存）
+- **策略**：核心逻辑可用已暴露的辅助函数重写，但 `gc_protect_via_stack` 和 `safe_lists` 缓存需要评估是否暴露或绕过。
+
+### 5.10 迁移原则补充
+1. **快速路径保留**：`_p_pii`、`_p_pip` 等被内部 opt 代码直接调用的快速路径函数，保留在 `s7.c` 中不动。
+2. **宏保留**：`H_xxx`、`Q_xxx` 宏保留在 `s7.c` 中（移到文件作用域）。
+3. **逐个迁移**：每完成一个函数，构建测试通过后立即 commit。

--- a/src/s7.c
+++ b/src/s7.c
@@ -31238,53 +31238,10 @@ s7_pointer s7_list_set(s7_scheme *sc, s7_pointer lst, s7_int num, s7_pointer val
   return(val);
 }
 
-static s7_pointer g_list_set_1(s7_scheme *sc, s7_pointer lst, s7_pointer args, int32_t arg_num)
-{
-  #define H_list_set "(list-set! lst i ... val) sets the i-th element (0-based) of the list to val"
-  #define Q_list_set s7_make_circular_signature(sc, 3, 4, sc->T, sc->is_pair_symbol, sc->is_integer_symbol, sc->is_integer_or_any_at_end_symbol)
+/* g_list_set and g_list_set_i are now defined in s7_liii_list.c */
 
-  s7_int index;
-  s7_pointer p = lst, ind;
-  /* (let ((L '((1 2 3) (4 5 6)))) (list-set! L 1 2 32) L) */
-
-  if (!is_mutable_pair(lst))
-    return(mutable_method_or_bust(sc, lst, sc->list_set_symbol, set_ulist_1(sc, lst, args), sc->type_names[T_PAIR], 1));
-  ind = car(args);
-  if ((arg_num > 2) && (is_null(cdr(args))))
-    {
-      set_car(lst, ind);
-      return(ind);
-    }
-  if (!s7_is_integer(ind))
-    return(method_or_bust(sc, ind, sc->list_set_symbol, set_ulist_1(sc, lst, args), sc->type_names[T_INTEGER], 2));
-  index = s7_integer_clamped_if_gmp(sc, ind);
-
-  if (index < 0) /* arg_num used here so can't use list_set_index_check */
-    out_of_range_error_nr(sc, sc->list_set_symbol, wrap_integer(sc, arg_num), ind, it_is_negative_string);
-  if (index > sc->max_list_length) /* (list-set! (list 1 2 3) (ash 1 61) 0) */
-    error_nr(sc, sc->out_of_range_symbol,
-	     set_elist_4(sc, wrap_string(sc, "list-set! ~:D argument ~D is too large, (*s7* 'max-list-length) is ~D", 69),
-			 wrap_integer(sc, arg_num), ind, wrap_integer(sc, sc->max_list_length)));
-
-  for (s7_int i = 0; (i < index) && is_pair(p); i++, p = cdr(p)) {}
-  if (!is_pair(p))
-    {
-      if (is_null(p))
-	out_of_range_error_nr(sc, sc->list_set_symbol, wrap_integer(sc, arg_num), ind, it_is_too_large_string);
-      wrong_type_error_nr(sc, sc->list_set_symbol, 1, lst, a_proper_list_string);
-    }
-  if (is_null(cddr(args)))
-    set_car(p, cadr(args));
-  else
-    {
-      if (!s7_is_pair(car(p)))
-	wrong_number_of_arguments_error_nr(sc, "too many arguments for list-set!: ~S", 36, args);
-      return(g_list_set_1(sc, car(p), cdr(args), arg_num + 1));
-    }
-  return(cadr(args)); /* args here == cdr(args) of original call */
-}
-
-static s7_pointer g_list_set(s7_scheme *sc, s7_pointer args) {return(g_list_set_1(sc, car(args), cdr(args), 2));}
+#define H_list_set "(list-set! lst i ... val) sets the i-th element (0-based) of the list to val"
+#define Q_list_set s7_make_circular_signature(sc, 3, 4, sc->T, sc->is_pair_symbol, sc->is_integer_symbol, sc->is_integer_or_any_at_end_symbol)
 
 static no_return void list_set_index_check_nr(s7_scheme *sc, s7_int index)
 {
@@ -31315,30 +31272,6 @@ static s7_pointer list_set_p_pip(s7_scheme *sc, s7_pointer lst, s7_int index, s7
   if (!is_pair(lst))
     wrong_type_error_nr(sc, sc->list_set_symbol, 1, lst, sc->type_names[T_PAIR]);
   return(list_set_p_pip_unchecked(sc, lst, index, value));
-}
-
-static s7_pointer g_list_set_i(s7_scheme *sc, s7_pointer args)
-{
-  const s7_pointer lst = car(args);
-  s7_pointer p = lst;
-  s7_int index;
-  if (!is_mutable_pair(lst))
-    return(mutable_method_or_bust(sc, lst, sc->list_set_symbol, args, sc->type_names[T_PAIR], 1));
-  index = s7_integer_clamped_if_gmp(sc, cadr(args));
-  if ((index < 0) || (index > sc->max_list_length)) list_set_index_check_nr(sc, index);
-
-  for (s7_int i = 0; (i < index) && is_pair(p); i++, p = cdr(p)) {}
-  if (!is_pair(p))
-    {
-      if (is_null(p))
-	out_of_range_error_nr(sc, sc->list_set_symbol, int_two, wrap_integer(sc, index), it_is_too_large_string);
-      wrong_type_error_nr(sc, sc->list_set_symbol, 1, lst, a_proper_list_string);
-    }
-  {
-    s7_pointer val = caddr(args);
-    set_car(p, val);
-    return(val);
-  }
 }
 
 static s7_pointer list_set_chooser(s7_scheme *sc, s7_pointer func, int32_t args, s7_pointer expr)

--- a/src/s7.c
+++ b/src/s7.c
@@ -21511,18 +21511,9 @@ static s7_pointer string_p_p(s7_scheme *sc, s7_pointer c)
 
 /* -------------------------------- list->string -------------------------------- */
 #if !WITH_PURE_S7
-static s7_pointer g_list_to_string(s7_scheme *sc, s7_pointer args)
-{
-  #define H_list_to_string "(list->string lst) appends all the list's characters into one string; (apply string lst)"
-  #define Q_list_to_string s7_make_signature(sc, 2, sc->is_string_symbol, sc->is_proper_list_symbol)
-
-  if (is_null(car(args)))
-    return(nil_string);
-  if (!s7_is_proper_list(sc, car(args)))
-    return(method_or_bust_p(sc, car(args), sc->list_to_string_symbol,
-			    wrap_string(sc, "a (proper, non-circular) list of characters", 43)));
-  return(s7i_string_1(sc, car(args), sc->list_to_string_symbol));
-}
+#define H_list_to_string "(list->string lst) appends all the list's characters into one string; (apply string lst)"
+#define Q_list_to_string s7_make_signature(sc, 2, sc->is_string_symbol, sc->is_proper_list_symbol)
+/* g_list_to_string is now defined in s7_liii_string.c */
 #endif
 
 

--- a/src/s7.c
+++ b/src/s7.c
@@ -21030,25 +21030,10 @@ end: (substring \"01234\" 1 2) -> \"1\""
 #define Q_substring s7_make_signature(sc, 4, sc->is_string_symbol, sc->is_string_symbol, sc->is_integer_symbol, sc->is_integer_symbol)
 /* g_substring is now defined in s7_liii_string.c */
 
-static s7_pointer g_substring_uncopied(s7_scheme *sc, s7_pointer args)
-{
-  #define H_substring_uncopied "(substring-uncopied str start (end (length str))) returns an immutable string sharing the portion of the string str between start and \
+#define H_substring_uncopied "(substring-uncopied str start (end (length str))) returns an immutable string sharing the portion of the string str between start and \
 end: (substring-uncopied \"01234\" 1 2) -> \"1\".  substring-uncopied does not GC protect the original string; it is intended for very brief uses."
-  #define Q_substring_uncopied s7_make_signature(sc, 4, sc->is_string_symbol, sc->is_string_symbol, sc->is_integer_symbol, sc->is_integer_symbol)
-
-  const s7_pointer str = car(args);
-  s7_int start = 0, end;
-
-  if (!is_string(str))
-    return(method_or_bust(sc, str, sc->substring_uncopied_symbol, args, sc->type_names[T_STRING], 1));
-  end = string_length(str);
-  if (!is_null(cdr(args)))
-    {
-      s7_pointer p = start_and_end(sc, sc->substring_uncopied_symbol, args, 2, cdr(args), &start, &end);
-      if (p != sc->unused) return(p);
-    }
-  return(wrap_string(sc, (char *)(string_value(str) + start), end - start));
-}
+#define Q_substring_uncopied s7_make_signature(sc, 4, sc->is_string_symbol, sc->is_string_symbol, sc->is_integer_symbol, sc->is_integer_symbol)
+/* g_substring_uncopied is now defined in s7_liii_string.c */
 
 static s7_pointer substring_uncopied_p_pii(s7_scheme *sc, s7_pointer str, s7_int start, s7_int end)
 {

--- a/src/s7_liii_list.c
+++ b/src/s7_liii_list.c
@@ -142,3 +142,79 @@ s7_pointer g_list(s7_scheme *sc, s7_pointer args)
 {
   return(s7i_copy_proper_list(sc, args));
 }
+
+s7_pointer g_list_set_1(s7_scheme *sc, s7_pointer lst, s7_pointer args, int32_t arg_num)
+{
+  #define H_list_set "(list-set! lst i ... val) sets the i-th element (0-based) of the list to val"
+  #define Q_list_set s7_make_circular_signature(sc, 3, 4, sc->T, sc->is_pair_symbol, sc->is_integer_symbol, sc->is_integer_or_any_at_end_symbol)
+
+  s7_int index;
+  s7_pointer p = lst, ind;
+
+  if (!s7_is_pair(lst) || s7_is_immutable(lst))
+    return(s7_wrong_type_arg_error(sc, "list-set!", 1, lst, "a mutable pair"));
+  ind = s7_car(args);
+  if ((arg_num > 2) && s7_is_null(sc, s7_cdr(args)))
+    {
+      s7_set_car(lst, ind);
+      return(ind);
+    }
+  if (!s7_is_integer(ind))
+    {
+      s7_pointer full_args = s7_cons(sc, lst, args);
+      return(s7i_method_or_bust(sc, ind, "list-set!", full_args, "an integer", 2));
+    }
+  index = s7_integer(ind);
+
+  if (index < 0)
+    return(s7_out_of_range_error(sc, "list-set!", arg_num, ind, "it is negative"));
+  if (index > s7i_max_list_length(sc))
+    return(s7_out_of_range_error(sc, "list-set!", arg_num, ind, "it is too large"));
+
+  for (s7_int i = 0; (i < index) && s7_is_pair(p); i++, p = s7_cdr(p)) {}
+  if (!s7_is_pair(p))
+    {
+      if (s7_is_null(sc, p))
+        return(s7_out_of_range_error(sc, "list-set!", arg_num, ind, "it is too large"));
+      return(s7_wrong_type_arg_error(sc, "list-set!", 1, lst, "a proper list"));
+    }
+  if (s7_is_null(sc, s7_cddr(args)))
+    s7_set_car(p, s7_cadr(args));
+  else
+    {
+      if (!s7_is_pair(s7_car(p)))
+        return(s7_wrong_number_of_args_error(sc, "list-set!", args));
+      return(g_list_set_1(sc, s7_car(p), s7_cdr(args), arg_num + 1));
+    }
+  return(s7_cadr(args));
+}
+
+s7_pointer g_list_set(s7_scheme *sc, s7_pointer args)
+{
+  return(g_list_set_1(sc, s7_car(args), s7_cdr(args), 2));
+}
+
+s7_pointer g_list_set_i(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  s7_pointer p = lst;
+  s7_int index;
+  if (!s7_is_pair(lst) || s7_is_immutable(lst))
+    return(s7_wrong_type_arg_error(sc, "list-set!", 1, lst, "a mutable pair"));
+  index = s7_integer(s7_cadr(args));
+  if ((index < 0) || (index > s7i_max_list_length(sc)))
+    return(s7_out_of_range_error(sc, "list-set!", 2, s7_make_integer(sc, index), "it is negative or too large"));
+
+  for (s7_int i = 0; (i < index) && s7_is_pair(p); i++, p = s7_cdr(p)) {}
+  if (!s7_is_pair(p))
+    {
+      if (s7_is_null(sc, p))
+        return(s7_out_of_range_error(sc, "list-set!", 2, s7_make_integer(sc, index), "it is too large"));
+      return(s7_wrong_type_arg_error(sc, "list-set!", 1, lst, "a proper list"));
+    }
+  {
+    s7_pointer val = s7_caddr(args);
+    s7_set_car(p, val);
+    return(val);
+  }
+}

--- a/src/s7_liii_list.h
+++ b/src/s7_liii_list.h
@@ -29,6 +29,10 @@ s7_pointer g_list_tail(s7_scheme *sc, s7_pointer args);
 s7_pointer g_cons(s7_scheme *sc, s7_pointer args);
 s7_pointer g_list(s7_scheme *sc, s7_pointer args);
 
+s7_pointer g_list_set(s7_scheme *sc, s7_pointer args);
+s7_pointer g_list_set_i(s7_scheme *sc, s7_pointer args);
+s7_pointer g_list_set_1(s7_scheme *sc, s7_pointer lst, s7_pointer args, int32_t arg_num);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/s7_liii_string.c
+++ b/src/s7_liii_string.c
@@ -404,3 +404,19 @@ s7_pointer g_string(s7_scheme *sc, s7_pointer args)
   if (s7_is_null(sc, args)) return(s7i_nil_string());
   return(s7i_string_1(sc, args, s7_make_symbol(sc, "string")));
 }
+
+s7_pointer g_substring_uncopied(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer str = s7_car(args);
+  s7_int start = 0, end;
+
+  if (!s7_is_string(str))
+    return(s7i_method_or_bust(sc, str, "substring-uncopied", args, "a string", 1));
+  end = s7_string_length(str);
+  if (!s7_is_null(sc, s7_cdr(args)))
+    {
+      s7_pointer p = s7i_start_and_end(sc, s7_make_symbol(sc, "substring-uncopied"), args, 2, s7_cdr(args), &start, &end);
+      if (!s7i_is_unused(sc, p)) return(p);
+    }
+  return(s7_make_string_with_length(sc, s7_string(str) + start, end - start));
+}

--- a/src/s7_liii_string.c
+++ b/src/s7_liii_string.c
@@ -420,3 +420,15 @@ s7_pointer g_substring_uncopied(s7_scheme *sc, s7_pointer args)
     }
   return(s7_make_string_with_length(sc, s7_string(str) + start, end - start));
 }
+
+#if !WITH_PURE_S7
+s7_pointer g_list_to_string(s7_scheme *sc, s7_pointer args)
+{
+  if (s7_is_null(sc, s7_car(args)))
+    return(s7i_nil_string());
+  if (!s7_is_proper_list(sc, s7_car(args)))
+    return(s7i_method_or_bust_p(sc, s7_car(args), "list->string",
+                                "a (proper, non-circular) list of characters"));
+  return(s7i_string_1(sc, s7_car(args), s7_make_symbol(sc, "list->string")));
+}
+#endif

--- a/src/s7_liii_string.h
+++ b/src/s7_liii_string.h
@@ -38,6 +38,10 @@ s7_pointer g_char_position_csi(s7_scheme *sc, s7_pointer args);
 
 s7_pointer g_string_position(s7_scheme *sc, s7_pointer args);
 
+#if !WITH_PURE_S7
+s7_pointer g_list_to_string(s7_scheme *sc, s7_pointer args);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/s7_liii_string.h
+++ b/src/s7_liii_string.h
@@ -28,6 +28,7 @@ s7_pointer g_string_fill(s7_scheme *sc, s7_pointer args);
 s7_pointer g_string_to_list(s7_scheme *sc, s7_pointer args);
 s7_pointer g_string_append(s7_scheme *sc, s7_pointer args);
 s7_pointer g_string(s7_scheme *sc, s7_pointer args);
+s7_pointer g_substring_uncopied(s7_scheme *sc, s7_pointer args);
 
 s7_pointer g_is_string(s7_scheme *sc, s7_pointer args);
 


### PR DESCRIPTION
## 摘要

迁移 `s7.c` 中剩余的 hash-table、list、string 相关内置函数到 `s7_liii_*.c`。

## 变更内容

- **s7_liii_string.c**: 新增 `g_substring_uncopied`、`g_list_to_string`
- **s7_liii_list.c**: 新增 `g_list_set`、`g_list_set_i`、`g_list_set_1`
- **s7.c**: 删除对应函数的 static 定义，保留 H/Q 宏和内部快速路径

## 评估保留在 s7.c 的函数

以下函数因与 s7 内部机制深度耦合，保留不动：
- `g_list_values`（quasiquote 内部宏展开逻辑）
- `g_list_append`（GC 栈保护、序列抽象）

## 测试

- `xmake b goldfish` 构建成功
- `bin/gf test --changed-since=main` 全部通过