### PR TITLE
[0051] Migrate max/min builtins to s7_scheme_base.c

### DIFF
--- a/devel/0051.md
+++ b/devel/0051.md
@@ -1,0 +1,56 @@
+# [0051] 迁移 max/min 内置函数到 s7_scheme_base.c
+
+## 相关文档
+- [0047.md](0047.md) - 前期 vector 迁移任务
+- [s7_migration.md](../s7_migration.md) - s7.c 分组迁移总策略
+
+## 任务相关的代码文件
+- `src/s7.c` - s7 解释器主文件，包含 `max_p_pp`/`min_p_pp` 核心比较逻辑
+- `src/s7_scheme_base.c/h` - max/min 函数迁移目标文件
+- `src/s7_internal_helpers.h` - 暴露 `max_p_pp`/`min_p_pp` 的内部 API 桥接声明
+
+## 如何测试
+
+### 编译测试
+```bash
+xmake b goldfish
+```
+
+### 功能测试
+```bash
+bin/gf -e "(max 1 2 3)"
+bin/gf -e "(min 1 2 3)"
+bin/gf -e "(max 1/2 1/3)"
+bin/gf -e "(min 1/2 1/3)"
+bin/gf -e "(max 1 2.5 3/2)"
+bin/gf -e "(min 1 2.5 3/2)"
+bin/gf -e "(max -5 -10)"
+bin/gf -e "(min -5 -10)"
+```
+
+### 回归测试
+```bash
+bin/gf test base
+```
+
+## 迁移策略
+
+### 保留在 s7.c 中的代码
+
+`max_p_pp` 和 `min_p_pp` 使用大量 s7 内部宏（`type()`、`integer()`、`real()`、`fraction()`、`is_t_integer`、`is_t_real`、`is_t_ratio` 等），无法在不暴露内部 cell 布局的情况下迁移到新文件，因此保留在 `s7.c` 中，但去掉 `static` 关键字，通过 `s7_internal_helpers.h` 对外声明。
+
+`max_chooser`/`min_chooser` 以及 `g_max_2`/`g_max_3`/`g_min_2`/`g_min_3` 与 `sc->max_2`/`sc->max_3`/`sc->min_2`/`sc->min_3` 等内部字段紧密耦合，保留在 `s7.c` 中。
+
+辅助函数 `max_i_ii`、`max_d_dd` 等仅在 `s7.c` 中被引用，保留在原处。
+
+### 迁移到 s7_scheme_base.c 的代码
+
+- `g_max` / `g_min`：入口函数，使用公开 API 重写
+  - `car`/`cdr`/`is_null`/`is_pair` → `s7_car`/`s7_cdr`/`s7_is_null`/`s7_is_pair`
+  - `method_or_bust_p` → `s7_wrong_type_arg_error`
+  - `is_real` → `s7_is_real`
+- `g_max_2` / `g_max_3` / `g_min_2` / `g_min_3`：2/3 参数优化版本，使用 `s7_cadr`/`s7_caddr` 替换内部宏
+
+### s7.c 中的函数注册调整
+
+由于 `H_max`、`Q_max`、`H_min`、`Q_min` 宏随 `g_max`/`g_min` 一起迁移到新文件，s7.c 中原有的 `defun("s7-max", max, ...)` 和 `defun("s7-min", min, ...)` 调用改为直接展开为 `s7_define_typed_function(...)`。

--- a/src/s7.c
+++ b/src/s7.c
@@ -18736,7 +18736,7 @@ static bool is_real_via_method_1(s7_scheme *sc, s7_pointer p)
 #define max_out_x(Sc, X, Y) method_or_bust_pp(Sc, X, Sc->max_symbol, X, Y, Sc->type_names[T_REAL], 1)
 #define max_out_y(Sc, X, Y) method_or_bust_pp(Sc, Y, Sc->max_symbol, X, Y, Sc->type_names[T_REAL], 2)
 
-static s7_pointer max_p_pp(s7_scheme *sc, s7_pointer x, s7_pointer y)
+s7_pointer max_p_pp(s7_scheme *sc, s7_pointer x, s7_pointer y)
 {
   /* same basic code as lt_b_7_pp (or any relop) but max returns NaN if NaN encountered, and methods for < and max return
    *    different results, so it seems simpler to repeat the other code.
@@ -18792,25 +18792,6 @@ static s7_pointer max_p_pp(s7_scheme *sc, s7_pointer x, s7_pointer y)
   return(x);
 }
 
-static s7_pointer g_max(s7_scheme *sc, s7_pointer args)
-{
-  #define H_max "(max ...) returns the maximum of its arguments"
-  #define Q_max sc->pcl_r
-
-  s7_pointer x = car(args);
-  if (is_null(cdr(args)))
-    {
-      if (is_real(x)) return(x);
-      return(method_or_bust_p(sc, x, sc->max_symbol, sc->type_names[T_REAL]));
-    }
-  for (s7_pointer nums = cdr(args); is_pair(nums); nums = cdr(nums))
-    x = max_p_pp(sc, x, car(nums));
-  return(x);
-}
-
-static s7_pointer g_max_2(s7_scheme *sc, s7_pointer args) {return(max_p_pp(sc, car(args), cadr(args)));}
-static s7_pointer g_max_3(s7_scheme *sc, s7_pointer args) {return(max_p_pp(sc, max_p_pp(sc, car(args), cadr(args)), caddr(args)));}
-
 static s7_pointer max_chooser(s7_scheme *sc, s7_pointer func, int32_t args, s7_pointer unused_expr)
 {
   return((args == 2) ? sc->max_2 : ((args == 3) ? sc->max_3 : func));
@@ -18827,7 +18808,7 @@ static s7_double max_d_dddd(s7_double x1, s7_double x2, s7_double x3, s7_double 
 #define min_out_x(Sc, X, Y) method_or_bust_pp(Sc, X, Sc->min_symbol, X, Y, Sc->type_names[T_REAL], 1)
 #define min_out_y(Sc, X, Y) method_or_bust_pp(Sc, Y, Sc->min_symbol, X, Y, Sc->type_names[T_REAL], 2)
 
-static s7_pointer min_p_pp(s7_scheme *sc, s7_pointer x, s7_pointer y)
+s7_pointer min_p_pp(s7_scheme *sc, s7_pointer x, s7_pointer y)
 {
   if (type(x) == type(y))
     {
@@ -18877,25 +18858,6 @@ static s7_pointer min_p_pp(s7_scheme *sc, s7_pointer x, s7_pointer y)
     }
   return(x);
 }
-
-static s7_pointer g_min(s7_scheme *sc, s7_pointer args)
-{
-  #define H_min "(min ...) returns the minimum of its arguments"
-  #define Q_min sc->pcl_r
-
-  s7_pointer x = car(args);
-  if (is_null(cdr(args)))
-    {
-      if (is_real(x)) return(x);
-      return(method_or_bust_p(sc, x, sc->min_symbol, sc->type_names[T_REAL]));
-    }
-  for (s7_pointer nums = cdr(args); is_pair(nums); nums = cdr(nums))
-    x = min_p_pp(sc, x, car(nums));
-  return(x);
-}
-
-static s7_pointer g_min_2(s7_scheme *sc, s7_pointer args) {return(min_p_pp(sc, car(args), cadr(args)));}
-static s7_pointer g_min_3(s7_scheme *sc, s7_pointer args) {return(min_p_pp(sc, min_p_pp(sc, car(args), cadr(args)), caddr(args)));}
 
 static s7_pointer min_chooser(s7_scheme *sc, s7_pointer func, int32_t args, s7_pointer unused_expr)
 {
@@ -91080,8 +91042,8 @@ static void init_rootlet(s7_scheme *sc)
   sc->subtract_symbol =              defun("-",		        subtract,		1, 0, true); set_all_integer_and_float(sc->subtract_symbol);
   sc->multiply_symbol =              defun("*",		        multiply,		0, 0, true); set_all_integer_and_float(sc->multiply_symbol);
   sc->divide_symbol =                defun("/",		        divide,			1, 0, true); set_all_float(sc->divide_symbol);
-  sc->min_symbol =                   defun("s7-min",		min,			1, 0, true); set_all_integer_and_float(sc->min_symbol);
-  sc->max_symbol =                   defun("s7-max",		max,			1, 0, true); set_all_integer_and_float(sc->max_symbol);
+  sc->min_symbol =                   s7_define_typed_function(sc, "s7-min", g_min, 1, 0, true, "(min ...) returns the minimum of its arguments", sc->pcl_r); set_all_integer_and_float(sc->min_symbol);
+  sc->max_symbol =                   s7_define_typed_function(sc, "s7-max", g_max, 1, 0, true, "(max ...) returns the maximum of its arguments", sc->pcl_r); set_all_integer_and_float(sc->max_symbol);
 
   sc->quotient_symbol =              defun("quotient",		quotient,		2, 0, false); set_all_integer(sc->quotient_symbol);
   sc->remainder_symbol =             defun("remainder",	        remainder,		2, 0, false); set_all_integer(sc->remainder_symbol);

--- a/src/s7_internal_helpers.h
+++ b/src/s7_internal_helpers.h
@@ -55,6 +55,10 @@ bool s7i_is_unused(s7_scheme *sc, s7_pointer p);
 s7_pointer s7i_method_or_bust_p(s7_scheme *sc, s7_pointer obj, const char *method_name, const char *type_name);
 s7_pointer s7i_method_or_bust_pp(s7_scheme *sc, s7_pointer obj, const char *method_name, s7_pointer x1, s7_pointer x2, const char *type_name, s7_int arg_pos);
 
+/* max/min core comparison functions (use internal macros, must stay in s7.c) */
+s7_pointer max_p_pp(s7_scheme *sc, s7_pointer x, s7_pointer y);
+s7_pointer min_p_pp(s7_scheme *sc, s7_pointer x, s7_pointer y);
+
 bool s7i_is_subvector(s7_pointer p);
 s7_int s7i_subvector_position(s7_pointer p);
 s7_pointer s7i_subvector_vector(s7_scheme *sc, s7_pointer p);

--- a/src/s7_scheme_base.c
+++ b/src/s7_scheme_base.c
@@ -7,6 +7,7 @@
  */
 
 #include "s7_scheme_base.h"
+#include "s7_internal_helpers.h"
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
@@ -841,3 +842,45 @@ s7_pointer g_read_line(s7_scheme *sc, s7_pointer args)
     }
   return s7i_port_read_line(sc, port, with_eol);
 }
+
+/* ---------------------------------------- max ---------------------------------------- */
+
+s7_pointer g_max(s7_scheme *sc, s7_pointer args)
+{
+  #define H_max "(max ...) returns the maximum of its arguments"
+  #define Q_max sc->pcl_r
+
+  s7_pointer x = s7_car(args);
+  if (s7_is_null(sc, s7_cdr(args)))
+    {
+      if (s7_is_real(x)) return(x);
+      return s7_wrong_type_arg_error(sc, "max", 1, x, "a real number");
+    }
+  for (s7_pointer nums = s7_cdr(args); s7_is_pair(nums); nums = s7_cdr(nums))
+    x = max_p_pp(sc, x, s7_car(nums));
+  return(x);
+}
+
+s7_pointer g_max_2(s7_scheme *sc, s7_pointer args) {return(max_p_pp(sc, s7_car(args), s7_cadr(args)));}
+s7_pointer g_max_3(s7_scheme *sc, s7_pointer args) {return(max_p_pp(sc, max_p_pp(sc, s7_car(args), s7_cadr(args)), s7_caddr(args)));}
+
+/* ---------------------------------------- min ---------------------------------------- */
+
+s7_pointer g_min(s7_scheme *sc, s7_pointer args)
+{
+  #define H_min "(min ...) returns the minimum of its arguments"
+  #define Q_min sc->pcl_r
+
+  s7_pointer x = s7_car(args);
+  if (s7_is_null(sc, s7_cdr(args)))
+    {
+      if (s7_is_real(x)) return(x);
+      return s7_wrong_type_arg_error(sc, "min", 1, x, "a real number");
+    }
+  for (s7_pointer nums = s7_cdr(args); s7_is_pair(nums); nums = s7_cdr(nums))
+    x = min_p_pp(sc, x, s7_car(nums));
+  return(x);
+}
+
+s7_pointer g_min_2(s7_scheme *sc, s7_pointer args) {return(min_p_pp(sc, s7_car(args), s7_cadr(args)));}
+s7_pointer g_min_3(s7_scheme *sc, s7_pointer args) {return(min_p_pp(sc, min_p_pp(sc, s7_car(args), s7_cadr(args)), s7_caddr(args)));}

--- a/src/s7_scheme_base.h
+++ b/src/s7_scheme_base.h
@@ -104,6 +104,16 @@ double s7_string_to_double_simple(const char *str, int32_t radix);
 /* read-line function */
 s7_pointer g_read_line(s7_scheme *sc, s7_pointer args);
 
+/* max function */
+s7_pointer g_max(s7_scheme *sc, s7_pointer args);
+s7_pointer g_max_2(s7_scheme *sc, s7_pointer args);
+s7_pointer g_max_3(s7_scheme *sc, s7_pointer args);
+
+/* min function */
+s7_pointer g_min(s7_scheme *sc, s7_pointer args);
+s7_pointer g_min_2(s7_scheme *sc, s7_pointer args);
+s7_pointer g_min_3(s7_scheme *sc, s7_pointer args);
+
 /* Helper functions exported from s7.c */
 const char *s7i_an_input_port_string(void);
 const char *s7i_a_boolean_string(void);


### PR DESCRIPTION
## 变更摘要

迁移 `max`/`min` 内置函数的入口函数及 2/3 参数优化版本到 `s7_scheme_base.c`，核心比较逻辑保留在 `s7.c` 中。

### 保留在 s7.c 中
- `max_p_pp` / `min_p_pp`：核心比较逻辑，依赖内部宏（`type()`、`integer()`、`real()`、`fraction()` 等），去掉 `static` 后通过 `s7_internal_helpers.h` 对外声明
- `max_chooser` / `min_chooser` 及辅助函数：与 `sc->max_2` 等内部字段耦合

### 迁移到 s7_scheme_base.c
- `g_max` / `g_min`：使用公开 API 重写（`s7_car`、`s7_cdr`、`s7_is_real`、`s7_wrong_type_arg_error` 等）
- `g_max_2` / `g_max_3` / `g_min_2` / `g_min_3`：使用 `s7_cadr` / `s7_caddr` 替换内部宏

### 测试
- 编译通过
- `bin/gf test base`：237 个测试全部通过