### PR TITLE
[0059] subprocess 控制流函数返回值统一改为 Either

### DIFF
--- a/goldfish/liii/subprocess.scm
+++ b/goldfish/liii/subprocess.scm
@@ -113,19 +113,18 @@
             ((and (pair? command) (symbol? (car command)))
              (%resolve-symbol-command (car command) (cdr command))
             ) ;
-            (else (value-error
-                    (let ((suggestion
-                            (if (and (pair? command) (string? (car command)))
-                              (format #f "'(~a ...)" (string->symbol (car command)))
-                              "'(xxx \"yyy\" \"zzz\")"
-                            ) ;if
-                          ) ;suggestion
-                         ) ;
-                      (format #f "Command list must start with a symbol, e.g. ~a, got: ~a"
-                        suggestion
-                        (object->string command)
-                      ) ;format
-                    ) ;let
+            (else (value-error (let ((suggestion (if (and (pair? command) (string? (car command)))
+                                                   (format #f "'(~a ...)" (string->symbol (car command)))
+                                                   "'(xxx \"yyy\" \"zzz\")"
+                                                 ) ;if
+                                     ) ;suggestion
+                                    ) ;
+                                 (format #f
+                                   "Command list must start with a symbol, e.g. ~a, got: ~a"
+                                   suggestion
+                                   (object->string command)
+                                 ) ;format
+                               ) ;let
                   ) ;value-error
             ) ;else
       ) ;cond
@@ -247,9 +246,29 @@
                              (values "" "" 0)
                             ) ;
                             ((pair? cmd-spec)
-                             (g_subprocess-run-values cmd-spec cwd env input timeout stdout stdout-mode stderr stderr-mode stdin)
+                             (g_subprocess-run-values cmd-spec
+                               cwd
+                               env
+                               input
+                               timeout
+                               stdout
+                               stdout-mode
+                               stderr
+                               stderr-mode
+                               stdin
+                             ) ;g_subprocess-run-values
                             ) ;
-                            (else (g_subprocess-run-values cmd-spec cwd env input timeout stdout stdout-mode stderr stderr-mode stdin)
+                            (else (g_subprocess-run-values cmd-spec
+                                    cwd
+                                    env
+                                    input
+                                    timeout
+                                    stdout
+                                    stdout-mode
+                                    stderr
+                                    stderr-mode
+                                    stdin
+                                  ) ;g_subprocess-run-values
                             ) ;else
                       ) ;cond
                      ) ;

--- a/goldfish/liii/subprocess.scm
+++ b/goldfish/liii/subprocess.scm
@@ -298,7 +298,7 @@
              ) ;
           (let loop
             ((cmds commands) (first? #t))
-            (cond ((null? cmds) 0)
+            (cond ((null? cmds) (from-right 0))
                   ((null? (cdr cmds))
                    (let-values (((out err code)
                                  (run-values (car cmds)
@@ -319,7 +319,10 @@
                                  ) ;run-values
                                 ) ;
                                ) ;
-                     code
+                     (if (zero? code)
+                       (from-right code)
+                       (from-left (list code (car cmds)))
+                     ) ;if
                    ) ;let-values
                   ) ;
                   (else (let-values (((out err code)
@@ -337,7 +340,10 @@
                                       ) ;run-values
                                      ) ;
                                     ) ;
-                          (if (zero? code) (loop (cdr cmds) #f) code)
+                          (if (zero? code)
+                            (loop (cdr cmds) #f)
+                            (from-left (list code (car cmds)))
+                          ) ;if
                         ) ;let-values
                   ) ;else
             ) ;cond

--- a/goldfish/liii/subprocess.scm
+++ b/goldfish/liii/subprocess.scm
@@ -259,9 +259,8 @@
     (define (run-string command . opts)
       (let-values (((out err code) (apply run-values command opts)))
         (if (zero? code)
-          out
-          (value-error (string-append "Command failed with exit code " (number->string code))
-          ) ;value-error
+          (from-right out)
+          (from-left code)
         ) ;if
       ) ;let-values
     ) ;define
@@ -390,7 +389,12 @@
              ) ;
           (let loop
             ((cmds commands) (last-code 0))
-            (cond ((null? cmds) last-code)
+            (cond ((null? cmds)
+                   (if (zero? last-code)
+                     (from-right last-code)
+                     (from-left last-code)
+                   ) ;if
+                  ) ;
                   (else (let-values (((out err code) (run-values (car cmds) :cwd cwd :env env :timeout timeout)))
                           (loop (cdr cmds) code)
                         ) ;let-values
@@ -410,7 +414,7 @@
              ) ;
           (let loop
             ((cmds commands) (input #f))
-            (cond ((null? cmds) "")
+            (cond ((null? cmds) (from-right ""))
                   ((null? (cdr cmds))
                    (let-values (((out err code)
                                  (run-values (car cmds)
@@ -428,9 +432,8 @@
                                 ) ;
                                ) ;
                      (if (zero? code)
-                       out
-                       (value-error (string-append "Pipe failed with exit code " (number->string code))
-                       ) ;value-error
+                       (from-right out)
+                       (from-left (list code (car cmds)))
                      ) ;if
                    ) ;let-values
                   ) ;
@@ -449,7 +452,10 @@
                                       ) ;run-values
                                      ) ;
                                     ) ;
-                          (loop (cdr cmds) out)
+                          (if (zero? code)
+                            (loop (cdr cmds) out)
+                            (from-left (list code (car cmds)))
+                          ) ;if
                         ) ;let-values
                   ) ;else
             ) ;cond

--- a/goldfish/liii/subprocess.scm
+++ b/goldfish/liii/subprocess.scm
@@ -114,7 +114,18 @@
              (%resolve-symbol-command (car command) (cdr command))
             ) ;
             (else (value-error
-                    "Command list must start with a symbol, e.g. '(xxx \"yyy\" \"zzz\"), not all strings"
+                    (let ((suggestion
+                            (if (and (pair? command) (string? (car command)))
+                              (format #f "'(~a ...)" (string->symbol (car command)))
+                              "'(xxx \"yyy\" \"zzz\")"
+                            ) ;if
+                          ) ;suggestion
+                         ) ;
+                      (format #f "Command list must start with a symbol, e.g. ~a, got: ~a"
+                        suggestion
+                        (object->string command)
+                      ) ;format
+                    ) ;let
                   ) ;value-error
             ) ;else
       ) ;cond

--- a/goldfish/liii/subprocess.scm
+++ b/goldfish/liii/subprocess.scm
@@ -229,7 +229,9 @@
             (input (%keyword-value :input opts #f))
             (timeout (%keyword-value :timeout opts #f))
             (stdout (%keyword-value :stdout opts #f))
+            (stdout-mode (%keyword-value :stdout-mode opts #f))
             (stderr (%keyword-value :stderr opts #f))
+            (stderr-mode (%keyword-value :stderr-mode opts #f))
             (stdin (%keyword-value :stdin opts #f))
             (cmd-spec (%command->exec-spec command))
             (orig-dir #f)
@@ -245,9 +247,9 @@
                              (values "" "" 0)
                             ) ;
                             ((pair? cmd-spec)
-                             (g_subprocess-run-values cmd-spec cwd env input timeout stdout stderr stdin)
+                             (g_subprocess-run-values cmd-spec cwd env input timeout stdout stdout-mode stderr stderr-mode stdin)
                             ) ;
-                            (else (g_subprocess-run-values cmd-spec cwd env input timeout stdout stderr stdin)
+                            (else (g_subprocess-run-values cmd-spec cwd env input timeout stdout stdout-mode stderr stderr-mode stdin)
                             ) ;else
                       ) ;cond
                      ) ;
@@ -444,18 +446,15 @@
       ) ;let-values
     ) ;define
 
-    (define (run-if condition then-cmd . else-cmds)
+    (define (run-if condition then-cmd else-cmd)
       (let-values (((out err code) (run-values condition)))
         (if (zero? code)
           (let-values (((out err code) (run-values then-cmd)))
             (if (zero? code) (from-right code) (from-left (list code then-cmd)))
           ) ;let-values
-          (if (null? else-cmds)
-            (from-right code)
-            (let-values (((out err code) (run-values (car else-cmds))))
-              (if (zero? code) (from-right code) (from-left (list code (car else-cmds))))
-            ) ;let-values
-          ) ;if
+          (let-values (((out err code) (run-values else-cmd)))
+            (if (zero? code) (from-right code) (from-left (list code else-cmd)))
+          ) ;let-values
         ) ;if
       ) ;let-values
     ) ;define

--- a/goldfish/liii/subprocess.scm
+++ b/goldfish/liii/subprocess.scm
@@ -31,6 +31,7 @@
   ) ;export
   (import (scheme base)
     (liii base)
+    (liii either)
     (liii error)
     (liii hash-table)
     (liii list)
@@ -449,12 +450,18 @@
       (let-values (((out err code) (run-values condition)))
         (if (zero? code)
           (let-values (((out err code) (run-values then-cmd)))
-            code
+            (if (zero? code)
+              (from-right code)
+              (from-left (list code then-cmd))
+            ) ;if
           ) ;let-values
           (if (null? else-cmds)
-            code
+            (from-right code)
             (let-values (((out err code) (run-values (car else-cmds))))
-              code
+              (if (zero? code)
+                (from-right code)
+                (from-left (list code (car else-cmds)))
+              ) ;if
             ) ;let-values
           ) ;if
         ) ;if
@@ -463,7 +470,15 @@
 
     (define (run-when condition command)
       (let-values (((out err code) (run-values condition)))
-        (if (zero? code) 0 (let-values (((out err code) (run-values command))) code))
+        (if (zero? code)
+          (from-right 0)
+          (let-values (((out err code) (run-values command)))
+            (if (zero? code)
+              (from-right code)
+              (from-left (list code command))
+            ) ;if
+          ) ;let-values
+        ) ;if
       ) ;let-values
     ) ;define
 

--- a/goldfish/liii/subprocess.scm
+++ b/goldfish/liii/subprocess.scm
@@ -76,7 +76,7 @@
         (cond ((procedure? val) (cons 'lambda (cons val args)))
               ((string? val) (cons val args))
               ((path? val) (cons (path->string val) args))
-              (else (string-join (cons (symbol->string sym) args) " "))
+              (else (cons (symbol->string sym) args))
         ) ;cond
       ) ;let
     ) ;define
@@ -113,8 +113,9 @@
             ((and (pair? command) (symbol? (car command)))
              (%resolve-symbol-command (car command) (cdr command))
             ) ;
-            ((and (list? command) (every string? command)) command)
-            (else (type-error "(run command ...): command must be string or list of strings")
+            (else (value-error
+                    "Command list must start with a symbol, e.g. '(xxx \"yyy\" \"zzz\"), not all strings"
+                  ) ;value-error
             ) ;else
       ) ;cond
     ) ;define

--- a/goldfish/liii/subprocess.scm
+++ b/goldfish/liii/subprocess.scm
@@ -135,35 +135,44 @@
           (set! orig-dir (getcwd))
           (chdir cwd)
         ) ;when
-        (let ((result
-               (cond ((and (pair? cmd-spec) (eq? (car cmd-spec) 'lambda))
-                      (apply (cadr cmd-spec) (cddr cmd-spec))
-                      0
-                     ) ;lambda
-                     ((or env input timeout stdout stderr stdin)
-                      (let-values (((out err code)
-                                    (run-values command
-                                      :cwd cwd :env env
-                                      :input input :timeout timeout
-                                      :stdout stdout :stderr stderr
-                                      :stdin stdin
-                                    ) ;run-values
-                                   ) ;
-                                  ) ;let-values
-                        (display out)
-                        (display err (current-error-port))
-                        code
-                      ) ;let-values
-                     ) ;has-keywords
-                     ((pair? cmd-spec)
-                      (let-values (((out err code) (run-values command)))
-                        (display out)
-                        (display err (current-error-port))
-                        code
-                      ) ;let-values
-                     ) ;list-form
-                     (else (os-call cmd-spec))
-               ) ;cond
+        (let ((result (cond ((and (pair? cmd-spec) (eq? (car cmd-spec) 'lambda))
+                             (apply (cadr cmd-spec) (cddr cmd-spec))
+                             0
+                            ) ;
+                            ((or env input timeout stdout stderr stdin)
+                             (let-values (((out err code)
+                                           (run-values command
+                                             :cwd
+                                             cwd
+                                             :env
+                                             env
+                                             :input
+                                             input
+                                             :timeout
+                                             timeout
+                                             :stdout
+                                             stdout
+                                             :stderr
+                                             stderr
+                                             :stdin
+                                             stdin
+                                           ) ;run-values
+                                          ) ;
+                                         ) ;
+                               (display out)
+                               (display err (current-error-port))
+                               code
+                             ) ;let-values
+                            ) ;
+                            ((pair? cmd-spec)
+                             (let-values (((out err code) (run-values command)))
+                               (display out)
+                               (display err (current-error-port))
+                               code
+                             ) ;let-values
+                            ) ;
+                            (else (os-call cmd-spec))
+                      ) ;cond
               ) ;result
              ) ;
           (when orig-dir
@@ -222,29 +231,12 @@
                       (cond ((and (pair? cmd-spec) (eq? (car cmd-spec) 'lambda))
                              (apply (cadr cmd-spec) (cddr cmd-spec))
                              (values "" "" 0)
-                            ) ;lambda
+                            ) ;
                             ((pair? cmd-spec)
-                             (g_subprocess-run-values cmd-spec
-                               cwd
-                               env
-                               input
-                               timeout
-                               stdout
-                               stderr
-                               stdin
-                             ) ;g_subprocess-run-values
-                            ) ;list
-                            (else
-                             (g_subprocess-run-values cmd-spec
-                               cwd
-                               env
-                               input
-                               timeout
-                               stdout
-                               stderr
-                               stdin
-                             ) ;g_subprocess-run-values
-                            ) ;string
+                             (g_subprocess-run-values cmd-spec cwd env input timeout stdout stderr stdin)
+                            ) ;
+                            (else (g_subprocess-run-values cmd-spec cwd env input timeout stdout stderr stdin)
+                            ) ;else
                       ) ;cond
                      ) ;
                     ) ;
@@ -258,10 +250,7 @@
 
     (define (run-string command . opts)
       (let-values (((out err code) (apply run-values command opts)))
-        (if (zero? code)
-          (from-right out)
-          (from-left code)
-        ) ;if
+        (if (zero? code) (from-right out) (from-left code))
       ) ;let-values
     ) ;define
 
@@ -318,10 +307,7 @@
                                  ) ;run-values
                                 ) ;
                                ) ;
-                     (if (zero? code)
-                       (from-right code)
-                       (from-left (list code (car cmds)))
-                     ) ;if
+                     (if (zero? code) (from-right code) (from-left (list code (car cmds))))
                    ) ;let-values
                   ) ;
                   (else (let-values (((out err code)
@@ -339,10 +325,7 @@
                                       ) ;run-values
                                      ) ;
                                     ) ;
-                          (if (zero? code)
-                            (loop (cdr cmds) #f)
-                            (from-left (list code (car cmds)))
-                          ) ;if
+                          (if (zero? code) (loop (cdr cmds) #f) (from-left (list code (car cmds))))
                         ) ;let-values
                   ) ;else
             ) ;cond
@@ -362,17 +345,11 @@
             (cond ((null? cmds) (from-right 0))
                   ((null? (cdr cmds))
                    (let-values (((out err code) (run-values (car cmds) :cwd cwd :env env :timeout timeout)))
-                     (if (zero? code)
-                       (from-right code)
-                       (from-left (list code (car cmds)))
-                     ) ;if
+                     (if (zero? code) (from-right code) (from-left (list code (car cmds))))
                    ) ;let-values
                   ) ;
                   (else (let-values (((out err code) (run-values (car cmds) :cwd cwd :env env :timeout timeout)))
-                          (if (zero? code)
-                            (from-right 0)
-                            (loop (cdr cmds))
-                          ) ;if
+                          (if (zero? code) (from-right 0) (loop (cdr cmds)))
                         ) ;let-values
                   ) ;else
             ) ;cond
@@ -390,10 +367,7 @@
           (let loop
             ((cmds commands) (last-code 0))
             (cond ((null? cmds)
-                   (if (zero? last-code)
-                     (from-right last-code)
-                     (from-left last-code)
-                   ) ;if
+                   (if (zero? last-code) (from-right last-code) (from-left last-code))
                   ) ;
                   (else (let-values (((out err code) (run-values (car cmds) :cwd cwd :env env :timeout timeout)))
                           (loop (cdr cmds) code)
@@ -431,10 +405,7 @@
                                  ) ;run-values
                                 ) ;
                                ) ;
-                     (if (zero? code)
-                       (from-right out)
-                       (from-left (list code (car cmds)))
-                     ) ;if
+                     (if (zero? code) (from-right out) (from-left (list code (car cmds))))
                    ) ;let-values
                   ) ;
                   (else (let-values (((out err code)
@@ -452,10 +423,7 @@
                                       ) ;run-values
                                      ) ;
                                     ) ;
-                          (if (zero? code)
-                            (loop (cdr cmds) out)
-                            (from-left (list code (car cmds)))
-                          ) ;if
+                          (if (zero? code) (loop (cdr cmds) out) (from-left (list code (car cmds))))
                         ) ;let-values
                   ) ;else
             ) ;cond
@@ -468,18 +436,12 @@
       (let-values (((out err code) (run-values condition)))
         (if (zero? code)
           (let-values (((out err code) (run-values then-cmd)))
-            (if (zero? code)
-              (from-right code)
-              (from-left (list code then-cmd))
-            ) ;if
+            (if (zero? code) (from-right code) (from-left (list code then-cmd)))
           ) ;let-values
           (if (null? else-cmds)
             (from-right code)
             (let-values (((out err code) (run-values (car else-cmds))))
-              (if (zero? code)
-                (from-right code)
-                (from-left (list code (car else-cmds)))
-              ) ;if
+              (if (zero? code) (from-right code) (from-left (list code (car else-cmds))))
             ) ;let-values
           ) ;if
         ) ;if
@@ -491,10 +453,7 @@
         (if (zero? code)
           (from-right 0)
           (let-values (((out err code) (run-values command)))
-            (if (zero? code)
-              (from-right code)
-              (from-left (list code command))
-            ) ;if
+            (if (zero? code) (from-right code) (from-left (list code command)))
           ) ;let-values
         ) ;if
       ) ;let-values

--- a/goldfish/liii/subprocess.scm
+++ b/goldfish/liii/subprocess.scm
@@ -22,6 +22,7 @@
     run-get
     run-allow!
     run-ban!
+    run-unban!
     run-and
     run-or
     run-sequence
@@ -43,7 +44,7 @@
 
     (define %run-registry (make-hash-table))
     (define %run-allow-list '())
-    (define %run-ban-list '())
+    (define %run-ban-list '(rm))
 
     (define (%keyword-value key opts default)
       (let loop
@@ -68,6 +69,25 @@
                      ) ;string-append
         ) ;value-error
       ) ;when
+    ) ;define
+
+    (define (%check-string-command cmd)
+      (let loop
+        ((banned %run-ban-list))
+        (when (pair? banned)
+          (let ((sym-str (symbol->string (car banned))))
+            (when (and (>= (string-length cmd) (string-length sym-str))
+                    (string=? (substring cmd 0 (string-length sym-str)) sym-str)
+                    (or (= (string-length cmd) (string-length sym-str))
+                      (char=? (string-ref cmd (string-length sym-str)) #\space)
+                    ) ;or
+                  ) ;and
+              (value-error (string-append "Command '" cmd "' has been banned"))
+            ) ;when
+          ) ;let
+          (loop (cdr banned))
+        ) ;when
+      ) ;let
     ) ;define
 
     (define (%resolve-symbol-command sym args)
@@ -142,6 +162,9 @@
             (orig-dir #f)
            ) ;
         (%check-cwd-conflict command cwd)
+        (when (string? cmd-spec)
+          (%check-string-command cmd-spec)
+        ) ;when
         (when cwd
           (set! orig-dir (getcwd))
           (chdir cwd)
@@ -222,6 +245,10 @@
       (set! %run-ban-list (cons symbol %run-ban-list))
     ) ;define
 
+    (define (run-unban! symbol)
+      (set! %run-ban-list (filter (lambda (x) (not (eq? x symbol))) %run-ban-list))
+    ) ;define
+
     (define (run-values command . opts)
       (let ((cwd (%keyword-value :cwd opts #f))
             (env (%keyword-value :env opts #f))
@@ -236,6 +263,9 @@
             (orig-dir #f)
            ) ;
         (%check-cwd-conflict command cwd)
+        (when (string? cmd-spec)
+          (%check-string-command cmd-spec)
+        ) ;when
         (when cwd
           (set! orig-dir (getcwd))
           (chdir cwd)

--- a/goldfish/liii/subprocess.scm
+++ b/goldfish/liii/subprocess.scm
@@ -360,14 +360,20 @@
              ) ;
           (let loop
             ((cmds commands))
-            (cond ((null? cmds) 0)
+            (cond ((null? cmds) (from-right 0))
                   ((null? (cdr cmds))
                    (let-values (((out err code) (run-values (car cmds) :cwd cwd :env env :timeout timeout)))
-                     code
+                     (if (zero? code)
+                       (from-right code)
+                       (from-left (list code (car cmds)))
+                     ) ;if
                    ) ;let-values
                   ) ;
                   (else (let-values (((out err code) (run-values (car cmds) :cwd cwd :env env :timeout timeout)))
-                          (if (zero? code) 0 (loop (cdr cmds)))
+                          (if (zero? code)
+                            (from-right 0)
+                            (loop (cdr cmds))
+                          ) ;if
                         ) ;let-values
                   ) ;else
             ) ;cond

--- a/src/goldfish.hpp
+++ b/src/goldfish.hpp
@@ -2441,8 +2441,8 @@ f_subprocess_run_values (s7_scheme* sc, s7_pointer args);
 inline void
 glue_subprocess_run_values (s7_scheme* sc) {
   const char* name = "g_subprocess-run-values";
-  const char* desc = "(g_subprocess-run-values command cwd env input timeout stdout stderr stdin) => (values stdout stderr exit-code)";
-  glue_define (sc, name, desc, f_subprocess_run_values, 1, 7);
+  const char* desc = "(g_subprocess-run-values command cwd env input timeout stdout stdout-mode stderr stderr-mode stdin) => (values stdout stderr exit-code)";
+  glue_define (sc, name, desc, f_subprocess_run_values, 1, 9);
 }
 
 static s7_pointer

--- a/src/liii_subprocess.cpp
+++ b/src/liii_subprocess.cpp
@@ -96,6 +96,15 @@ f_subprocess_run_values (s7_scheme* sc, s7_pointer args) {
     args = s7_cdr (args);
   }
 
+  bool stdout_append = false;
+  if (s7_is_pair (args)) {
+    s7_pointer stdout_mode_val = s7_car (args);
+    if (s7_is_symbol (stdout_mode_val) && strcmp (s7_symbol_name (stdout_mode_val), "append") == 0) {
+      stdout_append = true;
+    }
+    args = s7_cdr (args);
+  }
+
   bool stderr_to_stdout = false;
   bool stderr_discard = false;
   const char* stderr_path = nullptr;
@@ -112,6 +121,15 @@ f_subprocess_run_values (s7_scheme* sc, s7_pointer args) {
     }
     else if (s7_is_string (stderr_val)) {
       stderr_path = s7_string (stderr_val);
+    }
+    args = s7_cdr (args);
+  }
+
+  bool stderr_append = false;
+  if (s7_is_pair (args)) {
+    s7_pointer stderr_mode_val = s7_car (args);
+    if (s7_is_symbol (stderr_mode_val) && strcmp (s7_symbol_name (stderr_mode_val), "append") == 0) {
+      stderr_append = true;
     }
     args = s7_cdr (args);
   }
@@ -138,7 +156,7 @@ f_subprocess_run_values (s7_scheme* sc, s7_pointer args) {
   if (stdout_path) {
     attr.outtype = TB_PROCESS_REDIRECT_TYPE_FILEPATH;
     attr.out.path = stdout_path;
-    attr.outmode = TB_FILE_MODE_RW | TB_FILE_MODE_CREAT | TB_FILE_MODE_TRUNC;
+    attr.outmode = TB_FILE_MODE_RW | TB_FILE_MODE_CREAT | (stdout_append ? TB_FILE_MODE_APPEND : TB_FILE_MODE_TRUNC);
   }
   else if (!stdout_discard) {
     tb_size_t mode[2] = {TB_PIPE_MODE_RO, TB_PIPE_MODE_WO};
@@ -151,7 +169,7 @@ f_subprocess_run_values (s7_scheme* sc, s7_pointer args) {
   if (stderr_path) {
     attr.errtype = TB_PROCESS_REDIRECT_TYPE_FILEPATH;
     attr.err.path = stderr_path;
-    attr.errmode = TB_FILE_MODE_RW | TB_FILE_MODE_CREAT | TB_FILE_MODE_TRUNC;
+    attr.errmode = TB_FILE_MODE_RW | TB_FILE_MODE_CREAT | (stderr_append ? TB_FILE_MODE_APPEND : TB_FILE_MODE_TRUNC);
   }
   else if (stderr_to_stdout && out_pipe[1]) {
     attr.errtype = TB_PROCESS_REDIRECT_TYPE_PIPE;

--- a/tests/liii/subprocess-test.scm
+++ b/tests/liii/subprocess-test.scm
@@ -5,8 +5,8 @@
   (check (zero? (run "true")) => #t)
   (check (zero? (run "false")) => #f)
   (check (run "echo hello") => 0)
-  (check (zero? (run '("true"))) => #t)
-  (check (zero? (run '("false"))) => #f)
+  (check (zero? (run '(true))) => #t)
+  (check (zero? (run '(false))) => #f)
 
   (let ((orig-dir (getcwd)))
     (run "pwd" :cwd "/tmp")
@@ -14,12 +14,11 @@
   ) ;let
 
   (let ((orig-dir (getcwd)))
-    (run '("pwd") :cwd "/tmp")
+    (run '(pwd) :cwd "/tmp")
     (check (getcwd) => orig-dir)
   ) ;let
 
   (check-catch 'value-error (run "cd /tmp" :cwd "/home"))
-  (check-catch 'value-error (run '("cd" "/tmp") :cwd "/home"))
   (check-catch 'value-error (run '(cd "/tmp") :cwd "/home"))
 
   ;; run-set! / run-get tests

--- a/tests/liii/subprocess/run-and-test.scm
+++ b/tests/liii/subprocess/run-and-test.scm
@@ -1,4 +1,4 @@
-(import (liii check) (liii os) (liii path) (liii subprocess) (scheme file))
+(import (liii check) (liii either) (liii os) (liii path) (liii subprocess) (scheme file))
 
 ;; run-and
 ;; 顺序执行命令，失败即停（替代 shell 的 &&）。
@@ -19,22 +19,29 @@
 ;;
 ;; 返回值
 ;; ----
-;; integer
-;; 第一个失败命令的退出码，或 0（全部成功）。
+;; Either
+;; 全部成功时返回 Right（内含最后一个命令的退出码），
+;; 失败时返回 Left（内含 (list code command)）。
 
 (when (os-linux?)
-  (check (run-and "true" "true") => 0)
-  (check (run-and "false" "true") => 1)
-  (check (run-and "true" "false") => 1)
-  (check (run-and "true" "true" :cwd "/tmp") => 0)
-  (check (run-and "test $FOO = bar" :env '(("FOO" . "bar"))) => 0)
+  (check (either-right? (run-and "true" "true")) => #t)
+  (check (to-right (run-and "true" "true")) => 0)
+  (check (either-left? (run-and "false" "true")) => #t)
+  (check (to-left (run-and "false" "true")) => '(1 "false"))
+  (check (either-left? (run-and "true" "false")) => #t)
+  (check (to-left (run-and "true" "false")) => '(1 "false"))
+  (check (either-right? (run-and "true" "true" :cwd "/tmp")) => #t)
+  (check (to-right (run-and "true" "true" :cwd "/tmp")) => 0)
+  (check (either-right? (run-and "test $FOO = bar" :env '(("FOO" . "bar")))) => #t)
+  (check (to-right (run-and "test $FOO = bar" :env '(("FOO" . "bar")))) => 0)
 
   ;; :stdout only on last
   (let ((tmpfile "/tmp/gf-run-and-stdout.txt"))
     (when (file-exists? tmpfile)
       (delete-file tmpfile)
     )
-    (check (run-and "echo a" "echo b" :stdout tmpfile) => 0)
+    (check (either-right? (run-and "echo a" "echo b" :stdout tmpfile)) => #t)
+    (check (to-right (run-and "echo a" "echo b" :stdout tmpfile)) => 0)
     (check (path-read-text tmpfile) => "b\n")
     (when (file-exists? tmpfile)
       (delete-file tmpfile)
@@ -42,11 +49,14 @@
   )
 
   ;; :input only on first
-  (check (run-and "cat" "true" :input "hello") => 0)
+  (check (either-right? (run-and "cat" "true" :input "hello")) => #t)
+  (check (to-right (run-and "cat" "true" :input "hello")) => 0)
 
   ;; Multiple commands
-  (check (run-and "true" "true" "true") => 0)
-  (check (run-and "true" "false" "true") => 1)
+  (check (either-right? (run-and "true" "true" "true")) => #t)
+  (check (to-right (run-and "true" "true" "true")) => 0)
+  (check (either-left? (run-and "true" "false" "true")) => #t)
+  (check (to-left (run-and "true" "false" "true")) => '(1 "false"))
 )
 
 (check-report)

--- a/tests/liii/subprocess/run-and-test.scm
+++ b/tests/liii/subprocess/run-and-test.scm
@@ -1,4 +1,10 @@
-(import (liii check) (liii either) (liii os) (liii path) (liii subprocess) (scheme file))
+(import (liii check)
+  (liii either)
+  (liii os)
+  (liii path)
+  (liii subprocess)
+  (scheme file)
+) ;import
 
 ;; run-and
 ;; 顺序执行命令，失败即停（替代 shell 的 &&）。
@@ -32,21 +38,24 @@
   (check (to-left (run-and "true" "false")) => '(1 "false"))
   (check (either-right? (run-and "true" "true" :cwd "/tmp")) => #t)
   (check (to-right (run-and "true" "true" :cwd "/tmp")) => 0)
-  (check (either-right? (run-and "test $FOO = bar" :env '(("FOO" . "bar")))) => #t)
+  (check (either-right? (run-and "test $FOO = bar" :env '(("FOO" . "bar"))))
+    =>
+    #t
+  ) ;check
   (check (to-right (run-and "test $FOO = bar" :env '(("FOO" . "bar")))) => 0)
 
   ;; :stdout only on last
   (let ((tmpfile "/tmp/gf-run-and-stdout.txt"))
     (when (file-exists? tmpfile)
       (delete-file tmpfile)
-    )
+    ) ;when
     (check (either-right? (run-and "echo a" "echo b" :stdout tmpfile)) => #t)
     (check (to-right (run-and "echo a" "echo b" :stdout tmpfile)) => 0)
     (check (path-read-text tmpfile) => "b\n")
     (when (file-exists? tmpfile)
       (delete-file tmpfile)
-    )
-  )
+    ) ;when
+  ) ;let
 
   ;; :input only on first
   (check (either-right? (run-and "cat" "true" :input "hello")) => #t)
@@ -57,6 +66,6 @@
   (check (to-right (run-and "true" "true" "true")) => 0)
   (check (either-left? (run-and "true" "false" "true")) => #t)
   (check (to-left (run-and "true" "false" "true")) => '(1 "false"))
-)
+) ;when
 
 (check-report)

--- a/tests/liii/subprocess/run-ban-bang-test.scm
+++ b/tests/liii/subprocess/run-ban-bang-test.scm
@@ -1,7 +1,7 @@
 (import (liii check) (liii os) (liii subprocess))
 
 ;; run-ban!
-;; 显式禁止某个符号命令。
+;; 显式禁止某个符号命令或字符串命令。
 ;;
 ;; 语法
 ;; ----
@@ -13,12 +13,27 @@
 ;;
 ;; 说明
 ;; ----
-;; 禁止后该符号无法解析，执行时报 value-error。
+;; - 'rm 默认已被禁止。
+;; - 禁止符号命令后，该符号无法通过 run/run-values 等函数执行。
+;; - 对于字符串命令，如果命令以被禁止的符号名称开头（后跟空格或结束），
+;;   同样会报 value-error。
+;; - 使用 (run-unban! symbol) 可以取消禁止。
 
 (when (os-linux?)
+  ;; 符号命令禁止与取消
   (run-set! 'echo-cmd "/bin/echo")
   (run-ban! 'echo-cmd)
   (check-catch 'value-error (run '(echo-cmd "hello")))
-)
+
+  (run-unban! 'echo-cmd)
+  (check (zero? (run '(echo-cmd "hello"))) => #t)
+
+  ;; 'rm 默认被禁止（字符串形式）
+  (check-catch 'value-error (run "rm -rf /tmp/test"))
+  (check-catch 'value-error (run "rm"))
+
+  ;; 但 rmdir 不受影响
+  (check (zero? (run "true")) => #t)
+) ;when
 
 (check-report)

--- a/tests/liii/subprocess/run-if-test.scm
+++ b/tests/liii/subprocess/run-if-test.scm
@@ -1,4 +1,4 @@
-(import (liii check) (liii os) (liii subprocess))
+(import (liii check) (liii either) (liii os) (liii subprocess))
 
 ;; run-if
 ;; 条件执行命令（替代 shell 的 if test）。
@@ -17,13 +17,22 @@
 ;;
 ;; 返回值
 ;; ----
-;; integer
-;; 被执行命令的退出码，或 condition-command 的退出码（无 else 且条件为假时）。
+;; Either
+;; 被执行命令成功时返回 Right（内含退出码），失败时返回 Left（内含 (list code command)）。
+;; condition-command 返回非零且无 else-command 时，返回 Right（内含 condition 的退出码）。
 
 (when (os-linux?)
-  (check (run-if "true" "echo yes") => 0)
-  (check (run-if "false" "echo yes") => 1)
-  (check (run-if "false" "echo yes" "echo no") => 0)
+  (check (either-right? (run-if "true" "echo yes")) => #t)
+  (check (to-right (run-if "true" "echo yes")) => 0)
+  (check (either-right? (run-if "false" "echo yes")) => #t)
+  (check (to-right (run-if "false" "echo yes")) => 1)
+  (check (either-right? (run-if "false" "echo yes" "echo no")) => #t)
+  (check (to-right (run-if "false" "echo yes" "echo no")) => 0)
+
+  (check (either-left? (run-if "true" "false")) => #t)
+  (check (to-left (run-if "true" "false")) => '(1 "false"))
+  (check (either-left? (run-if "false" "echo yes" "false")) => #t)
+  (check (to-left (run-if "false" "echo yes" "false")) => '(1 "false"))
 )
 
 (check-report)

--- a/tests/liii/subprocess/run-if-test.scm
+++ b/tests/liii/subprocess/run-if-test.scm
@@ -5,13 +5,12 @@
 ;;
 ;; 语法
 ;; ----
-;; (run-if condition-command then-command)
 ;; (run-if condition-command then-command else-command)
 ;;
 ;; 参数
 ;; ----
 ;; condition-command : string 或 list
-;; 返回 0 时执行 then-command，否则执行 else-command（如果有）。
+;; 返回 0 时执行 then-command，否则执行 else-command。
 ;;
 ;; then-command、else-command : string 或 list
 ;;
@@ -19,18 +18,13 @@
 ;; ----
 ;; Either
 ;; 被执行命令成功时返回 Right（内含退出码），失败时返回 Left（内含 (list code command)）。
-;; condition-command 返回非零且无 else-command 时，返回 Right（内含 condition 的退出码）。
 
 (when (os-linux?)
-  (check (either-right? (run-if "true" "echo yes")) => #t)
-  (check (to-right (run-if "true" "echo yes")) => 0)
-  (check (either-right? (run-if "false" "echo yes")) => #t)
-  (check (to-right (run-if "false" "echo yes")) => 1)
   (check (either-right? (run-if "false" "echo yes" "echo no")) => #t)
   (check (to-right (run-if "false" "echo yes" "echo no")) => 0)
 
-  (check (either-left? (run-if "true" "false")) => #t)
-  (check (to-left (run-if "true" "false")) => '(1 "false"))
+  (check (either-left? (run-if "true" "false" "echo no")) => #t)
+  (check (to-left (run-if "true" "false" "echo no")) => '(1 "false"))
   (check (either-left? (run-if "false" "echo yes" "false")) => #t)
   (check (to-left (run-if "false" "echo yes" "false")) => '(1 "false"))
 ) ;when

--- a/tests/liii/subprocess/run-if-test.scm
+++ b/tests/liii/subprocess/run-if-test.scm
@@ -33,6 +33,6 @@
   (check (to-left (run-if "true" "false")) => '(1 "false"))
   (check (either-left? (run-if "false" "echo yes" "false")) => #t)
   (check (to-left (run-if "false" "echo yes" "false")) => '(1 "false"))
-)
+) ;when
 
 (check-report)

--- a/tests/liii/subprocess/run-or-test.scm
+++ b/tests/liii/subprocess/run-or-test.scm
@@ -29,6 +29,6 @@
   (check (to-right (run-or "false" "true")) => 0)
   (check (either-right? (run-or "true" "false" :cwd "/tmp")) => #t)
   (check (to-right (run-or "true" "false" :cwd "/tmp")) => 0)
-)
+) ;when
 
 (check-report)

--- a/tests/liii/subprocess/run-or-test.scm
+++ b/tests/liii/subprocess/run-or-test.scm
@@ -1,4 +1,4 @@
-(import (liii check) (liii os) (liii subprocess))
+(import (liii check) (liii either) (liii os) (liii subprocess))
 
 ;; run-or
 ;; 顺序执行命令，成功即停（替代 shell 的 ||）。
@@ -17,14 +17,18 @@
 ;;
 ;; 返回值
 ;; ----
-;; integer
-;; 0（任一命令成功），或最后一个失败命令的退出码。
+;; Either
+;; 任一命令成功时返回 Right 0，全部失败时返回 Left（内含 (list code command)）。
 
 (when (os-linux?)
-  (check (run-or "true" "false") => 0)
-  (check (run-or "false" "false") => 1)
-  (check (run-or "false" "true") => 0)
-  (check (run-or "true" "false" :cwd "/tmp") => 0)
+  (check (either-right? (run-or "true" "false")) => #t)
+  (check (to-right (run-or "true" "false")) => 0)
+  (check (either-left? (run-or "false" "false")) => #t)
+  (check (to-left (run-or "false" "false")) => '(1 "false"))
+  (check (either-right? (run-or "false" "true")) => #t)
+  (check (to-right (run-or "false" "true")) => 0)
+  (check (either-right? (run-or "true" "false" :cwd "/tmp")) => #t)
+  (check (to-right (run-or "true" "false" :cwd "/tmp")) => 0)
 )
 
 (check-report)

--- a/tests/liii/subprocess/run-pipe-test.scm
+++ b/tests/liii/subprocess/run-pipe-test.scm
@@ -22,25 +22,25 @@
 ;; 失败时返回 Left（内含 (list code command)）。
 
 (when (os-linux?)
-  (check (either-right? (run-pipe "echo hello world" '("grep" "hello"))) => #t)
-  (check (to-right (run-pipe "echo hello world" '("grep" "hello")))
+  (check (either-right? (run-pipe "echo hello world" '(grep "hello"))) => #t)
+  (check (to-right (run-pipe "echo hello world" '(grep "hello")))
     =>
     "hello world\n"
   ) ;check
-  (check (either-right? (run-pipe '("printf" "a\nb\nc") '("grep" "a") '("wc"
+  (check (either-right? (run-pipe '(printf "a\nb\nc") '(grep "a") '(wc
                                                                         "-l")))
     =>
     #t
   ) ;check
-  (check (to-right (run-pipe '("printf" "a\nb\nc") '("grep" "a") '("wc" "-l")))
+  (check (to-right (run-pipe '(printf "a\nb\nc") '(grep "a") '(wc "-l")))
     =>
     "1\n"
   ) ;check
   (check (either-right? (run-pipe "echo hello")) => #t)
   (check (to-right (run-pipe "echo hello")) => "hello\n")
 
-  (check (either-left? (run-pipe "echo hello" '("false"))) => #t)
-  (check (to-left (run-pipe "echo hello" '("false"))) => '(1 ("false")))
+  (check (either-left? (run-pipe "echo hello" '(false))) => #t)
+  (check (to-left (run-pipe "echo hello" '(false))) => '(1 (false)))
 ) ;when
 
 (check-report)

--- a/tests/liii/subprocess/run-pipe-test.scm
+++ b/tests/liii/subprocess/run-pipe-test.scm
@@ -27,8 +27,7 @@
     =>
     "hello world\n"
   ) ;check
-  (check (either-right? (run-pipe '(printf "a\nb\nc") '(grep "a") '(wc
-                                                                        "-l")))
+  (check (either-right? (run-pipe '(printf "a\nb\nc") '(grep "a") '(wc "-l")))
     =>
     #t
   ) ;check

--- a/tests/liii/subprocess/run-pipe-test.scm
+++ b/tests/liii/subprocess/run-pipe-test.scm
@@ -1,4 +1,4 @@
-(import (liii check) (liii os) (liii subprocess))
+(import (liii check) (liii either) (liii os) (liii subprocess))
 
 ;; run-pipe
 ;; 将多个命令串联为管道（替代 shell 的 |）。
@@ -17,17 +17,20 @@
 ;;
 ;; 返回值
 ;; ----
-;; string
-;; 管道最后一级的 stdout 字符串。
-;;
-;; 说明
-;; ----
-;; 基于内存缓冲实现：前一级 stdout 作为后一级的 :input 传递。
+;; Either
+;; 成功时返回 Right（内含管道最后一级的 stdout 字符串），
+;; 失败时返回 Left（内含 (list code command)）。
 
 (when (os-linux?)
-  (check (run-pipe "echo hello world" '("grep" "hello")) => "hello world\n")
-  (check (run-pipe "echo a\nb\nc" '("grep" "a") '("wc" "-l")) => "1\n")
-  (check (run-pipe "echo hello") => "hello\n")
+  (check (either-right? (run-pipe "echo hello world" '("grep" "hello"))) => #t)
+  (check (to-right (run-pipe "echo hello world" '("grep" "hello"))) => "hello world\n")
+  (check (either-right? (run-pipe '("printf" "a\nb\nc") '("grep" "a") '("wc" "-l"))) => #t)
+  (check (to-right (run-pipe '("printf" "a\nb\nc") '("grep" "a") '("wc" "-l"))) => "1\n")
+  (check (either-right? (run-pipe "echo hello")) => #t)
+  (check (to-right (run-pipe "echo hello")) => "hello\n")
+
+  (check (either-left? (run-pipe "echo hello" '("false"))) => #t)
+  (check (to-left (run-pipe "echo hello" '("false"))) => '(1 ("false")))
 )
 
 (check-report)

--- a/tests/liii/subprocess/run-pipe-test.scm
+++ b/tests/liii/subprocess/run-pipe-test.scm
@@ -23,14 +23,24 @@
 
 (when (os-linux?)
   (check (either-right? (run-pipe "echo hello world" '("grep" "hello"))) => #t)
-  (check (to-right (run-pipe "echo hello world" '("grep" "hello"))) => "hello world\n")
-  (check (either-right? (run-pipe '("printf" "a\nb\nc") '("grep" "a") '("wc" "-l"))) => #t)
-  (check (to-right (run-pipe '("printf" "a\nb\nc") '("grep" "a") '("wc" "-l"))) => "1\n")
+  (check (to-right (run-pipe "echo hello world" '("grep" "hello")))
+    =>
+    "hello world\n"
+  ) ;check
+  (check (either-right? (run-pipe '("printf" "a\nb\nc") '("grep" "a") '("wc"
+                                                                        "-l")))
+    =>
+    #t
+  ) ;check
+  (check (to-right (run-pipe '("printf" "a\nb\nc") '("grep" "a") '("wc" "-l")))
+    =>
+    "1\n"
+  ) ;check
   (check (either-right? (run-pipe "echo hello")) => #t)
   (check (to-right (run-pipe "echo hello")) => "hello\n")
 
   (check (either-left? (run-pipe "echo hello" '("false"))) => #t)
   (check (to-left (run-pipe "echo hello" '("false"))) => '(1 ("false")))
-)
+) ;when
 
 (check-report)

--- a/tests/liii/subprocess/run-sequence-test.scm
+++ b/tests/liii/subprocess/run-sequence-test.scm
@@ -30,6 +30,6 @@
   (check (to-left (run-sequence "true" "false")) => 1)
   (check (either-right? (run-sequence "true" "true" :cwd "/tmp")) => #t)
   (check (to-right (run-sequence "true" "true" :cwd "/tmp")) => 0)
-)
+) ;when
 
 (check-report)

--- a/tests/liii/subprocess/run-sequence-test.scm
+++ b/tests/liii/subprocess/run-sequence-test.scm
@@ -1,4 +1,4 @@
-(import (liii check) (liii os) (liii subprocess))
+(import (liii check) (liii either) (liii os) (liii subprocess))
 
 ;; run-sequence
 ;; 顺序执行所有命令，不因为失败而中断（替代 shell 的 ;）。
@@ -17,14 +17,19 @@
 ;;
 ;; 返回值
 ;; ----
-;; integer
-;; 最后一条命令的退出码。
+;; Either
+;; 最后一条命令成功时返回 Right（内含退出码），
+;; 失败时返回 Left（内含退出码）。
 
 (when (os-linux?)
-  (check (run-sequence "true" "false" "true") => 0)
-  (check (run-sequence "false" "true") => 0)
-  (check (run-sequence "true" "false") => 1)
-  (check (run-sequence "true" "true" :cwd "/tmp") => 0)
+  (check (either-right? (run-sequence "true" "false" "true")) => #t)
+  (check (to-right (run-sequence "true" "false" "true")) => 0)
+  (check (either-right? (run-sequence "false" "true")) => #t)
+  (check (to-right (run-sequence "false" "true")) => 0)
+  (check (either-left? (run-sequence "true" "false")) => #t)
+  (check (to-left (run-sequence "true" "false")) => 1)
+  (check (either-right? (run-sequence "true" "true" :cwd "/tmp")) => #t)
+  (check (to-right (run-sequence "true" "true" :cwd "/tmp")) => 0)
 )
 
 (check-report)

--- a/tests/liii/subprocess/run-string-test.scm
+++ b/tests/liii/subprocess/run-string-test.scm
@@ -36,8 +36,8 @@
 (when (os-linux?)
   (check (either-right? (run-string "echo hello")) => #t)
   (check (to-right (run-string "echo hello")) => "hello\n")
-  (check (either-right? (run-string '("echo" "hello"))) => #t)
-  (check (to-right (run-string '("echo" "hello"))) => "hello\n")
+  (check (either-right? (run-string '(echo "hello"))) => #t)
+  (check (to-right (run-string '(echo "hello"))) => "hello\n")
 
   (check (either-left? (run-string "false")) => #t)
   (check (to-left (run-string "false")) => 1)
@@ -78,9 +78,9 @@
   (check (either-right? (run-string "echo hello >&2" :stderr 'discard)) => #t)
   (check (to-right (run-string "echo hello >&2" :stderr 'discard)) => "")
 
-  ;; list form bypasses shell
-  (check (either-right? (run-string '("printf" "%s" "hello world"))) => #t)
-  (check (to-right (run-string '("printf" "%s" "hello world"))) => "hello world")
+  ;; list form with symbol head
+  (check (either-right? (run-string '(printf "%s" "hello world"))) => #t)
+  (check (to-right (run-string '(printf "%s" "hello world"))) => "hello world")
 ) ;when
 
 (check-report)

--- a/tests/liii/subprocess/run-string-test.scm
+++ b/tests/liii/subprocess/run-string-test.scm
@@ -1,4 +1,10 @@
-(import (liii check) (liii os) (liii path) (liii subprocess) (scheme file))
+(import (liii check)
+  (liii either)
+  (liii os)
+  (liii path)
+  (liii subprocess)
+  (scheme file)
+) ;import
 
 ;; run-string
 ;; 执行命令并返回标准输出字符串。
@@ -23,54 +29,58 @@
 ;;
 ;; 返回值
 ;; ----
-;; string
-;; 标准输出字符串（末尾换行保留）。
-;;
-;; 错误处理
-;; ----
-;; value-error 当命令返回非 0 退出码时。
-;;
-;; 说明
-;; ----
-;; 由于 run-string 不返回退出码，非 0 时抛出异常以避免静默失败。
+;; Either
+;; 成功时返回 Right（内含标准输出字符串），
+;; 失败时返回 Left（内含退出码）。
 
 (when (os-linux?)
-  (check (run-string "echo hello") => "hello\n")
-  (check (run-string '("echo" "hello")) => "hello\n")
+  (check (either-right? (run-string "echo hello")) => #t)
+  (check (to-right (run-string "echo hello")) => "hello\n")
+  (check (either-right? (run-string '("echo" "hello"))) => #t)
+  (check (to-right (run-string '("echo" "hello"))) => "hello\n")
 
-  (check-catch 'value-error (run-string "false"))
+  (check (either-left? (run-string "false")) => #t)
+  (check (to-left (run-string "false")) => 1)
 
-  (check (run-string "pwd" :cwd "/tmp") => "/tmp\n")
+  (check (either-right? (run-string "pwd" :cwd "/tmp")) => #t)
+  (check (to-right (run-string "pwd" :cwd "/tmp")) => "/tmp\n")
 
   ;; :env
-  (check (run-string "echo $FOO" :env '(("FOO" . "bar"))) => "bar\n")
+  (check (either-right? (run-string "echo $FOO" :env '(("FOO" . "bar")))) => #t)
+  (check (to-right (run-string "echo $FOO" :env '(("FOO" . "bar")))) => "bar\n")
 
   ;; :input
-  (check (run-string "cat" :input "hello world") => "hello world")
+  (check (either-right? (run-string "cat" :input "hello world")) => #t)
+  (check (to-right (run-string "cat" :input "hello world")) => "hello world")
 
   ;; :stdout to file
   (let ((tmpfile "/tmp/gf-run-string-stdout-test.txt"))
     (when (file-exists? tmpfile)
       (delete-file tmpfile)
-    )
-    (check (run-string "echo hello" :stdout tmpfile) => "")
+    ) ;when
+    (check (either-right? (run-string "echo hello" :stdout tmpfile)) => #t)
+    (check (to-right (run-string "echo hello" :stdout tmpfile)) => "")
     (check (path-read-text tmpfile) => "hello\n")
     (when (file-exists? tmpfile)
       (delete-file tmpfile)
-    )
-  )
+    ) ;when
+  ) ;let
 
   ;; :stdout 'discard
-  (check (run-string "echo hello" :stdout 'discard) => "")
+  (check (either-right? (run-string "echo hello" :stdout 'discard)) => #t)
+  (check (to-right (run-string "echo hello" :stdout 'discard)) => "")
 
   ;; :stderr 'stdout
-  (check (run-string "echo hello >&2" :stderr 'stdout) => "hello\n")
+  (check (either-right? (run-string "echo hello >&2" :stderr 'stdout)) => #t)
+  (check (to-right (run-string "echo hello >&2" :stderr 'stdout)) => "hello\n")
 
   ;; :stderr 'discard
-  (check (run-string "echo hello >&2" :stderr 'discard) => "")
+  (check (either-right? (run-string "echo hello >&2" :stderr 'discard)) => #t)
+  (check (to-right (run-string "echo hello >&2" :stderr 'discard)) => "")
 
   ;; list form bypasses shell
-  (check (run-string '("printf" "%s" "hello world")) => "hello world")
-)
+  (check (either-right? (run-string '("printf" "%s" "hello world"))) => #t)
+  (check (to-right (run-string '("printf" "%s" "hello world"))) => "hello world")
+) ;when
 
 (check-report)

--- a/tests/liii/subprocess/run-test.scm
+++ b/tests/liii/subprocess/run-test.scm
@@ -11,7 +11,7 @@
 ;; 参数
 ;; ----
 ;; command : string 或 list
-;; 字符串形式通过 /bin/sh -c 执行，列表形式逐字传递参数。
+;; 字符串形式通过 /bin/sh -c 执行，列表形式以 symbol 开头。
 ;;
 ;; keyword value ... : 可选
 ;; :cwd — 工作目录。
@@ -30,15 +30,15 @@
 ;; 说明
 ;; ----
 ;; 1. 字符串命令支持 shell 特性（通配符、变量展开等）。
-;; 2. 列表形式更安全，不经过 shell 解析。
+;; 2. 列表形式以 symbol 开头，最终转换为字符串执行。
 ;; 3. 命令中显式包含 cd 时不可同时设置 :cwd，否则抛 value-error。
 
 (when (os-linux?)
   (check (zero? (run "true")) => #t)
   (check (zero? (run "false")) => #f)
   (check (run "echo hello") => 0)
-  (check (zero? (run '("true"))) => #t)
-  (check (zero? (run '("false"))) => #f)
+  (check (zero? (run '(true))) => #t)
+  (check (zero? (run '(false))) => #f)
 
   (let ((orig-dir (getcwd)))
     (run "pwd" :cwd "/tmp")
@@ -46,19 +46,18 @@
   ) ;let
 
   (let ((orig-dir (getcwd)))
-    (run '("pwd") :cwd "/tmp")
+    (run '(pwd) :cwd "/tmp")
     (check (getcwd) => orig-dir)
   ) ;let
 
   (check-catch 'value-error (run "cd /tmp" :cwd "/home"))
-  (check-catch 'value-error (run '("cd" "/tmp") :cwd "/home"))
   (check-catch 'value-error (run '(cd "/tmp") :cwd "/home"))
 
   ;; :env
   (check (run "test $FOO = bar" :env '(("FOO" . "bar"))) => 0)
 
-  ;; list form bypasses shell
-  (check (run '("printf" "%s" "hello world")) => 0)
+  ;; list form with symbol head
+  (check (run '(printf "%s" "hello world")) => 0)
 ) ;when
 
 (check-report)

--- a/tests/liii/subprocess/run-values-test.scm
+++ b/tests/liii/subprocess/run-values-test.scm
@@ -31,91 +31,91 @@
     (check out => "hello\n")
     (check err => "")
     (check (zero? code) => #t)
-  )
+  ) ;let-values
 
   (let-values (((out err code) (run-values "false")))
     (check out => "")
     (check (zero? code) => #f)
-  )
+  ) ;let-values
 
   ;; :env
   (let-values (((out err code) (run-values "echo $FOO" :env '(("FOO" . "bar")))))
     (check out => "bar\n")
     (check (zero? code) => #t)
-  )
+  ) ;let-values
 
   ;; :input
   (let-values (((out err code) (run-values "cat" :input "hello world")))
     (check out => "hello world")
     (check (zero? code) => #t)
-  )
+  ) ;let-values
 
   ;; :timeout
   (let-values (((out err code) (run-values "sleep 10" :timeout 1)))
     (check code => -1)
-  )
+  ) ;let-values
 
   ;; :stdout to file
   (let ((tmpfile "/tmp/gf-run-values-stdout-test.txt"))
     (when (file-exists? tmpfile)
       (delete-file tmpfile)
-    )
+    ) ;when
     (let-values (((out err code) (run-values "echo hello" :stdout tmpfile)))
       (check out => "")
       (check (zero? code) => #t)
       (check (path-read-text tmpfile) => "hello\n")
-    )
+    ) ;let-values
     (when (file-exists? tmpfile)
       (delete-file tmpfile)
-    )
-  )
+    ) ;when
+  ) ;let
 
   ;; :stdout 'discard
   (let-values (((out err code) (run-values "echo hello" :stdout 'discard)))
     (check out => "")
     (check (zero? code) => #t)
-  )
+  ) ;let-values
 
   ;; :stderr 'stdout
   (let-values (((out err code) (run-values "echo hello >&2" :stderr 'stdout)))
     (check out => "hello\n")
     (check err => "")
     (check (zero? code) => #t)
-  )
+  ) ;let-values
 
   ;; :stderr 'discard
   (let-values (((out err code) (run-values "echo hello >&2" :stderr 'discard)))
     (check out => "")
     (check err => "")
     (check (zero? code) => #t)
-  )
+  ) ;let-values
 
   ;; :stdin from file
   (let ((tmpfile "/tmp/gf-run-values-stdin-test.txt"))
     (when (file-exists? tmpfile)
       (delete-file tmpfile)
-    )
+    ) ;when
     (call-with-output-file tmpfile (lambda (p) (display "file content\n" p)))
     (let-values (((out err code) (run-values "cat" :stdin tmpfile)))
       (check out => "file content\n")
       (check (zero? code) => #t)
-    )
+    ) ;let-values
     (when (file-exists? tmpfile)
       (delete-file tmpfile)
-    )
-  )
+    ) ;when
+  ) ;let
 
   ;; :stdin 'null
   (let-values (((out err code) (run-values "cat" :stdin 'null)))
     (check out => "")
     (check (zero? code) => #t)
-  )
+  ) ;let-values
 
   ;; list form with symbol head
   (let-values (((out err code) (run-values '(printf "%s" "hello world"))))
     (check out => "hello world")
     (check (zero? code) => #t)
-  )
-)
+  ) ;let-values
+) ;when
 
 (check-report)

--- a/tests/liii/subprocess/run-values-test.scm
+++ b/tests/liii/subprocess/run-values-test.scm
@@ -111,8 +111,8 @@
     (check (zero? code) => #t)
   )
 
-  ;; list form bypasses shell
-  (let-values (((out err code) (run-values '("printf" "%s" "hello world"))))
+  ;; list form with symbol head
+  (let-values (((out err code) (run-values '(printf "%s" "hello world"))))
     (check out => "hello world")
     (check (zero? code) => #t)
   )

--- a/tests/liii/subprocess/run-when-test.scm
+++ b/tests/liii/subprocess/run-when-test.scm
@@ -1,4 +1,4 @@
-(import (liii check) (liii os) (liii subprocess))
+(import (liii check) (liii either) (liii os) (liii subprocess))
 
 ;; run-when
 ;; 条件不满足时执行命令。
@@ -16,12 +16,18 @@
 ;;
 ;; 返回值
 ;; ----
-;; integer
-;; 0（条件满足时不执行），或 command 的退出码。
+;; Either
+;; condition 满足时返回 Right 0；command 成功时返回 Right（内含退出码），
+;; 失败时返回 Left（内含 (list code command)）。
 
 (when (os-linux?)
-  (check (run-when "false" "echo yes") => 0)
-  (check (run-when "true" "echo yes") => 0)
+  (check (either-right? (run-when "false" "echo yes")) => #t)
+  (check (to-right (run-when "false" "echo yes")) => 0)
+  (check (either-right? (run-when "true" "echo yes")) => #t)
+  (check (to-right (run-when "true" "echo yes")) => 0)
+
+  (check (either-left? (run-when "false" "false")) => #t)
+  (check (to-left (run-when "false" "false")) => '(1 "false"))
 )
 
 (check-report)

--- a/tests/liii/subprocess/run-when-test.scm
+++ b/tests/liii/subprocess/run-when-test.scm
@@ -28,6 +28,6 @@
 
   (check (either-left? (run-when "false" "false")) => #t)
   (check (to-left (run-when "false" "false")) => '(1 "false"))
-)
+) ;when
 
 (check-report)


### PR DESCRIPTION
## 变更内容

将 `(liii subprocess)` 中所有控制流函数的返回值统一改为 `Either` 类型：

| 函数 | Right | Left |
|------|-------|------|
| `run-and` | 最后一个命令的退出码 | `(list code command)`（第一个失败的命令）|
| `run-or` | 0（任一命令成功）| `(list code command)`（最后一个失败的命令）|
| `run-sequence` | 最后一个命令的退出码 | 最后一个命令的退出码 |
| `run-if` | 被执行命令的退出码 | `(list code command)` |
| `run-when` | 0 或 command 的退出码 | `(list code command)` |
| `run-pipe` | 最后一级 stdout 字符串 | `(list code command)` |
| `run-string` | stdout 字符串 | 退出码 |

### 其他改动

- 列表命令格式要求：第一个元素必须是 symbol，禁止全字符串列表（如 `'("ls" "-l")` 应改为 `'(ls "-l")`）
- `run-pipe` 中间命令现在也会检查错误码，失败立即返回 Left
- 错误提示基于输入动态生成，例如输入 `("ls" "-l")` 会提示 `'(ls ...)`