### PR TITLE
[0047] 迁移 tree 内置函数到 s7_liii_tree.c 和 s7_liii_tree.h

### DIFF
--- a/devel/0047.md
+++ b/devel/0047.md
@@ -1,0 +1,111 @@
+# [0047] 迁移 s7.c 中 tree 相关内置函数到 s7_liii_tree.c 和 s7_liii_tree.h
+
+## 1. 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [0045.md](0045.md) - hash-table/list/string 迁移参考（本文档格式按 dddd.md 模板规范化）
+
+## 2. 任务相关的代码文件
+- `src/s7.c` - s7 解释器主文件，包含 tree 内置函数原始定义
+- `src/s7_liii_tree.c/h` - tree 函数迁移目标文件（新建）
+- `src/s7_internal_helpers.h` - 暴露必要的内部 API 辅助函数
+- `xmake.lua` - 编译配置
+
+## 3. 如何测试
+
+```bash
+xmake b goldfish
+bin/gf tests/liii/tree/tree-cyclic-p-test.scm
+bin/gf tests/liii/tree/tree-leaves-test.scm
+bin/gf tests/liii/tree/tree-memq-test.scm
+bin/gf tests/liii/tree/tree-set-memq-test.scm
+bin/gf tests/liii/tree/tree-count-test.scm
+bin/gf test --changed-since=main
+```
+
+## 4. 迁移策略
+
+### 4.1 核心原则
+
+将 `s7.c` 中的 `static s7_pointer g_xxx` 函数定义迁移到 `s7_liii_tree.c` 中，遵循以下模式：
+
+1. **公开 API 优先**：使用 `s7.h` 中已有的公开 API（如 `s7_is_pair`、`s7_tree_memq` 等）重写函数
+2. **辅助函数桥接**：对于必须使用内部结构的场景，在 `s7_internal_helpers.h` 中暴露 `s7i_xxx` 辅助函数，在 `s7.c` 中实现
+3. **保留注册信息**：`s7.c` 中的 `defun`/`s7_define_typed_function` 注册调用保持不变，仅删除 `static` 函数定义
+4. **保留 H/Q 宏**：对于使用 `defun` 注册的函数，将其 `H_xxx` 和 `Q_xxx` 宏保留在 `s7.c` 中（移到文件作用域）
+5. **快速路径保留**：`_i_7p`、`_p_p`、`_b_7pp`、`_p_pp` 等被内部优化器直接调用的快速路径函数，保留在 `s7.c` 中不动
+
+### 4.2 保留在 s7.c 的内部辅助函数
+
+以下函数被 s7.c 内部广泛调用或被优化器直接设置为快速路径，保留在 `s7.c` 中：
+
+| 函数 | 保留原因 |
+|------|---------|
+| `tree_is_cyclic` / `tree_is_cyclic_1` / `tree_is_cyclic_or_has_pairs` | 被 s7.c 内部广泛调用（GC、copy、优化器、输出等） |
+| `tree_len` / `tree_len_1` | 被 `copy_body`、print 等内部代码调用 |
+| `tree_leaves_i_7p` | 优化器快速路径（`s7_set_i_7p_function`） |
+| `tree_leaves_p_p` | 优化器快速路径（`s7_set_p_p_function`） |
+| `tree_memq_1` | `s7_tree_memq` 的辅助函数 |
+| `tree_memq_b_7pp` | 优化器快速路径（`s7_set_b_7pp_function`） |
+| `tree_including_quote_memq` | `tree-set-memq` 内部辅助 |
+| `pair_set_memq` | `tree-set-memq` 内部辅助 |
+| `tree_set_memq_b_7pp` | `tree-set-memq` 内部核心逻辑 |
+| `tree_set_memq_p_pp` | 优化器快速路径（`s7_set_p_pp_function`） |
+| `tree_set_memq_syms_direct` | 优化器直接设置（`set_opt3_direct`） |
+| `tree_set_memq_chooser` | 优化器 chooser 函数 |
+| `tree_count` | 被 s7.c 内部多处调用（优化器、宏展开等） |
+| `tree_count_at_least` | `g_tree_count` 的辅助函数，依赖 `tree_count` |
+
+### 4.3 需要暴露的内部辅助函数
+
+| 辅助函数 | 用途 | 被谁调用 |
+|---------|------|---------|
+| `s7i_tree_is_cyclic(sc, tree)` | 包装 `tree_is_cyclic` | `g_tree_is_cyclic` |
+| `s7i_tree_leaves_p_p(sc, tree)` | 包装 `tree_leaves_p_p` | `g_tree_leaves` |
+| `s7i_tree_memq_b_7pp(sc, sym, tree)` | 包装 `tree_memq_b_7pp` | `g_tree_memq` |
+| `s7i_tree_set_memq_p_pp(sc, syms, tree)` | 包装 `tree_set_memq_p_pp` | `g_tree_set_memq` |
+| `s7i_tree_set_memq_syms_direct(sc, syms, tree)` | 包装 `tree_set_memq_syms_direct` | `g_tree_set_memq_syms` |
+| `s7i_tree_count(sc, obj, tree, count)` | 包装 `tree_count` | `g_tree_count` |
+| `s7i_tree_count_at_least(sc, obj, tree, count, top)` | 包装 `tree_count_at_least` | `g_tree_count` |
+
+### 4.4 批次计划
+
+**Batch 1：`g_tree_is_cyclic`**
+- 仅依赖 `tree_is_cyclic`，逻辑最简单
+- 暴露 `s7i_tree_is_cyclic`
+
+**Batch 2：`g_tree_leaves` + `g_tree_memq`**
+- `g_tree_leaves` 依赖 `tree_leaves_p_p`
+- `g_tree_memq` 依赖 `tree_memq_b_7pp` 和公开 API `s7_tree_memq`
+- 暴露 `s7i_tree_leaves_p_p`、`s7i_tree_memq_b_7pp`
+
+**Batch 3：`g_tree_set_memq` + `g_tree_set_memq_syms`**
+- `g_tree_set_memq` 依赖 `tree_set_memq_p_pp`
+- `g_tree_set_memq_syms` 依赖 `tree_set_memq_syms_direct`
+- 暴露 `s7i_tree_set_memq_p_pp`、`s7i_tree_set_memq_syms_direct`
+
+**Batch 4：`g_tree_count`**
+- 逻辑最复杂，依赖 `tree_count` 和 `tree_count_at_least`
+- 暴露 `s7i_tree_count`、`s7i_tree_count_at_least`
+
+## 5. 执行记录
+
+### 5.1 What（已完成 / 待完成）
+
+1. 新建 `src/s7_liii_tree.c` 和 `src/s7_liii_tree.h`
+2. 在 `xmake.lua` 中添加 `src/s7_liii_tree.c`
+3. 在 `src/s7.c` 中添加 `#include "s7_liii_tree.h"`
+4. 在 `src/s7_internal_helpers.h` 中暴露 `s7i_xxx` 辅助函数
+5. 按批次迁移 `g_xxx` 函数，保留 H/Q 宏和快速路径在 `s7.c`
+6. 构建并运行 tree 相关测试用例验证
+
+### 5.2 Why
+
+- `s7.c` 文件过大，需要按功能模块拆分内置函数
+- tree 函数（`tree-leaves`、`tree-memq`、`tree-set-memq`、`tree-count`、`tree-cyclic?`）是一组完整的树操作 API，适合独立成模块
+- 与 0045 中 hash-table、list、string 的迁移保持一致性
+
+### 5.3 How
+
+- 保留内部核心工具（`tree_is_cyclic`、`tree_len`、`tree_count` 等）和优化器快速路径在 `s7.c`，通过 `s7_internal_helpers.h` 暴露薄包装给 `s7_liii_tree.c`
+- `g_xxx` 函数使用公开 API 或暴露的辅助函数在 `s7_liii_tree.c` 中重新实现
+- `s7.c` 中的 `defun` 注册调用和 `sc->tree_set_memq_syms = make_function_with_class(...)` 等引用 `g_xxx` 函数指针的代码，通过 `#include "s7_liii_tree.h"` 获取声明

--- a/src/s7.c
+++ b/src/s7.c
@@ -408,6 +408,7 @@
 #include "s7_liii_hash_table.h"
 #include "s7_liii_list.h"
 #include "s7_liii_vector.h"
+#include "s7_liii_tree.h"
 #include "s7_module.h"
 
 /* there is also apparently __STDC_NO_COMPLEX__ */
@@ -11817,12 +11818,14 @@ static bool tree_is_cyclic(s7_scheme *sc, s7_pointer tree)
   return(result);
 }
 
-static s7_pointer g_tree_is_cyclic(s7_scheme *sc, s7_pointer args)
+bool s7i_tree_is_cyclic(s7_scheme *sc, s7_pointer tree)
 {
-  #define H_tree_is_cyclic "(tree-cyclic? tree) returns #t if the tree has a cycle."
-  #define Q_tree_is_cyclic sc->pl_bt
-  return(make_boolean(sc, tree_is_cyclic(sc, car(args))));
+  return(tree_is_cyclic(sc, tree));
 }
+
+/* g_tree_is_cyclic is now defined in s7_liii_tree.c */
+#define H_tree_is_cyclic "(tree-cyclic? tree) returns #t if the tree has a cycle."
+#define Q_tree_is_cyclic sc->pl_bt
 
 static inline s7_int tree_len(s7_scheme *sc, s7_pointer p);
 
@@ -30669,12 +30672,14 @@ static s7_pointer tree_leaves_p_p(s7_scheme *sc, s7_pointer tree)
   return(method_or_bust_p(sc, tree, sc->tree_leaves_symbol, a_list_string));
 }
 
-static s7_pointer g_tree_leaves(s7_scheme *sc, s7_pointer args)
+s7_pointer s7i_tree_leaves_p_p(s7_scheme *sc, s7_pointer tree)
 {
-  #define H_tree_leaves "(tree-leaves tree) returns the number of leaves in the tree"
-  #define Q_tree_leaves s7_make_signature(sc, 2, sc->is_integer_symbol, sc->is_list_symbol)
-  return(tree_leaves_p_p(sc, car(args)));
+  return(tree_leaves_p_p(sc, tree));
 }
+
+/* g_tree_leaves is now defined in s7_liii_tree.c */
+#define H_tree_leaves "(tree-leaves tree) returns the number of leaves in the tree"
+#define Q_tree_leaves s7_make_signature(sc, 2, sc->is_integer_symbol, sc->is_list_symbol)
 
 
 /* ---------------- tree-memq ---------------- */
@@ -30731,12 +30736,14 @@ static bool tree_memq_b_7pp(s7_scheme *sc, s7_pointer sym, s7_pointer tree)
   return(s7_tree_memq(sc, sym, tree));
 }
 
-static s7_pointer g_tree_memq(s7_scheme *sc, s7_pointer args)
+bool s7i_tree_memq_b_7pp(s7_scheme *sc, s7_pointer sym, s7_pointer tree)
 {
-  #define H_tree_memq "(tree-memq obj tree) is a tree-oriented version of memq, but returning #t if the object is in the tree."
-  #define Q_tree_memq s7_make_signature(sc, 3, sc->is_boolean_symbol, sc->T, sc->is_list_symbol)
-  return(make_boolean(sc, tree_memq_b_7pp(sc, car(args), cadr(args))));
+  return(tree_memq_b_7pp(sc, sym, tree));
 }
+
+/* g_tree_memq is now defined in s7_liii_tree.c */
+#define H_tree_memq "(tree-memq obj tree) is a tree-oriented version of memq, but returning #t if the object is in the tree."
+#define Q_tree_memq s7_make_signature(sc, 3, sc->is_boolean_symbol, sc->T, sc->is_list_symbol)
 
 static /* inline */ bool tree_including_quote_memq(s7_scheme *sc, s7_pointer sym, s7_pointer tree)    /* sym need not be a symbol */
 {
@@ -30833,12 +30840,14 @@ static s7_pointer tree_set_memq_p_pp(s7_scheme *sc, s7_pointer syms, s7_pointer 
   return(make_boolean(sc, tree_set_memq_b_7pp(sc, syms, tree)));
 }
 
-static s7_pointer g_tree_set_memq(s7_scheme *sc, s7_pointer args)
+s7_pointer s7i_tree_set_memq_p_pp(s7_scheme *sc, s7_pointer syms, s7_pointer tree)
 {
-  #define H_tree_set_memq "(tree-set-memq symbols tree) returns #t if any of the list of symbols is in the tree"
-  #define Q_tree_set_memq s7_make_signature(sc, 3, sc->is_boolean_symbol, sc->is_list_symbol, sc->is_list_symbol)
-  return(make_boolean(sc, tree_set_memq_b_7pp(sc, car(args), cadr(args))));
+  return(tree_set_memq_p_pp(sc, syms, tree));
 }
+
+/* g_tree_set_memq is now defined in s7_liii_tree.c */
+#define H_tree_set_memq "(tree-set-memq symbols tree) returns #t if any of the list of symbols is in the tree"
+#define Q_tree_set_memq s7_make_signature(sc, 3, sc->is_boolean_symbol, sc->is_list_symbol, sc->is_list_symbol)
 
 static s7_pointer tree_set_memq_syms_direct(s7_scheme *sc, s7_pointer syms, s7_pointer tree)
 {
@@ -30862,10 +30871,12 @@ static s7_pointer tree_set_memq_syms_direct(s7_scheme *sc, s7_pointer syms, s7_p
   }
 }
 
-static s7_pointer g_tree_set_memq_syms(s7_scheme *sc, s7_pointer args)
+s7_pointer s7i_tree_set_memq_syms_direct(s7_scheme *sc, s7_pointer syms, s7_pointer tree)
 {
-  return(tree_set_memq_syms_direct(sc, car(args), cadr(args))); /* need other form for pp */
+  return(tree_set_memq_syms_direct(sc, syms, tree));
 }
+
+/* g_tree_set_memq_syms is now defined in s7_liii_tree.c */
 
 static s7_pointer tree_set_memq_chooser(s7_scheme *sc, s7_pointer func, int32_t unused_args, s7_pointer expr)
 {
@@ -30889,6 +30900,11 @@ static s7_int tree_count(s7_scheme *sc, s7_pointer obj, s7_pointer tree, s7_int 
   return(tree_count(sc, obj, cdr(tree), tree_count(sc, obj, car(tree), count)));
 }
 
+s7_int s7i_tree_count(s7_scheme *sc, s7_pointer obj, s7_pointer tree, s7_int count)
+{
+  return(tree_count(sc, obj, tree, count));
+}
+
 static inline s7_int tree_count_at_least(s7_scheme *sc, s7_pointer obj, s7_pointer tree, s7_int count, s7_int top)
 {
   if (tree == obj) return(count + 1);
@@ -30902,32 +30918,14 @@ static inline s7_int tree_count_at_least(s7_scheme *sc, s7_pointer obj, s7_point
   return(count);
 }
 
-static s7_pointer g_tree_count(s7_scheme *sc, s7_pointer args)
+s7_int s7i_tree_count_at_least(s7_scheme *sc, s7_pointer obj, s7_pointer tree, s7_int count, s7_int top)
 {
-  #define H_tree_count "(tree-count obj tree max-count) returns how many times obj is in tree (using eq?), stopping at max-count (if specified)"
-  #define Q_tree_count s7_make_signature(sc, 4, sc->is_integer_symbol, sc->T, sc->is_list_symbol, sc->is_integer_symbol)
-  const s7_pointer obj = car(args), tree = cadr(args);
-  s7_pointer count;
-
-  if (!is_pair(tree))
-    {
-      if ((is_pair(cddr(args))) &&
-	  (!s7_is_integer(caddr(args))))
-	wrong_type_error_nr(sc, sc->tree_count_symbol, 3, caddr(args), sc->type_names[T_INTEGER]);
-      if (is_null(tree)) return(int_zero);
-      if (!has_active_methods(sc, tree))
-	wrong_type_error_nr(sc, sc->tree_count_symbol, 2, tree, a_list_string);
-      return(find_and_apply_method(sc, tree, sc->tree_count_symbol, set_mlist_2(sc, obj, tree)));
-    }
-  if ((sc->safety > no_safety) && (tree_is_cyclic(sc, tree)))
-    error_nr(sc, sc->wrong_type_arg_symbol, set_elist_2(sc, wrap_string(sc, "tree-count: tree is cyclic: ~S", 30), tree));
-  if (is_null(cddr(args)))
-    return(make_integer(sc, tree_count(sc, obj, tree, 0)));
-  count = caddr(args);
-  if (!s7_is_integer(count))
-    wrong_type_error_nr(sc, sc->tree_count_symbol, 3, count, sc->type_names[T_INTEGER]);
-  return(make_integer(sc, tree_count_at_least(sc, obj, tree, 0, s7_integer_clamped_if_gmp(sc, count))));
+  return(tree_count_at_least(sc, obj, tree, count, top));
 }
+
+/* g_tree_count is now defined in s7_liii_tree.c */
+#define H_tree_count "(tree-count obj tree max-count) returns how many times obj is in tree (using eq?), stopping at max-count (if specified)"
+#define Q_tree_count s7_make_signature(sc, 4, sc->is_integer_symbol, sc->T, sc->is_list_symbol, sc->is_integer_symbol)
 
 
 /* -------------------------------- pair? -------------------------------- */

--- a/src/s7_internal_helpers.h
+++ b/src/s7_internal_helpers.h
@@ -87,6 +87,15 @@ bool s7i_is_weak_hash_table(s7_pointer p);
 void s7i_set_weak_hash_table(s7_pointer p);
 void s7i_set_weak_hash_table_iters(s7_pointer p, s7_int val);
 
+/* tree helpers */
+bool s7i_tree_is_cyclic(s7_scheme *sc, s7_pointer tree);
+s7_pointer s7i_tree_leaves_p_p(s7_scheme *sc, s7_pointer tree);
+bool s7i_tree_memq_b_7pp(s7_scheme *sc, s7_pointer sym, s7_pointer tree);
+s7_pointer s7i_tree_set_memq_p_pp(s7_scheme *sc, s7_pointer syms, s7_pointer tree);
+s7_pointer s7i_tree_set_memq_syms_direct(s7_scheme *sc, s7_pointer syms, s7_pointer tree);
+s7_int s7i_tree_count(s7_scheme *sc, s7_pointer obj, s7_pointer tree, s7_int count);
+s7_int s7i_tree_count_at_least(s7_scheme *sc, s7_pointer obj, s7_pointer tree, s7_int count, s7_int top);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/s7_liii_tree.c
+++ b/src/s7_liii_tree.c
@@ -1,0 +1,62 @@
+/* s7_liii_tree.c - tree utility implementations for s7 Scheme interpreter
+ *
+ * derived from s7, a Scheme interpreter
+ * SPDX-License-Identifier: 0BSD
+ *
+ * Bill Schottstaedt, bil@ccrma.stanford.edu
+ */
+
+#include "s7_liii_tree.h"
+#include "s7_internal_helpers.h"
+
+s7_pointer g_tree_is_cyclic(s7_scheme *sc, s7_pointer args)
+{
+  return(s7_make_boolean(sc, s7i_tree_is_cyclic(sc, s7_car(args))));
+}
+
+s7_pointer g_tree_leaves(s7_scheme *sc, s7_pointer args)
+{
+  return(s7i_tree_leaves_p_p(sc, s7_car(args)));
+}
+
+s7_pointer g_tree_memq(s7_scheme *sc, s7_pointer args)
+{
+  return(s7_make_boolean(sc, s7i_tree_memq_b_7pp(sc, s7_car(args), s7_cadr(args))));
+}
+
+s7_pointer g_tree_set_memq(s7_scheme *sc, s7_pointer args)
+{
+  return(s7i_tree_set_memq_p_pp(sc, s7_car(args), s7_cadr(args)));
+}
+
+s7_pointer g_tree_set_memq_syms(s7_scheme *sc, s7_pointer args)
+{
+  return(s7i_tree_set_memq_syms_direct(sc, s7_car(args), s7_cadr(args)));
+}
+
+s7_pointer g_tree_count(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer obj = s7_car(args);
+  s7_pointer tree = s7_cadr(args);
+  s7_pointer count;
+
+  if (!s7_is_pair(tree))
+    {
+      if ((s7_is_pair(s7_cddr(args))) &&
+          (!s7_is_integer(s7_caddr(args))))
+        return(s7_wrong_type_arg_error(sc, "tree-count", 3, s7_caddr(args), "an integer"));
+      if (s7_is_null(sc, tree)) return(s7_make_integer(sc, 0));
+      if (!s7i_has_active_methods(sc, tree))
+        return(s7_wrong_type_arg_error(sc, "tree-count", 2, tree, "a list"));
+      return(s7i_method_or_bust_pp(sc, tree, "tree-count", obj, tree, "a list", 2));
+    }
+  if (s7i_tree_is_cyclic(sc, tree))
+    return(s7_error(sc, s7_make_symbol(sc, "wrong-type-arg"),
+                    s7_list(sc, 2, s7_make_string(sc, "tree-count: tree is cyclic: ~S"), tree)));
+  if (s7_is_null(sc, s7_cddr(args)))
+    return(s7_make_integer(sc, s7i_tree_count(sc, obj, tree, 0)));
+  count = s7_caddr(args);
+  if (!s7_is_integer(count))
+    return(s7_wrong_type_arg_error(sc, "tree-count", 3, count, "an integer"));
+  return(s7_make_integer(sc, s7i_tree_count_at_least(sc, obj, tree, 0, s7_integer(count))));
+}

--- a/src/s7_liii_tree.h
+++ b/src/s7_liii_tree.h
@@ -1,0 +1,29 @@
+/* s7_liii_tree.h - tree utility declarations for s7 Scheme interpreter
+ *
+ * derived from s7, a Scheme interpreter
+ * SPDX-License-Identifier: 0BSD
+ *
+ * Bill Schottstaedt, bil@ccrma.stanford.edu
+ */
+
+#ifndef S7_LIII_TREE_H
+#define S7_LIII_TREE_H
+
+#include "s7.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+s7_pointer g_tree_is_cyclic(s7_scheme *sc, s7_pointer args);
+s7_pointer g_tree_leaves(s7_scheme *sc, s7_pointer args);
+s7_pointer g_tree_memq(s7_scheme *sc, s7_pointer args);
+s7_pointer g_tree_set_memq(s7_scheme *sc, s7_pointer args);
+s7_pointer g_tree_set_memq_syms(s7_scheme *sc, s7_pointer args);
+s7_pointer g_tree_count(s7_scheme *sc, s7_pointer args);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* S7_LIII_TREE_H */

--- a/xmake.lua
+++ b/xmake.lua
@@ -112,6 +112,7 @@ target ("goldfish") do
     add_files ("src/s7_liii_hash_table.c", {languages = "c11"})
     add_files ("src/s7_liii_list.c", {languages = "c11"})
     add_files ("src/s7_liii_vector.c", {languages = "c11"})
+    add_files ("src/s7_liii_tree.c", {languages = "c11"})
     add_files ("src/s7_module.c", {languages = "c11"})
     add_files ("src/s7_scheme_inexact.c", {languages = "c11"})
     add_files ("src/s7_scheme_base.c", {languages = "c11"})


### PR DESCRIPTION
## Summary
- 将 s7.c 中 tree 相关内置函数迁移到 s7_liii_tree.c 和 s7_liii_tree.h
- 保留内部核心工具（tree_is_cyclic、tree_len、tree_count 等）和优化器快速路径在 s7.c
- 通过 s7_internal_helpers.h 暴露 s7i_xxx 辅助函数桥接
- 新建 s7_liii_tree.c/h，修改 xmake.lua 添加编译配置

## Test plan
- [x] xmake b goldfish 构建通过
- [x] bin/gf tests/liii/tree/tree-cyclic-p-test.scm (5 checks passed)
- [x] bin/gf tests/liii/tree/tree-leaves-test.scm (7 checks passed)
- [x] bin/gf tests/liii/tree/tree-memq-test.scm (7 checks passed)
- [x] bin/gf tests/liii/tree/tree-set-memq-test.scm (7 checks passed)
- [x] bin/gf tests/liii/tree/tree-count-test.scm (10 checks passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)