### PR TITLE
[0053] 修正 (scheme base) 和 (scheme write) 越界导出函数

### DIFF
--- a/devel/0053.md
+++ b/devel/0053.md
@@ -70,16 +70,49 @@ bin/gf doc char-ready?
 - `tests/scheme/base/write-char-test.scm` 目前不存在，后续可补充 `write-char` 的独立测试文件
 - `write-char` 仅在 `(scheme base)` 中导出，`(scheme write)` 不再重复导出
 
+## 2026/05/28 修正 (scheme base) 越界导出和 (scheme write) 越界导出
+
+### What
+
+1. 从 `(scheme base)` 的 export 列表中移除属于 `(scheme write)` 的函数：`display`、`write`、`write-shared`、`write-simple`
+2. 从 `(scheme write)` 的 export 列表中移除属于 `(scheme base)` 的函数：`newline`
+3. 将 `newline` 的测试文件从 `tests/scheme/write/` 移动到 `tests/scheme/base/`，并更新 import 为 `(scheme base)`
+4. 运行 `bin/gf doc --build-json` 重建函数索引
+
+### Why
+
+- R7RS 标准中 `display`、`write` 等属于 `(scheme write)`，不应在 `(scheme base)` 中导出
+- `newline` 属于 `(scheme base)`，不应在 `(scheme write)` 中导出
+- 越界导出导致 `bin/gf doc` 文档系统无法正确定位函数的测试文件（例如 `bin/gf doc "write"` 找不到文档）
+
+### How
+
+1. 检查 `(scheme base)` export 列表与 R7RS 标准的对应关系
+2. 移除越界导出的函数，确保每个函数只在其所属的库中导出
+3. 将 `newline-test.scm` 移动到正确的目录 `tests/scheme/base/`
+4. 重建索引并验证 `bin/gf doc "write"`、`bin/gf doc "display"`、`bin/gf doc "newline"` 等均可正常输出
+
 ### 提交步骤
 
 ```bash
-# 1. 运行测试
-bin/gf test tests/scheme/base/
+# 1. 格式化代码
+bin/gf fmt goldfish/scheme/base.scm
+bin/gf fmt goldfish/scheme/write.scm
+bin/gf fmt tests/scheme/base/newline-test.scm
 
-# 2. 重建文档索引
+# 2. 运行测试
+bin/gf tests/scheme/base/newline-test.scm
+bin/gf tests/scheme/write/display-test.scm
+bin/gf tests/scheme/write/write-test.scm
+bin/gf tests/scheme/write/write-simple-test.scm
+bin/gf tests/scheme/write/write-shared-test.scm
+
+# 3. 重建文档索引
 bin/gf doc --build-json
 
-# 3. 提交代码
-git add goldfish/scheme/base.scm
-git commit -m "[0053] 补全 (scheme base) 缺失的 R7RS 导出函数"
+# 4. 提交代码
+git add goldfish/scheme/base.scm goldfish/scheme/write.scm
+git add tests/scheme/write/newline-test.scm tests/scheme/base/newline-test.scm
+git add devel/0053.md
+git commit -m "[0053] 修正 (scheme base) 和 (scheme write) 越界导出函数"
 ```

--- a/goldfish/scheme/base.scm
+++ b/goldfish/scheme/base.scm
@@ -197,11 +197,7 @@
     read-string
     read
     write-char
-    write
-    display
     newline
-    write-shared
-    write-simple
     flush-output-port
     eof-object?
     eof-object

--- a/goldfish/scheme/write.scm
+++ b/goldfish/scheme/write.scm
@@ -15,7 +15,7 @@
 ;;
 
 (define-library (scheme write)
-  (export display write write-shared write-simple newline)
+  (export display write write-shared write-simple)
   (begin
 
     (define write-simple write)

--- a/tests/scheme/base/newline-test.scm
+++ b/tests/scheme/base/newline-test.scm
@@ -1,4 +1,4 @@
-(import (liii check) (scheme write))
+(import (liii check) (scheme base))
 (check-set-mode! 'report-failed)
 ;; newline
 ;; 向输出端口写入一个换行符。


### PR DESCRIPTION
## Summary
- 从 `(scheme base)` 移除属于 `(scheme write)` 的函数：`display`、`write`、`write-shared`、`write-simple`
- 从 `(scheme write)` 移除属于 `(scheme base)` 的函数：`newline`
- 将 `newline-test.scm` 从 `tests/scheme/write/` 移动到 `tests/scheme/base/`
- 重建 `gf doc` 索引，修复 `bin/gf doc \"write\"`、`bin/gf doc \"display\"` 等命令无法查找文档的问题

## Test plan
- [x] `bin/gf tests/scheme/base/newline-test.scm` 通过
- [x] `bin/gf tests/scheme/write/display-test.scm` 通过
- [x] `bin/gf tests/scheme/write/write-test.scm` 通过
- [x] `bin/gf tests/scheme/write/write-simple-test.scm` 通过
- [x] `bin/gf tests/scheme/write/write-shared-test.scm` 通过
- [x] `bin/gf doc \"write\"` 正常输出文档
- [x] `bin/gf doc \"display\"` 正常输出文档
- [x] `bin/gf doc \"newline\"` 正常输出文档

🤖 Generated with [Claude Code](https://claude.com/claude-code)