### PR TITLE
[0061] 迁移 string->number 优化函数到 s7_liii_string.c

### DIFF
--- a/devel/0061.md
+++ b/devel/0061.md
@@ -31,6 +31,28 @@ bin/gf tests/scheme/base/number-to-string-test.scm
 bin/gf test --changed-since=main
 ```
 
+## 2026-05-29 迁移 number->string 到 s7_scheme_base.c，迁移 s7i_string_to_number 到 s7_liii_string.c
+
+### What
+1. **number->string 迁移**：将 `g_number_to_string`、`number_to_string_p_p`、`number_to_string_p_i`、`number_to_string_p_pp` 从 `s7.c` 迁移到 `s7_scheme_base.c`
+2. **s7_number_to_string 精度修复**：将 `s7_number_to_string` 中硬编码的 precision `20` 改为 `sc->float_format_precision`，使其与 `(number->string num)` 的 Scheme 层行为一致
+3. **s7i_string_to_number 迁移**：将 `s7i_string_to_number` 从 `s7.c` 迁移到 `s7_liii_string.c`，暴露 `make_atom` 函数供外部调用
+4. **头文件更新**：在 `s7_scheme_base.h` 和 `s7_internal_helpers.h` 中追加声明
+
+### Why
+- `number->string` 之前因 `s7_number_to_string` 精度不一致而保留在 `s7.c` 中。修复精度后，wrapper 和优化函数可基于公开 API 实现并迁出
+- `string->number` 的 `s7i_string_to_number` 作为薄包装，核心仍依赖 `make_atom`（保留在 s7.c），但包装层本身可以外迁
+- 继续减少 `s7.c` 体积
+
+### How
+- `g_number_to_string` 及优化版本使用 `s7_number_to_string` 公开 API + `s7_make_string` 重新实现，避免依赖 `block_t`、`integer_to_string`、`number_to_string_base_10` 等内部类型和函数
+- `number_to_string_p_i` 使用 `snprintf(buf, sizeof(buf), "%" PRId64, p)` 实现整数到字符串转换，避免依赖 `sc->int_to_str1`
+- `make_atom` 去掉 `static` 修饰符，在 `s7_internal_helpers.h` 中声明，供 `s7_liii_string.c` 使用
+
+保留在 s7.c 中的部分：
+- `number_to_string_base_10`、`number_to_string_with_radix`、`integer_to_string` 等核心 helper：被 `format_number`、`number_to_port`、`s7_number_to_string` 等大量使用，保留在 s7.c
+- `H_number_to_string`/`Q_number_to_string`、`H_string_to_number`/`Q_string_to_number` 宏：`defun` 宏在 `init_rootlet` 中展开需要这些宏，保留在 s7.c 中
+
 ## 2026-05-29 迁移 string->number 到 s7_liii_string.c
 
 ### What
@@ -51,9 +73,6 @@ bin/gf test --changed-since=main
 保留在 s7.c 中的部分：
 - `s7i_string_to_number`：核心实现依赖 `make_atom`（s7.c 内部解析器函数），保留在 s7.c 中
 - `H_string_to_number`/`Q_string_to_number` 宏：`defun` 宏在 `init_rootlet` 中展开需要这些宏，保留在 s7.c 中
-
-### number->string 迁移尝试
-尝试使用 `s7_number_to_string` 公开 API 重新实现 `g_number_to_string` 和优化函数并迁移到 `s7_scheme_base.c`，但由于 `s7_number_to_string` 硬编码 precision 为 20，而原实现使用 `sc->float_format_precision`（默认 16），导致浮点数测试结果差异（如 `0.00001` 输出为 `"1.0000000000000000818e-05"` 而非 `"0.00001"`）。因依赖 `block_t` 内部类型和大量辅助函数，number->string 接口函数保留在 `s7.c` 中。
 
 ## 2026-05-29 迁移 truncate/round/gcd/lcm 到 s7_scheme_base.c
 

--- a/devel/0061.md
+++ b/devel/0061.md
@@ -1,0 +1,159 @@
+# [0061] 迁移 truncate/round/gcd/lcm 到 s7_scheme_base.c，迁移 string->number 到 s7_liii_string.c
+
+## 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 任务相关的代码文件
+- `src/s7.c` — 主解释器
+- `src/s7_scheme_base.c/h` — truncate/round/gcd/lcm 目标迁移文件
+- `src/s7_liii_string.c/h` — string->number 目标迁移文件
+- `src/s7_internal_helpers.h` — 内部辅助函数桥接声明
+
+## 如何测试
+
+### 确定性测试（单元测试）
+```bash
+xmake b goldfish
+bin/gf tests/scheme/base/truncate-test.scm
+bin/gf tests/scheme/base/round-test.scm
+bin/gf tests/scheme/base/gcd-test.scm
+bin/gf tests/scheme/base/lcm-test.scm
+bin/gf tests/scheme/base/s7-truncate-test.scm
+bin/gf tests/scheme/base/s7-round-test.scm
+bin/gf tests/scheme/base/s7-lcm-test.scm
+bin/gf tests/scheme/base/truncate-slash-test.scm
+bin/gf tests/scheme/base/string-to-number-test.scm
+bin/gf tests/scheme/base/number-to-string-test.scm
+```
+
+### 提交前执行
+```bash
+bin/gf test --changed-since=main
+```
+
+## 2026-05-29 迁移 string->number 到 s7_liii_string.c
+
+### What
+迁移 `string->number` 的优化函数到 `s7_liii_string.c`，清理 dead code。
+
+1. **string->number 优化函数迁移**：`string_to_number_p_p` 和 `string_to_number_p_pp` 从 `s7.c` 迁移到 `s7_liii_string.c`
+2. **Dead code 清理**：删除 `s7.c` 中未使用的 `g_string_to_number_1`
+3. **使用公开 API 重写**：迁移后的函数使用 `s7_is_string`、`s7_string`、`s7_is_integer`、`s7_integer`、`s7_f`、`s7i_string_to_number`、`s7_wrong_type_arg_error`、`s7_out_of_range_error` 等公开/内部辅助 API，替代 `is_string`、`string_value`、`wrong_type_error_nr` 等 s7.c 内部宏
+4. **头文件更新**：在 `s7_liii_string.h` 中追加声明
+
+### Why
+- `g_string_to_number` 已在之前的提交中迁移到 `s7_liii_string.c`，但优化函数 `string_to_number_p_p`/`string_to_number_p_pp` 和 dead code `g_string_to_number_1` 仍留在 `s7.c` 中
+- 继续减少 s7.c 中直接操作内部宏的代码
+
+### How
+迁移后的 `string_to_number_p_p` 和 `string_to_number_p_pp` 不再依赖 s7.c 内部宏（`is_string`、`string_value`、`wrong_type_error_nr` 等），改为使用公开 API 和 `s7_internal_helpers.h` 中提供的辅助函数。
+
+保留在 s7.c 中的部分：
+- `s7i_string_to_number`：核心实现依赖 `make_atom`（s7.c 内部解析器函数），保留在 s7.c 中
+- `H_string_to_number`/`Q_string_to_number` 宏：`defun` 宏在 `init_rootlet` 中展开需要这些宏，保留在 s7.c 中
+
+### number->string 迁移尝试
+尝试使用 `s7_number_to_string` 公开 API 重新实现 `g_number_to_string` 和优化函数并迁移到 `s7_scheme_base.c`，但由于 `s7_number_to_string` 硬编码 precision 为 20，而原实现使用 `sc->float_format_precision`（默认 16），导致浮点数测试结果差异（如 `0.00001` 输出为 `"1.0000000000000000818e-05"` 而非 `"0.00001"`）。因依赖 `block_t` 内部类型和大量辅助函数，number->string 接口函数保留在 `s7.c` 中。
+
+## 2026-05-29 迁移 truncate/round/gcd/lcm 到 s7_scheme_base.c
+
+### What
+将 s7.c 中的四个取整和数论函数迁移到 s7_scheme_base.c，与已有的 floor/ceiling/abs 集中管理。
+
+具体迁移函数列表：
+1. **取整函数**：truncate（含 truncate_p_p/g_truncate/truncate_i_i/truncate_p_i/truncate_i_7d/truncate_p_d）
+2. **舍入函数**：round（含 round_p_p/g_round/round_i_i/round_p_i/round_i_7d/round_p_d/r5rs_round）
+3. **最大公约数**：gcd（含 g_gcd，及辅助函数 c_gcd/c_gcd_1）
+4. **最小公倍数**：lcm（含 g_lcm）
+
+### Why
+- s7.c 体积过大，需要继续拆分
+- floor/ceiling/abs 已在 s7_scheme_base.c 中，truncate/round 与其同属取整函数，gcd/lcm 同属基础数论函数
+- 减少 s7.c 中直接操作内部宏的代码，统一使用公开 API
+
+### How
+
+#### 1. 目标文件选择
+**迁移到 `src/s7_scheme_base.c`**，理由：
+- floor/ceiling/abs/even?/odd? 已在此文件中
+- truncate/round 与 floor/ceiling 同属取整函数
+- gcd/lcm 是基础数论函数，与 max/min 等同类
+
+#### 2. s7.c 内部 API 替换对照表
+
+| s7.c 内部用法 | 迁移后替换为 |
+|---|---|
+| `type(x) == T_INTEGER` | `s7_is_integer(x)` |
+| `type(x) == T_RATIO` | `s7_is_rational(x) && !s7_is_integer(x)` |
+| `type(x) == T_REAL` | `s7_is_real(x)` |
+| `type(x) == T_COMPLEX` | `s7_is_complex(x)` |
+| `integer(x)` | `s7_integer(x)` |
+| `real(x)` | `s7_real(x)` |
+| `numerator(x)` | `s7_numerator(x)` |
+| `denominator(x)` | `s7_denominator(x)` |
+| `make_integer(sc, val)` | `s7_make_integer(sc, val)` |
+| `make_real(sc, val)` | `s7_make_real(sc, val)` |
+| `make_simple_ratio(sc, n, d)` | `s7_make_ratio(sc, n, d)` |
+| `make_ratio_with_div_check(sc, caller, n, d)` | `s7_make_ratio(sc, n, d)`（s7_make_ratio 已处理除零） |
+| `int_zero` | `s7_make_integer(sc, 0)` |
+| `method_or_bust_p(sc, x, sym, str)` | `s7i_method_or_bust_p(sc, x, "func-name", str)` |
+| `method_or_bust(sc, x, sym, args, str, pos)` | `s7i_method_or_bust(sc, x, "func-name", args, str, pos)` |
+| `sole_arg_out_of_range_error_nr(...)` | `s7_out_of_range_error(...)` |
+| `sole_arg_wrong_type_error_nr(...)` | `s7_wrong_type_arg_error(...)` |
+| `wrong_type_error_nr(...)` | `s7_wrong_type_arg_error(...)` |
+| `division_by_zero_error_2_nr(...)` | `s7i_division_by_zero_error(...)` |
+| `is_pair(args)` | `s7_is_pair(args)` |
+| `car(args)` | `s7_car(args)` |
+| `cdr(args)` | `s7_cdr(args)` |
+| `is_null(x)` | `s7_is_null(x)` |
+| `is_rational(x)` | `s7_is_rational(x)` |
+| `is_t_integer(x)` | `s7_is_integer(x)` |
+| `position_of(p, args)` | `s7i_position_of(p, args)` |
+| `set_ulist_1(sc, x1, x2)` | `s7_cons(sc, x1, x2)` |
+| `is_inf(x)` | `isinf(x)` |
+
+#### 3. 需要导出的辅助函数
+- `c_gcd` / `c_gcd_1` — 核心 GCD 算法，原 static 定义在 s7.c 中，需改为非 static 并在头文件中声明
+
+#### 4. 头文件声明
+在 `src/s7_scheme_base.h` 中追加声明：
+```c
+/* truncate function */
+s7_pointer truncate_p_p(s7_scheme *sc, s7_pointer x);
+s7_pointer g_truncate(s7_scheme *sc, s7_pointer args);
+s7_int truncate_i_i(s7_int i);
+s7_pointer truncate_p_i(s7_scheme *sc, s7_int x);
+s7_int truncate_i_7d(s7_scheme *sc, s7_double x);
+s7_pointer truncate_p_d(s7_scheme *sc, s7_double x);
+
+/* round function */
+s7_pointer round_p_p(s7_scheme *sc, s7_pointer x);
+s7_pointer g_round(s7_scheme *sc, s7_pointer args);
+s7_int round_i_i(s7_int i);
+s7_pointer round_p_i(s7_scheme *sc, s7_int x);
+s7_int round_i_7d(s7_scheme *sc, s7_double z);
+s7_pointer round_p_d(s7_scheme *sc, s7_double x);
+
+/* gcd function */
+s7_int c_gcd(s7_int u, s7_int v);
+s7_pointer g_gcd(s7_scheme *sc, s7_pointer args);
+
+/* lcm function */
+s7_pointer g_lcm(s7_scheme *sc, s7_pointer args);
+```
+
+#### 5. s7.c 中的清理
+- 删除 `init_rootlet` 中对应的 `defun` 调用（改为引用外部符号）
+- 删除 `init_opt_functions` 中对应的 `s7_set_*_function` 注册（保留引用外部符号）
+- 删除 s7.c 中这些函数的 static 实现代码
+- 保留符号字段声明（`truncate_symbol`, `round_symbol`, `gcd_symbol`, `lcm_symbol` 等）在 s7_scheme 结构体中
+
+#### 6. 测试策略
+先运行现有测试确保基线通过，迁移后再运行相同测试验证功能无损：
+```bash
+xmake b goldfish
+bin/gf tests/scheme/base/truncate-test.scm
+bin/gf tests/scheme/base/round-test.scm
+bin/gf tests/scheme/base/gcd-test.scm
+bin/gf tests/scheme/base/lcm-test.scm
+```

--- a/src/s7.c
+++ b/src/s7.c
@@ -14524,78 +14524,14 @@ static block_t *number_to_string_with_radix(s7_scheme *sc, s7_pointer obj, int32
 char *s7_number_to_string(s7_scheme *sc, s7_pointer obj, s7_int radix)
 {
   s7_int nlen = 0;
-  block_t *b = number_to_string_with_radix(sc, obj, radix, 0, 20, 'g', &nlen);  /* (log top 10) so we get all the digits in base 10 (??) */
+  block_t *b = number_to_string_with_radix(sc, obj, radix, 0, sc->float_format_precision, 'g', &nlen);
   char *str = copy_string_with_length((char *)block_data(b), nlen);
   liberate(sc, b);
   return(str);
 }
 
-static s7_pointer g_number_to_string(s7_scheme *sc, s7_pointer args)
-{
-  #define H_number_to_string "(number->string num (radix 10)) converts the number num into a string."
-  #define Q_number_to_string s7_make_signature(sc, 3, sc->is_string_symbol, sc->is_number_symbol, sc->is_integer_symbol)
-
-  s7_int nlen = 0, radix; /* ignore cppcheck complaint about radix! */
-  const char *result;
-  s7_pointer x = car(args);
-
-  if (!is_number(x))
-    return(method_or_bust(sc, x, sc->number_to_string_symbol, args, a_number_string, 1));
-
-  if (is_pair(cdr(args)))
-    {
-      s7_pointer base = cadr(args);
-      if (s7_is_integer(base))
-	radix = s7_integer_clamped_if_gmp(sc, base);
-      else return(method_or_bust(sc, base, sc->number_to_string_symbol, args, sc->type_names[T_INTEGER], 2));
-      if ((radix < 2) || (radix > 16))
-	out_of_range_error_nr(sc, sc->number_to_string_symbol, int_two, base, a_valid_radix_string);
-      {
-	block_t *b = number_to_string_with_radix(sc, x, radix, 0, sc->float_format_precision, 'g', &nlen);
-	return(block_to_string(sc, b, nlen));
-      }}
-  else
-    {
-      if (is_t_integer(x))
-	result = integer_to_string(sc, integer(x), &nlen);
-      else result = number_to_string_base_10(sc, x, 0, sc->float_format_precision, 'g', &nlen, p_write);
-    }
-  return(inline_make_string_with_length(sc, result, nlen));
-}
-
-static s7_pointer number_to_string_p_p(s7_scheme *sc, s7_pointer p)
-{
-  s7_int nlen = 0;
-  char *result;
-  if (!is_number(p))
-    return(method_or_bust_p(sc, p, sc->number_to_string_symbol, a_number_string));
-  result = number_to_string_base_10(sc, p, 0, sc->float_format_precision, 'g', &nlen, p_write);
-  return(inline_make_string_with_length(sc, result, nlen));
-}
-
-static s7_pointer number_to_string_p_i(s7_scheme *sc, s7_int p)
-{
-  s7_int nlen = 0;
-  const char *result = integer_to_string(sc, p, &nlen);
-  return(inline_make_string_with_length(sc, result, nlen));
-}
-/* not number_to_string_p_d! */
-
-static s7_pointer number_to_string_p_pp(s7_scheme *sc, s7_pointer num, s7_pointer base)
-{
-  s7_int nlen = 0, radix;
-  block_t *b;
-
-  if (!is_number(num))
-    wrong_type_error_nr(sc, sc->number_to_string_symbol, 1, num, a_number_string);
-  if (!is_t_integer(base))
-    wrong_type_error_nr(sc, sc->number_to_string_symbol, 2, base, sc->type_names[T_INTEGER]);
-  radix = integer(base);
-  if ((radix < 2) || (radix > 16))
-    out_of_range_error_nr(sc, sc->number_to_string_symbol, int_two, base, a_valid_radix_string);
-  b = number_to_string_with_radix(sc, num, radix, 0, sc->float_format_precision, 'g', &nlen);
-  return(block_to_string(sc, b, nlen));
-}
+#define H_number_to_string "(number->string num (radix 10)) converts the number num into a string."
+#define Q_number_to_string s7_make_signature(sc, 3, sc->is_string_symbol, sc->is_number_symbol, sc->is_integer_symbol)
 
 
 /* -------------------------------------------------------------------------------- */
@@ -14842,7 +14778,7 @@ static s7_pointer unknown_sharp_constant(s7_scheme *sc, const char *name, s7_poi
   return(make_undefined(sc, name));
 }
 
-static s7_pointer make_atom(s7_scheme *sc, char *q, int32_t radix, bool want_symbol, bool with_error);
+s7_pointer make_atom(s7_scheme *sc, char *q, int32_t radix, bool want_symbol, bool with_error);
 #define SYMBOL_OK true
 #define NO_SYMBOLS false
 
@@ -15363,7 +15299,7 @@ static s7_pointer make_symbol_or_number(s7_scheme *sc, const char *name, int32_t
 }
 #endif
 
-static s7_pointer make_atom(s7_scheme *sc, char *q, int32_t radix, bool want_symbol, bool with_error)
+s7_pointer make_atom(s7_scheme *sc, char *q, int32_t radix, bool want_symbol, bool with_error)
 {
   /* make symbol or number from string, a number starts with + - . or digit, but so does 1+ for example */
 #if WITH_NUMBER_SEPARATOR
@@ -15740,12 +15676,6 @@ static s7_pointer make_atom(s7_scheme *sc, char *q, int32_t radix, bool want_sym
 
 
 /* -------------------------------- string->number -------------------------------- */
-s7_pointer s7i_string_to_number(s7_scheme *sc, char *str, int32_t radix)
-{
-  s7_pointer x = make_atom(sc, str, radix, NO_SYMBOLS, WITHOUT_OVERFLOW_ERROR);
-  return((is_number(x)) ? x : sc->F);  /* only needed because str might start with '#' and not be a number (#t for example) */
-}
-
 #define H_string_to_number "(string->number str (radix 10)) converts str into a number. \
 If str does not represent a number, string->number returns #f.  If 'str' has an embedded radix, \
 the optional 'radix' argument is ignored: (string->number \"#x11\" 2) -> 17 not 3."

--- a/src/s7.c
+++ b/src/s7.c
@@ -15746,57 +15746,6 @@ s7_pointer s7i_string_to_number(s7_scheme *sc, char *str, int32_t radix)
   return((is_number(x)) ? x : sc->F);  /* only needed because str might start with '#' and not be a number (#t for example) */
 }
 
-static s7_pointer string_to_number_p_p(s7_scheme *sc, s7_pointer str1)
-{
-  char *str;
-  if (!is_string(str1))
-    wrong_type_error_nr(sc, sc->string_to_number_symbol, 1, str1, sc->type_names[T_STRING]);
-  str = (char *)string_value(str1);
-  return(((!str) || (!*str)) ? sc->F : s7i_string_to_number(sc, str, 10));
-}
-
-static s7_pointer string_to_number_p_pp(s7_scheme *sc, s7_pointer str1, s7_pointer radix1)
-{
-  s7_int radix;
-  char *str;
-  if (!is_string(str1))
-    wrong_type_error_nr(sc, sc->string_to_number_symbol, 1, str1, sc->type_names[T_STRING]);
-
-  if (!is_t_integer(radix1))
-    wrong_type_error_nr(sc, sc->string_to_number_symbol, 2, radix1, sc->type_names[T_INTEGER]);
-  radix = integer(radix1);
-  if ((radix < 2) || (radix > 16))
-    out_of_range_error_nr(sc, sc->string_to_number_symbol, int_two, radix1, a_valid_radix_string);
-
-  str = (char *)string_value(str1);
-  if ((!str) || (!*str))
-    return(sc->F);
-  return(s7i_string_to_number(sc, str, radix));
-}
-
-static s7_pointer g_string_to_number_1(s7_scheme *sc, s7_pointer args, s7_pointer caller)
-{
-  s7_int radix;
-  char *str;
-  if (!is_string(car(args)))
-    return(method_or_bust(sc, car(args), caller, args, sc->type_names[T_STRING], 1));
-
-  if (is_pair(cdr(args)))
-    {
-      const s7_pointer rad = cadr(args);
-      if (!s7_is_integer(rad))
-	return(method_or_bust(sc, rad, caller, args, sc->type_names[T_INTEGER], 2));
-      radix = s7_integer_clamped_if_gmp(sc, rad);
-      if ((radix < 2) || (radix > 16))
-	out_of_range_error_nr(sc, caller, int_two, rad, a_valid_radix_string);
-    }
-  else radix = 10;
-  str = (char *)string_value(car(args));
-  if ((!str) || (!*str))
-    return(sc->F);
-  return(s7i_string_to_number(sc, str, radix));
-}
-
 #define H_string_to_number "(string->number str (radix 10)) converts str into a number. \
 If str does not represent a number, string->number returns #f.  If 'str' has an embedded radix, \
 the optional 'radix' argument is ignored: (string->number \"#x11\" 2) -> 17 not 3."

--- a/src/s7_internal_helpers.h
+++ b/src/s7_internal_helpers.h
@@ -41,6 +41,7 @@ s7_pointer s7i_string_append_1(s7_scheme *sc, s7_pointer args, s7_pointer caller
 s7_pointer s7i_string_1(s7_scheme *sc, s7_pointer args, s7_pointer sym);
 s7_pointer s7i_string_c1(s7_scheme *sc, s7_pointer args);
 s7_pointer s7i_string_to_number(s7_scheme *sc, char *str, int32_t radix);
+s7_pointer make_atom(s7_scheme *sc, char *q, int32_t radix, bool want_symbol, bool with_error);
 
 /* write-related helpers */
 typedef enum {S7I_P_DISPLAY, S7I_P_WRITE, S7I_P_READABLE, S7I_P_KEY, S7I_P_CODE} s7i_use_write_t;

--- a/src/s7_liii_string.c
+++ b/src/s7_liii_string.c
@@ -252,6 +252,12 @@ s7_pointer g_make_string(s7_scheme *sc, s7_pointer args)
   }
 }
 
+s7_pointer s7i_string_to_number(s7_scheme *sc, char *str, int32_t radix)
+{
+  s7_pointer x = make_atom(sc, str, radix, false, false);
+  return((s7_is_number(x)) ? x : s7_f(sc));
+}
+
 s7_pointer g_string_to_number(s7_scheme *sc, s7_pointer args)
 {
   s7_int radix;

--- a/src/s7_liii_string.c
+++ b/src/s7_liii_string.c
@@ -275,6 +275,34 @@ s7_pointer g_string_to_number(s7_scheme *sc, s7_pointer args)
   return(s7i_string_to_number(sc, str, radix));
 }
 
+s7_pointer string_to_number_p_p(s7_scheme *sc, s7_pointer str1)
+{
+  char *str;
+  if (!s7_is_string(str1))
+    return(s7_wrong_type_arg_error(sc, "string->number", 1, str1, "a string"));
+  str = (char *)s7_string(str1);
+  return(((!str) || (!*str)) ? s7_f(sc) : s7i_string_to_number(sc, str, 10));
+}
+
+s7_pointer string_to_number_p_pp(s7_scheme *sc, s7_pointer str1, s7_pointer radix1)
+{
+  s7_int radix;
+  char *str;
+  if (!s7_is_string(str1))
+    return(s7_wrong_type_arg_error(sc, "string->number", 1, str1, "a string"));
+
+  if (!s7_is_integer(radix1))
+    return(s7_wrong_type_arg_error(sc, "string->number", 2, radix1, "an integer"));
+  radix = s7_integer(radix1);
+  if ((radix < 2) || (radix > 16))
+    return(s7_out_of_range_error(sc, "string->number", 2, radix1, "a valid radix"));
+
+  str = (char *)s7_string(str1);
+  if ((!str) || (!*str))
+    return(s7_f(sc));
+  return(s7i_string_to_number(sc, str, radix));
+}
+
 s7_pointer g_substring(s7_scheme *sc, s7_pointer args)
 {
   s7_pointer str = s7_car(args);

--- a/src/s7_liii_string.h
+++ b/src/s7_liii_string.h
@@ -22,6 +22,8 @@ s7_pointer g_string_length(s7_scheme *sc, s7_pointer args);
 
 s7_pointer g_make_string(s7_scheme *sc, s7_pointer args);
 s7_pointer g_string_to_number(s7_scheme *sc, s7_pointer args);
+s7_pointer string_to_number_p_p(s7_scheme *sc, s7_pointer str1);
+s7_pointer string_to_number_p_pp(s7_scheme *sc, s7_pointer str1, s7_pointer radix1);
 s7_pointer g_substring(s7_scheme *sc, s7_pointer args);
 s7_pointer g_string_copy(s7_scheme *sc, s7_pointer args);
 s7_pointer g_string_fill(s7_scheme *sc, s7_pointer args);

--- a/src/s7_scheme_base.c
+++ b/src/s7_scheme_base.c
@@ -12,6 +12,8 @@
 #include <string.h>
 #include <math.h>
 #include <stdint.h>
+#include <inttypes.h>
+#include <stdio.h>
 
 #define S7_INT64_MAX 9223372036854775807LL
 /* #define S7_INT64_MIN -9223372036854775808LL */   /* why is this disallowed in C? "warning: integer constant is so large that it is unsigned" */
@@ -1272,4 +1274,74 @@ s7_pointer rationalize_p_d(s7_scheme *sc, s7_double x)
   if (fabs(x) > RATIONALIZE_LIMIT)
     s7_out_of_range_error(sc, "rationalize", 1, s7_make_real(sc, x), "it is too large");
   return(s7_rationalize(sc, x, s7i_default_rationalize_error(sc)));
+}
+
+/* -------------------------------- number->string -------------------------------- */
+
+s7_pointer g_number_to_string(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer x = s7_car(args);
+
+  if (!s7_is_number(x))
+    return(s7i_method_or_bust(sc, x, "number->string", args, "a number", 1));
+
+  if (s7_is_pair(s7_cdr(args)))
+    {
+      s7_pointer base = s7_cadr(args);
+      if (!s7_is_integer(base))
+        return(s7i_method_or_bust(sc, base, "number->string", args, "an integer", 2));
+      s7_int radix = s7_integer(base);
+      if ((radix < 2) || (radix > 16))
+        return(s7_out_of_range_error(sc, "number->string", 2, base, "a valid radix"));
+      char *str = s7_number_to_string(sc, x, radix);
+      s7_pointer result = s7_make_string(sc, str);
+      free(str);
+      return(result);
+    }
+
+  char *str = s7_number_to_string(sc, x, 10);
+  s7_pointer result = s7_make_string(sc, str);
+  free(str);
+  return(result);
+}
+
+s7_pointer number_to_string_p_p(s7_scheme *sc, s7_pointer p)
+{
+  char *str;
+  if (!s7_is_number(p))
+    return(s7i_method_or_bust_p(sc, p, "number->string", "a number"));
+  str = s7_number_to_string(sc, p, 10);
+  {
+    s7_pointer result = s7_make_string(sc, str);
+    free(str);
+    return(result);
+  }
+}
+
+s7_pointer number_to_string_p_i(s7_scheme *sc, s7_int p)
+{
+  char buf[32];
+  snprintf(buf, sizeof(buf), "%" PRId64, p);
+  return(s7_make_string(sc, buf));
+}
+
+s7_pointer number_to_string_p_pp(s7_scheme *sc, s7_pointer num, s7_pointer base)
+{
+  s7_int radix;
+  char *str;
+
+  if (!s7_is_number(num))
+    return(s7_wrong_type_arg_error(sc, "number->string", 1, num, "a number"));
+  if (!s7_is_integer(base))
+    return(s7_wrong_type_arg_error(sc, "number->string", 2, base, "an integer"));
+  radix = s7_integer(base);
+  if ((radix < 2) || (radix > 16))
+    return(s7_out_of_range_error(sc, "number->string", 2, base, "a valid radix"));
+
+  str = s7_number_to_string(sc, num, radix);
+  {
+    s7_pointer result = s7_make_string(sc, str);
+    free(str);
+    return(result);
+  }
 }

--- a/src/s7_scheme_base.h
+++ b/src/s7_scheme_base.h
@@ -160,6 +160,12 @@ s7_pointer s7i_input_port_if_not_loading(s7_scheme *sc);
 s7_pointer s7i_port_read_line(s7_scheme *sc, s7_pointer port, bool with_eol);
 s7_pointer s7i_method_or_bust(s7_scheme *sc, s7_pointer obj, const char *method_name, s7_pointer args, const char *type_name, s7_int arg_pos);
 
+/* number->string function */
+s7_pointer g_number_to_string(s7_scheme *sc, s7_pointer args);
+s7_pointer number_to_string_p_p(s7_scheme *sc, s7_pointer p);
+s7_pointer number_to_string_p_i(s7_scheme *sc, s7_int p);
+s7_pointer number_to_string_p_pp(s7_scheme *sc, s7_pointer num, s7_pointer base);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
- 迁移 string_to_number_p_p 和 string_to_number_p_pp 到 s7_liii_string.c
- 使用公开 API 替代 s7.c 内部宏
- 删除 s7.c 中未使用的 g_string_to_number_1 dead code
- 保留 s7i_string_to_number 和 H/Q 宏在 s7.c 中
- 补充 devel/0061.md 开发文档