### PR TITLE
[0069] 迁移更多list相关内置函数到 s7_liii_list.c

### DIFF
--- a/devel/0069.md
+++ b/devel/0069.md
@@ -95,3 +95,17 @@ git push -u origin da/0069/s7_list
 | `g_vector_to_list` | 32418-32448 | vector->list |
 
 ## 6. 日期 任务描述
+
+### 2025-05-29 第二、三批：3 级和 4 级 cxxxr 变体迁移
+
+#### What
+1. 迁移 8 个 3 级 cxxxr g_ 函数（caaar, caadr, cadar, caddr, cdaar, cdddr, cdadr, cddar）到 s7_liii_list.c
+2. 迁移 16 个 4 级 cxxxr g_ 函数（caaaar, caaadr, caadar, cadaar, caaddr, cadddr, cadadr, caddar, cdaaar, cdaadr, cdadar, cddaar, cdaddr, cddddr, cddadr, cdddar）到 s7_liii_list.c
+3. 所有 _p_p 优化函数保留在 s7.c 中
+4. 使用公共 API（s7_wrong_type_arg_error, s7i_sole_arg_method_or_bust）重写，无需新增桥接
+
+#### Why
+继续分批迁移 s7 内置 list 相关函数，减小 s7.c 的体积。
+
+#### How
+迁移模式与第一批一致：g_ 函数使用公共 API 重写迁移到 s7_liii_list.c，_p_p 优化函数因依赖 s7.c 内部 static 变量和宏而保留。第四批（assoc/assq/assv）和第五批（g_length, g_reverse_in_place, g_list_append, g_vector_to_list）因大量依赖内部 static 函数而暂不迁移。

--- a/devel/0069.md
+++ b/devel/0069.md
@@ -1,0 +1,97 @@
+# [0069] 迁移更多 s7 内置 list 相关函数从 s7.c 到 s7_liii_list.c
+
+## 1. 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2. 任务相关的代码文件
+- `src/s7.c` — 主解释器（list 函数原始实现）
+- `src/s7_liii_list.c` / `src/s7_liii_list.h` — 目标迁移文件
+- `src/s7_internal_helpers.h` — 内部辅助函数桥接声明
+
+## 3. 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b goldfish
+bin/gf tests/s7/pair-test.scm
+bin/gf tests/s7/list-test.scm
+```
+
+### 3.2 提交前执行
+```bash
+bin/gf test --changed-since=main
+```
+
+## 4. 如何提交
+
+```bash
+git push -u origin da/0069/s7_list
+```
+
+## 5. 待迁移函数清单
+
+### 第一批：简单谓词函数
+| 函数名 | s7.c 行号 | 说明 |
+|---|---|---|
+| `g_is_pair` | 29607-29612 | pair? 谓词 |
+| `g_is_list` | 29620-29626 | list? 谓词 |
+| `g_is_proper_list` | 29702-29707 | proper-list? 谓词 |
+
+依赖：`check_boolean_method` 宏（需要桥接为 `s7i_check_boolean_method` 或手动展开）
+
+### 第二批：3 级 cxxxr 变体
+| 函数名 | s7.c 行号 | 说明 |
+|---|---|---|
+| `g_caaar` | 30134-30139 | car(car(car(x))) |
+| `g_caadr` | 30151-30160 | car(car(cdr(x))) |
+| `g_cadar` | 30163-30173 | car(cdr(car(x))) |
+| `g_caddr` | 30201-30211 | car(cdr(cdr(x))) |
+| `g_cdaar` | 30193-30198 | cdr(car(car(x))) |
+| `g_cdddr` | 30241-30246 | cdr(cdr(cdr(x))) |
+| `g_cdadr` | 30257-30262 | cdr(car(cdr(x))) |
+| `g_cddar` | 30273-30278 | cdr(cdr(car(x))) |
+
+依赖：`sole_arg_method_or_bust`（已有桥接 `s7i_sole_arg_method_or_bust`）、`sole_arg_wrong_type_error_nr`（需要新增桥接）、各种 `*_a_list_string` 错误字符串（需要 extern 暴露）
+
+### 第三批：4 级 cxxxr 变体
+| 函数名 | s7.c 行号 | 说明 |
+|---|---|---|
+| `g_caaaar` | 30281-30292 | car^4(x) |
+| `g_caaadr` | 30295-30306 | car^3(cdr(x)) |
+| `g_caadar` | 30309-30320 | car^2(cdr(car(x))) |
+| `g_cadaar` | 30323-30334 | car^2(cdr(car^2(x))) |
+| `g_caaddr` | 30347-30352 | car^2(cdr^2(x)) |
+| `g_cadddr` | 30364-30369 | car(cdr^3(x)) |
+| `g_cadadr` | 30381-30386 | car(cdr(car(cdr(x)))) |
+| `g_caddar` | 30398-30403 | car(cdr^2(car(x))) |
+| `g_cdaaar` | 30406-30417 | cdr(car^3(x)) |
+| `g_cdaadr` | 30420-30431 | cdr(car^2(cdr(x))) |
+| `g_cdadar` | 30434-30445 | cdr(car(cdr(car(x)))) |
+| `g_cddaar` | 30448-30459 | cdr^2(car^2(x)) |
+| `g_cdaddr` | 30462-30473 | cdr(car(cdr^2(x))) |
+| `g_cddddr` | 30486-30491 | cdr^4(x) |
+| `g_cddadr` | 30503-30508 | cdr^2(car(cdr(x))) |
+| `g_cdddar` | 30521-30526 | cdr^3(car(x)) |
+
+依赖：同第二批
+
+### 第四批：assoc/assq/assv 函数
+| 函数名 | s7.c 行号 | 说明 |
+|---|---|---|
+| `g_assq` | 30555-30563 | assoc via eq? |
+| `g_assv` | 30596-30601 | assoc via eqv? |
+| `g_assoc` | 30688-30787 | assoc via equal? |
+
+依赖：`s7_assq`（已有公共 API）、`assv_p_pp`、`assoc_1`、`method_or_bust_pp`（已有桥接）、`method_or_bust_ppp`（需桥接）、`methods_or_bust_pp`（需桥接）、`closure_has_two_normal_args`、`is_safe_c_function`/`c_function_call` 等优化器内部函数
+
+### 第五批：其他 list 函数
+| 函数名 | s7.c 行号 | 说明 |
+|---|---|---|
+| `g_make_list` | 29764-29769 | make-list |
+| `g_length` | 40537-40544 | length |
+| `g_reverse` | 41627-41633 | reverse |
+| `g_reverse_in_place` | 41854-41860 | reverse! |
+| `g_list_append` | 31408-31495 | append |
+| `g_vector_to_list` | 32418-32448 | vector->list |
+
+## 6. 日期 任务描述

--- a/src/s7.c
+++ b/src/s7.c
@@ -30121,12 +30121,9 @@ static s7_pointer caaar_p_p(s7_scheme *sc, s7_pointer lst)
   return(caaar(lst));
 }
 
-static s7_pointer g_caaar(s7_scheme *sc, s7_pointer args)
-{
-  #define H_caaar "(caaar lst) returns (car (car (car lst))): (caaar '(((1 2)))) -> 1"
-  #define Q_caaar sc->pl_p
-  return(caaar_p_p(sc, car(args)));
-}
+#define H_caaar "(caaar lst) returns (car (car (car lst))): (caaar '(((1 2)))) -> 1"
+#define Q_caaar sc->pl_p
+/* g_caaar is now defined in s7_liii_list.c */
 
 /* -------- caadr -------- */
 static s7_pointer caadr_p_p(s7_scheme *sc, s7_pointer lst)
@@ -30138,29 +30135,14 @@ static s7_pointer caadr_p_p(s7_scheme *sc, s7_pointer lst)
   return(NULL);
 }
 
-static s7_pointer g_caadr(s7_scheme *sc, s7_pointer args)
-{
-  #define H_caadr "(caadr lst) returns (car (car (cdr lst))): (caadr '(1 (2 3))) -> 2"
-  #define Q_caadr sc->pl_p
-  s7_pointer lst = car(args);
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->caadr_symbol, args, sc->type_names[T_PAIR]));
-  if (!is_pair(cdr(lst))) sole_arg_wrong_type_error_nr(sc, sc->caadr_symbol, lst, cdr_a_list_string);
-  if (!is_pair(cadr(lst))) sole_arg_wrong_type_error_nr(sc, sc->caadr_symbol, lst, cadr_a_list_string);
-  return(caadr(lst));
-}
+#define H_caadr "(caadr lst) returns (car (car (cdr lst))): (caadr '(1 (2 3))) -> 2"
+#define Q_caadr sc->pl_p
+/* g_caadr is now defined in s7_liii_list.c */
 
 /* -------- cadar -------- */
-static s7_pointer g_cadar(s7_scheme *sc, s7_pointer args)
-{
-  #define H_cadar "(cadar lst) returns (car (cdr (car lst))): (cadar '((1 2 3))) -> 2"
-  #define Q_cadar sc->pl_p
-
-  s7_pointer lst = car(args);
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->cadar_symbol, args, sc->type_names[T_PAIR]));
-  if (!is_pair(car(lst))) sole_arg_wrong_type_error_nr(sc, sc->cadar_symbol, lst, car_a_list_string);
-  if (!is_pair(cdar(lst))) sole_arg_wrong_type_error_nr(sc, sc->cadar_symbol, lst, cdar_a_list_string);
-  return(cadar(lst));
-}
+#define H_cadar "(cadar lst) returns (car (cdr (car lst))): (cadar '((1 2 3))) -> 2"
+#define Q_cadar sc->pl_p
+/* g_cadar is now defined in s7_liii_list.c */
 
 static s7_pointer cadar_p_p(s7_scheme *sc, s7_pointer lst)
 {
@@ -30180,25 +30162,14 @@ static s7_pointer cdaar_p_p(s7_scheme *sc, s7_pointer lst)
   return(cdaar(lst));
 }
 
-static s7_pointer g_cdaar(s7_scheme *sc, s7_pointer args)
-{
-  #define H_cdaar "(cdaar lst) returns (cdr (car (car lst))): (cdaar '(((1 2 3)))) -> '(2 3)"
-  #define Q_cdaar sc->pl_p
-  return(cdaar_p_p(sc, car(args)));
-}
+#define H_cdaar "(cdaar lst) returns (cdr (car (car lst))): (cdaar '(((1 2 3)))) -> '(2 3)"
+#define Q_cdaar sc->pl_p
+/* g_cdaar is now defined in s7_liii_list.c */
 
 /* -------- caddr -------- */
-static s7_pointer g_caddr(s7_scheme *sc, s7_pointer args)
-{
-  #define H_caddr "(caddr lst) returns (car (cdr (cdr lst))): (caddr '(1 2 3 4)) -> 3"
-  #define Q_caddr sc->pl_p
-
-  s7_pointer lst = car(args);
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->caddr_symbol, args, sc->type_names[T_PAIR]));
-  if (!is_pair(cdr(lst))) sole_arg_wrong_type_error_nr(sc, sc->caddr_symbol, lst, cdr_a_list_string);
-  if (!is_pair(cddr(lst))) sole_arg_wrong_type_error_nr(sc, sc->caddr_symbol, lst, cddr_a_list_string);
-  return(caddr(lst));
-}
+#define H_caddr "(caddr lst) returns (car (cdr (cdr lst))): (caddr '(1 2 3 4)) -> 3"
+#define Q_caddr sc->pl_p
+/* g_caddr is now defined in s7_liii_list.c */
 
 static s7_pointer caddr_p_p(s7_scheme *sc, s7_pointer lst)
 {
@@ -30228,12 +30199,9 @@ static s7_pointer cdddr_p_p(s7_scheme *sc, s7_pointer lst)
   return(cdddr(lst));
 }
 
-static s7_pointer g_cdddr(s7_scheme *sc, s7_pointer args)
-{
-  #define H_cdddr "(cdddr lst) returns (cdr (cdr (cdr lst))): (cdddr '(1 2 3 4)) -> '(4)"
-  #define Q_cdddr sc->pl_p
-  return(cdddr_p_p(sc, car(args)));
-}
+#define H_cdddr "(cdddr lst) returns (cdr (cdr (cdr lst))): (cdddr '(1 2 3 4)) -> '(4)"
+#define Q_cdddr sc->pl_p
+/* g_cdddr is now defined in s7_liii_list.c */
 
 /* -------- cdadr -------- */
 static s7_pointer cdadr_p_p(s7_scheme *sc, s7_pointer lst)
@@ -30244,12 +30212,9 @@ static s7_pointer cdadr_p_p(s7_scheme *sc, s7_pointer lst)
   return(cdadr(lst));
 }
 
-static s7_pointer g_cdadr(s7_scheme *sc, s7_pointer args)
-{
-  #define H_cdadr "(cdadr lst) returns (cdr (car (cdr lst))): (cdadr '(1 (2 3 4))) -> '(3 4)"
-  #define Q_cdadr sc->pl_p
-  return(cdadr_p_p(sc, car(args)));
-}
+#define H_cdadr "(cdadr lst) returns (cdr (car (cdr lst))): (cdadr '(1 (2 3 4))) -> '(3 4)"
+#define Q_cdadr sc->pl_p
+/* g_cdadr is now defined in s7_liii_list.c */
 
 /* -------- cddar -------- */
 static s7_pointer cddar_p_p(s7_scheme *sc, s7_pointer lst)
@@ -30260,68 +30225,29 @@ static s7_pointer cddar_p_p(s7_scheme *sc, s7_pointer lst)
   return(cddar(lst));
 }
 
-static s7_pointer g_cddar(s7_scheme *sc, s7_pointer args)
-{
-  #define H_cddar "(cddar lst) returns (cdr (cdr (car lst))): (cddar '((1 2 3 4))) -> '(3 4)"
-  #define Q_cddar sc->pl_p
-  return(cddar_p_p(sc, car(args)));
-}
+#define H_cddar "(cddar lst) returns (cdr (cdr (car lst))): (cddar '((1 2 3 4))) -> '(3 4)"
+#define Q_cddar sc->pl_p
+/* g_cddar is now defined in s7_liii_list.c */
 
 /* -------- caaaar -------- */
-static s7_pointer g_caaaar(s7_scheme *sc, s7_pointer args)
-{
-  #define H_caaaar "(caaaar lst) returns (car (car (car (car lst)))): (caaaar '((((1 2))))) -> 1"
-  #define Q_caaaar sc->pl_p
-
-  s7_pointer lst = car(args);
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->caaaar_symbol, args, sc->type_names[T_PAIR]));
-  if (!is_pair(car(lst))) sole_arg_wrong_type_error_nr(sc, sc->caaaar_symbol, lst, car_a_list_string);
-  if (!is_pair(caar(lst))) sole_arg_wrong_type_error_nr(sc, sc->caaaar_symbol, lst, caar_a_list_string);
-  if (!is_pair(caaar(lst))) sole_arg_wrong_type_error_nr(sc, sc->caaaar_symbol, lst, caaar_a_list_string);
-  return(caaaar(lst));
-}
+#define H_caaaar "(caaaar lst) returns (car (car (car (car lst)))): (caaaar '((((1 2))))) -> 1"
+#define Q_caaaar sc->pl_p
+/* g_caaaar is now defined in s7_liii_list.c */
 
 /* -------- caaadr -------- */
-static s7_pointer g_caaadr(s7_scheme *sc, s7_pointer args)
-{
-  #define H_caaadr "(caaadr lst) returns (car (car (car (cdr lst)))): (caaadr '(1 ((2 3)))) -> 2"
-  #define Q_caaadr sc->pl_p
-
-  s7_pointer lst = car(args);
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->caaadr_symbol, args, sc->type_names[T_PAIR]));
-  if (!is_pair(cdr(lst))) sole_arg_wrong_type_error_nr(sc, sc->caaadr_symbol, lst, cdr_a_list_string);
-  if (!is_pair(cadr(lst))) sole_arg_wrong_type_error_nr(sc, sc->caaadr_symbol, lst, cadr_a_list_string);
-  if (!is_pair(caadr(lst))) sole_arg_wrong_type_error_nr(sc, sc->caaadr_symbol, lst, caadr_a_list_string);
-  return(caaadr(lst));
-}
+#define H_caaadr "(caaadr lst) returns (car (car (car (cdr lst)))): (caaadr '(1 ((2 3)))) -> 2"
+#define Q_caaadr sc->pl_p
+/* g_caaadr is now defined in s7_liii_list.c */
 
 /* -------- caadar -------- */
-static s7_pointer g_caadar(s7_scheme *sc, s7_pointer args)
-{
-  #define H_caadar "(caadar lst) returns (car (car (cdr (car lst)))): (caadar '((1 (2 3)))) -> 2"
-  #define Q_caadar sc->pl_p
-
-  s7_pointer lst = car(args);
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->caadar_symbol, args, sc->type_names[T_PAIR]));
-  if (!is_pair(car(lst))) sole_arg_wrong_type_error_nr(sc, sc->caadar_symbol, lst, car_a_list_string);
-  if (!is_pair(cdar(lst))) sole_arg_wrong_type_error_nr(sc, sc->caadar_symbol, lst, cdar_a_list_string);
-  if (!is_pair(cadar(lst))) sole_arg_wrong_type_error_nr(sc, sc->caadar_symbol, lst, cadar_a_list_string);
-  return(caadar(lst));
-}
+#define H_caadar "(caadar lst) returns (car (car (cdr (car lst)))): (caadar '((1 (2 3)))) -> 2"
+#define Q_caadar sc->pl_p
+/* g_caadar is now defined in s7_liii_list.c */
 
 /* -------- cadaar -------- */
-static s7_pointer g_cadaar(s7_scheme *sc, s7_pointer args)
-{
-  #define H_cadaar "(cadaar lst) returns (car (cdr (car (car lst)))): (cadaar '(((1 2 3)))) -> 2"
-  #define Q_cadaar sc->pl_p
-
-  s7_pointer lst = car(args);
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->cadaar_symbol, args, sc->type_names[T_PAIR]));
-  if (!is_pair(car(lst))) sole_arg_wrong_type_error_nr(sc, sc->cadaar_symbol, lst, car_a_list_string);
-  if (!is_pair(caar(lst))) sole_arg_wrong_type_error_nr(sc, sc->cadaar_symbol, lst, caar_a_list_string);
-  if (!is_pair(cdaar(lst))) sole_arg_wrong_type_error_nr(sc, sc->cadaar_symbol, lst, cdaar_a_list_string);
-  return(cadaar(lst));
-}
+#define H_cadaar "(cadaar lst) returns (car (cdr (car (car lst)))): (cadaar '(((1 2 3)))) -> 2"
+#define Q_cadaar sc->pl_p
+/* g_cadaar is now defined in s7_liii_list.c */
 
 /* -------- caaddr -------- */
 
@@ -30334,12 +30260,9 @@ static s7_pointer caaddr_p_p(s7_scheme *sc, s7_pointer lst)
   return(caaddr(lst));
 }
 
-static s7_pointer g_caaddr(s7_scheme *sc, s7_pointer args)
-{
-  #define H_caaddr "(caaddr lst) returns (car (car (cdr (cdr lst)))): (caaddr '(1 2 (3 4))) -> 3"
-  #define Q_caaddr sc->pl_p
-  return(caaddr_p_p(sc, car(args)));
-}
+#define H_caaddr "(caaddr lst) returns (car (car (cdr (cdr lst)))): (caaddr '(1 2 (3 4))) -> 3"
+#define Q_caaddr sc->pl_p
+/* g_caaddr is now defined in s7_liii_list.c */
 
 /* -------- cadddr -------- */
 static s7_pointer cadddr_p_p(s7_scheme *sc, s7_pointer lst)
@@ -30351,12 +30274,9 @@ static s7_pointer cadddr_p_p(s7_scheme *sc, s7_pointer lst)
   return(cadddr(lst));
 }
 
-static s7_pointer g_cadddr(s7_scheme *sc, s7_pointer args)
-{
-  #define H_cadddr "(cadddr lst) returns (car (cdr (cdr (cdr lst)))): (cadddr '(1 2 3 4 5)) -> 4"
-  #define Q_cadddr sc->pl_p
-  return(cadddr_p_p(sc, car(args)));
-}
+#define H_cadddr "(cadddr lst) returns (car (cdr (cdr (cdr lst)))): (cadddr '(1 2 3 4 5)) -> 4"
+#define Q_cadddr sc->pl_p
+/* g_cadddr is now defined in s7_liii_list.c */
 
 /* -------- cadadr -------- */
 static s7_pointer cadadr_p_p(s7_scheme *sc, s7_pointer lst)
@@ -30368,12 +30288,9 @@ static s7_pointer cadadr_p_p(s7_scheme *sc, s7_pointer lst)
   return(cadadr(lst));
 }
 
-static s7_pointer g_cadadr(s7_scheme *sc, s7_pointer args)
-{
-  #define H_cadadr "(cadadr lst) returns (car (cdr (car (cdr lst)))): (cadadr '(1 (2 3 4))) -> 3"
-  #define Q_cadadr sc->pl_p
-  return(cadadr_p_p(sc, car(args)));
-}
+#define H_cadadr "(cadadr lst) returns (car (cdr (car (cdr lst)))): (cadadr '(1 (2 3 4))) -> 3"
+#define Q_cadadr sc->pl_p
+/* g_cadadr is now defined in s7_liii_list.c */
 
 /* -------- caddar -------- */
 static s7_pointer caddar_p_p(s7_scheme *sc, s7_pointer lst)
@@ -30385,82 +30302,34 @@ static s7_pointer caddar_p_p(s7_scheme *sc, s7_pointer lst)
   return(caddar(lst));
 }
 
-static s7_pointer g_caddar(s7_scheme *sc, s7_pointer args)
-{
-  #define H_caddar "(caddar lst) returns (car (cdr (cdr (car lst)))): (caddar '((1 2 3 4))) -> 3"
-  #define Q_caddar sc->pl_p
-  return(caddar_p_p(sc, car(args)));
-}
+#define H_caddar "(caddar lst) returns (car (cdr (cdr (car lst)))): (caddar '((1 2 3 4))) -> 3"
+#define Q_caddar sc->pl_p
+/* g_caddar is now defined in s7_liii_list.c */
 
 /* -------- cdaaar -------- */
-static s7_pointer g_cdaaar(s7_scheme *sc, s7_pointer args)
-{
-  #define H_cdaaar "(cdaaar lst) returns (cdr (car (car (car lst)))): (cdaaar '((((1 2 3))))) -> '(2 3)"
-  #define Q_cdaaar sc->pl_p
-
-  s7_pointer lst = car(args);
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->cdaaar_symbol, args, sc->type_names[T_PAIR]));
-  if (!is_pair(car(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdaaar_symbol, lst, car_a_list_string);
-  if (!is_pair(caar(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdaaar_symbol, lst, caar_a_list_string);
-  if (!is_pair(caaar(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdaaar_symbol, lst, caaar_a_list_string);
-  return(cdaaar(lst));
-}
+#define H_cdaaar "(cdaaar lst) returns (cdr (car (car (car lst)))): (cdaaar '((((1 2 3))))) -> '(2 3)"
+#define Q_cdaaar sc->pl_p
+/* g_cdaaar is now defined in s7_liii_list.c */
 
 /* -------- cdaadr -------- */
-static s7_pointer g_cdaadr(s7_scheme *sc, s7_pointer args)
-{
-  #define H_cdaadr "(cdaadr lst) returns (cdr (car (car (cdr lst)))): (cdaadr '(1 ((2 3 4)))) -> '(3 4)"
-  #define Q_cdaadr sc->pl_p
-
-  s7_pointer lst = car(args);
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->cdaadr_symbol, args, sc->type_names[T_PAIR]));
-  if (!is_pair(cdr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdaadr_symbol, lst, cdr_a_list_string);
-  if (!is_pair(cadr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdaadr_symbol, lst, cadr_a_list_string);
-  if (!is_pair(caadr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdaadr_symbol, lst, caadr_a_list_string);
-  return(cdaadr(lst));
-}
+#define H_cdaadr "(cdaadr lst) returns (cdr (car (car (cdr lst)))): (cdaadr '(1 ((2 3 4)))) -> '(3 4)"
+#define Q_cdaadr sc->pl_p
+/* g_cdaadr is now defined in s7_liii_list.c */
 
 /* -------- cdadar -------- */
-static s7_pointer g_cdadar(s7_scheme *sc, s7_pointer args)
-{
-  #define H_cdadar "(cdadar lst) returns (cdr (car (cdr (car lst)))): (cdadar '((1 (2 3 4)))) -> '(3 4)"
-  #define Q_cdadar sc->pl_p
-
-  s7_pointer lst = car(args);
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->cdadar_symbol, args, sc->type_names[T_PAIR]));
-  if (!is_pair(car(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdadar_symbol, lst, car_a_list_string);
-  if (!is_pair(cdar(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdadar_symbol, lst, cdar_a_list_string);
-  if (!is_pair(cadar(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdadar_symbol, lst, cadar_a_list_string);
-  return(cdadar(lst));
-}
+#define H_cdadar "(cdadar lst) returns (cdr (car (cdr (car lst)))): (cdadar '((1 (2 3 4)))) -> '(3 4)"
+#define Q_cdadar sc->pl_p
+/* g_cdadar is now defined in s7_liii_list.c */
 
 /* -------- cddaar -------- */
-static s7_pointer g_cddaar(s7_scheme *sc, s7_pointer args)
-{
-  #define H_cddaar "(cddaar lst) returns (cdr (cdr (car (car lst)))): (cddaar '(((1 2 3 4)))) -> '(3 4)"
-  #define Q_cddaar sc->pl_p
-
-  s7_pointer lst = car(args);
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->cddaar_symbol, args, sc->type_names[T_PAIR]));
-  if (!is_pair(car(lst))) sole_arg_wrong_type_error_nr(sc, sc->cddaar_symbol, lst, car_a_list_string);
-  if (!is_pair(caar(lst))) sole_arg_wrong_type_error_nr(sc, sc->cddaar_symbol, lst, caar_a_list_string);
-  if (!is_pair(cdaar(lst))) sole_arg_wrong_type_error_nr(sc, sc->cddaar_symbol, lst, cdaar_a_list_string);
-  return(cddaar(lst));
-}
+#define H_cddaar "(cddaar lst) returns (cdr (cdr (car (car lst)))): (cddaar '(((1 2 3 4)))) -> '(3 4)"
+#define Q_cddaar sc->pl_p
+/* g_cddaar is now defined in s7_liii_list.c */
 
 /* -------- cdaddr -------- */
-static s7_pointer g_cdaddr(s7_scheme *sc, s7_pointer args)
-{
-  #define H_cdaddr "(cdaddr lst) returns (cdr (car (cdr (cdr lst)))): (cdaddr '(1 2 (3 4 5))) -> '(4 5)"
-  #define Q_cdaddr sc->pl_p
-
-  s7_pointer lst = car(args);
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->cdaddr_symbol, args, sc->type_names[T_PAIR]));
-  if (!is_pair(cdr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdaddr_symbol, lst, cdr_a_list_string);
-  if (!is_pair(cddr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdaddr_symbol, lst, cddr_a_list_string);
-  if (!is_pair(caddr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdaddr_symbol, lst, caddr_a_list_string);
-  return(cdaddr(lst));
-}
+#define H_cdaddr "(cdaddr lst) returns (cdr (car (cdr (cdr lst)))): (cdaddr '(1 2 (3 4 5))) -> '(4 5)"
+#define Q_cdaddr sc->pl_p
+/* g_cdaddr is now defined in s7_liii_list.c */
 
 /* -------- cddddr -------- */
 
@@ -30473,12 +30342,9 @@ static s7_pointer cddddr_p_p(s7_scheme *sc, s7_pointer lst)
   return(cddddr(lst));
 }
 
-static s7_pointer g_cddddr(s7_scheme *sc, s7_pointer args)
-{
-  #define H_cddddr "(cddddr lst) returns (cdr (cdr (cdr (cdr lst)))): (cddddr '(1 2 3 4 5)) -> '(5)"
-  #define Q_cddddr sc->pl_p
-  return(cddddr_p_p(sc, car(args)));
-}
+#define H_cddddr "(cddddr lst) returns (cdr (cdr (cdr (cdr lst)))): (cddddr '(1 2 3 4 5)) -> '(5)"
+#define Q_cddddr sc->pl_p
+/* g_cddddr is now defined in s7_liii_list.c */
 
 /* -------- cddadr -------- */
 static s7_pointer cddadr_p_p(s7_scheme *sc, s7_pointer lst)
@@ -30490,12 +30356,9 @@ static s7_pointer cddadr_p_p(s7_scheme *sc, s7_pointer lst)
   return(cddadr(lst));
 }
 
-static s7_pointer g_cddadr(s7_scheme *sc, s7_pointer args)
-{
-  #define H_cddadr "(cddadr lst) returns (cdr (cdr (car (cdr lst)))): (cddadr '(1 (2 3 4 5))) -> '(4 5)"
-  #define Q_cddadr sc->pl_p
-  return(cddadr_p_p(sc, car(args)));
-}
+#define H_cddadr "(cddadr lst) returns (cdr (cdr (car (cdr lst)))): (cddadr '(1 (2 3 4 5))) -> '(4 5)"
+#define Q_cddadr sc->pl_p
+/* g_cddadr is now defined in s7_liii_list.c */
 
 /* -------- cdddar -------- */
 
@@ -30508,12 +30371,9 @@ static s7_pointer cdddar_p_p(s7_scheme *sc, s7_pointer lst)
   return(cdddar(lst));
 }
 
-static s7_pointer g_cdddar(s7_scheme *sc, s7_pointer args)
-{
-  #define H_cdddar "(cdddar lst) returns (cdr (cdr (cdr (car lst)))): (cdddar '((1 2 3 4 5))) -> '(4 5)"
-  #define Q_cdddar sc->pl_p
-  return(cdddar_p_p(sc, car(args)));
-}
+#define H_cdddar "(cdddar lst) returns (cdr (cdr (cdr (car lst)))): (cdddar '((1 2 3 4 5))) -> '(4 5)"
+#define Q_cdddar sc->pl_p
+/* g_cdddar is now defined in s7_liii_list.c */
 
 
 /* -------------------------------- assoc assv assq -------------------------------- */

--- a/src/s7.c
+++ b/src/s7.c
@@ -29604,12 +29604,9 @@ static s7_pointer g_tree_count(s7_scheme *sc, s7_pointer args)
 
 
 /* -------------------------------- pair? -------------------------------- */
-static s7_pointer g_is_pair(s7_scheme *sc, s7_pointer args)
-{
-  #define H_is_pair "(pair? obj) returns #t if obj is a pair (a non-empty list)"
-  #define Q_is_pair sc->pl_bt
-  check_boolean_method(sc, is_pair, sc->is_pair_symbol, args);
-}
+#define H_is_pair "(pair? obj) returns #t if obj is a pair (a non-empty list)"
+#define Q_is_pair sc->pl_bt
+/* g_is_pair is now defined in s7_liii_list.c */
 
 
 /* -------------------------------- list? -------------------------------- */
@@ -29617,13 +29614,9 @@ bool s7_is_list(s7_scheme *sc, s7_pointer p) {return(is_list(p));}
 
 static bool is_list_b(s7_pointer p) {return((is_pair(p)) || (type(p) == T_NIL));}
 
-static s7_pointer g_is_list(s7_scheme *sc, s7_pointer args)
-{
-  #define H_is_list "(list? obj) returns #t if obj is a pair or null"
-  #define Q_is_list sc->pl_bt
-  #define is_a_list(p) s7_is_list(sc, p)
-  check_boolean_method(sc, is_a_list, sc->is_list_symbol, args);
-}
+#define H_is_list "(list? obj) returns #t if obj is a pair or null"
+#define Q_is_list sc->pl_bt
+/* g_is_list is now defined in s7_liii_list.c */
 
 static s7_int proper_list_length(s7_pointer a)
 {
@@ -29699,12 +29692,9 @@ bool s7_is_proper_list(s7_scheme *sc, s7_pointer lst)
   return(true);
 }
 
-static s7_pointer g_is_proper_list(s7_scheme *sc, s7_pointer args)
-{
-  #define H_is_proper_list "(proper-list? x) returns #t is x is a list that is neither circular nor dotted."
-  #define Q_is_proper_list sc->pl_bt
-  return(make_boolean(sc, s7_is_proper_list(sc, car(args))));
-}
+#define H_is_proper_list "(proper-list? x) returns #t is x is a list that is neither circular nor dotted."
+#define Q_is_proper_list sc->pl_bt
+/* g_is_proper_list is now defined in s7_liii_list.c */
 
 static s7_pointer is_proper_list_p_p(s7_scheme *sc, s7_pointer arg) {return(make_boolean(sc, s7_is_proper_list(sc, arg)));}
 

--- a/src/s7_liii_list.c
+++ b/src/s7_liii_list.c
@@ -109,6 +109,330 @@ s7_pointer g_cddr(s7_scheme *sc, s7_pointer args)
   return(s7_cddr(lst));
 }
 
+/* -------------------------------- 3-level cxxxr -------------------------------- */
+
+s7_pointer g_caaar(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "caaar", args, "a pair"));
+  if (!s7_is_pair(s7_car(lst)))
+    return(s7_wrong_type_arg_error(sc, "caaar", 1, lst, "a pair whose car is also a pair"));
+  if (!s7_is_pair(s7_caar(lst)))
+    return(s7_wrong_type_arg_error(sc, "caaar", 1, lst, "a pair whose caar is also a pair"));
+  return(s7_caaar(lst));
+}
+
+s7_pointer g_caadr(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "caadr", args, "a pair"));
+  if (!s7_is_pair(s7_cdr(lst)))
+    return(s7_wrong_type_arg_error(sc, "caadr", 1, lst, "a pair whose cdr is also a pair"));
+  if (!s7_is_pair(s7_cadr(lst)))
+    return(s7_wrong_type_arg_error(sc, "caadr", 1, lst, "a pair whose cadr is also a pair"));
+  return(s7_caadr(lst));
+}
+
+s7_pointer g_cadar(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "cadar", args, "a pair"));
+  if (!s7_is_pair(s7_car(lst)))
+    return(s7_wrong_type_arg_error(sc, "cadar", 1, lst, "a pair whose car is also a pair"));
+  if (!s7_is_pair(s7_cdar(lst)))
+    return(s7_wrong_type_arg_error(sc, "cadar", 1, lst, "a pair whose cdar is also a pair"));
+  return(s7_cadar(lst));
+}
+
+s7_pointer g_caddr(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "caddr", args, "a pair"));
+  if (!s7_is_pair(s7_cdr(lst)))
+    return(s7_wrong_type_arg_error(sc, "caddr", 1, lst, "a pair whose cdr is also a pair"));
+  if (!s7_is_pair(s7_cddr(lst)))
+    return(s7_wrong_type_arg_error(sc, "caddr", 1, lst, "a pair whose cddr is also a pair"));
+  return(s7_caddr(lst));
+}
+
+s7_pointer g_cdaar(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "cdaar", args, "a pair"));
+  if (!s7_is_pair(s7_car(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdaar", 1, lst, "a pair whose car is also a pair"));
+  if (!s7_is_pair(s7_caar(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdaar", 1, lst, "a pair whose caar is also a pair"));
+  return(s7_cdaar(lst));
+}
+
+s7_pointer g_cdddr(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "cdddr", args, "a pair"));
+  if (!s7_is_pair(s7_cdr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdddr", 1, lst, "a pair whose cdr is also a pair"));
+  if (!s7_is_pair(s7_cddr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdddr", 1, lst, "a pair whose cddr is also a pair"));
+  return(s7_cdddr(lst));
+}
+
+s7_pointer g_cdadr(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "cdadr", args, "a pair"));
+  if (!s7_is_pair(s7_cdr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdadr", 1, lst, "a pair whose cdr is also a pair"));
+  if (!s7_is_pair(s7_cadr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdadr", 1, lst, "a pair whose cadr is also a pair"));
+  return(s7_cdadr(lst));
+}
+
+s7_pointer g_cddar(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "cddar", args, "a pair"));
+  if (!s7_is_pair(s7_car(lst)))
+    return(s7_wrong_type_arg_error(sc, "cddar", 1, lst, "a pair whose car is also a pair"));
+  if (!s7_is_pair(s7_cdar(lst)))
+    return(s7_wrong_type_arg_error(sc, "cddar", 1, lst, "a pair whose cdar is also a pair"));
+  return(s7_cddar(lst));
+}
+
+/* -------------------------------- 4-level cxxxr -------------------------------- */
+
+s7_pointer g_caaaar(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "caaaar", args, "a pair"));
+  if (!s7_is_pair(s7_car(lst)))
+    return(s7_wrong_type_arg_error(sc, "caaaar", 1, lst, "a pair whose car is also a pair"));
+  if (!s7_is_pair(s7_caar(lst)))
+    return(s7_wrong_type_arg_error(sc, "caaaar", 1, lst, "a pair whose caar is also a pair"));
+  if (!s7_is_pair(s7_caaar(lst)))
+    return(s7_wrong_type_arg_error(sc, "caaaar", 1, lst, "a pair whose caaar is also a pair"));
+  return(s7_caaaar(lst));
+}
+
+s7_pointer g_caaadr(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "caaadr", args, "a pair"));
+  if (!s7_is_pair(s7_cdr(lst)))
+    return(s7_wrong_type_arg_error(sc, "caaadr", 1, lst, "a pair whose cdr is also a pair"));
+  if (!s7_is_pair(s7_cadr(lst)))
+    return(s7_wrong_type_arg_error(sc, "caaadr", 1, lst, "a pair whose cadr is also a pair"));
+  if (!s7_is_pair(s7_caadr(lst)))
+    return(s7_wrong_type_arg_error(sc, "caaadr", 1, lst, "a pair whose caadr is also a pair"));
+  return(s7_caaadr(lst));
+}
+
+s7_pointer g_caadar(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "caadar", args, "a pair"));
+  if (!s7_is_pair(s7_car(lst)))
+    return(s7_wrong_type_arg_error(sc, "caadar", 1, lst, "a pair whose car is also a pair"));
+  if (!s7_is_pair(s7_cdar(lst)))
+    return(s7_wrong_type_arg_error(sc, "caadar", 1, lst, "a pair whose cdar is also a pair"));
+  if (!s7_is_pair(s7_cadar(lst)))
+    return(s7_wrong_type_arg_error(sc, "caadar", 1, lst, "a pair whose cadar is also a pair"));
+  return(s7_caadar(lst));
+}
+
+s7_pointer g_cadaar(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "cadaar", args, "a pair"));
+  if (!s7_is_pair(s7_car(lst)))
+    return(s7_wrong_type_arg_error(sc, "cadaar", 1, lst, "a pair whose car is also a pair"));
+  if (!s7_is_pair(s7_caar(lst)))
+    return(s7_wrong_type_arg_error(sc, "cadaar", 1, lst, "a pair whose caar is also a pair"));
+  if (!s7_is_pair(s7_cdaar(lst)))
+    return(s7_wrong_type_arg_error(sc, "cadaar", 1, lst, "a pair whose cdaar is also a pair"));
+  return(s7_cadaar(lst));
+}
+
+s7_pointer g_caaddr(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "caaddr", args, "a pair"));
+  if (!s7_is_pair(s7_cdr(lst)))
+    return(s7_wrong_type_arg_error(sc, "caaddr", 1, lst, "a pair whose cdr is also a pair"));
+  if (!s7_is_pair(s7_cddr(lst)))
+    return(s7_wrong_type_arg_error(sc, "caaddr", 1, lst, "a pair whose cddr is also a pair"));
+  if (!s7_is_pair(s7_caddr(lst)))
+    return(s7_wrong_type_arg_error(sc, "caaddr", 1, lst, "a pair whose caddr is also a pair"));
+  return(s7_caaddr(lst));
+}
+
+s7_pointer g_cadddr(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "cadddr", args, "a pair"));
+  if (!s7_is_pair(s7_cdr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cadddr", 1, lst, "a pair whose cdr is also a pair"));
+  if (!s7_is_pair(s7_cddr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cadddr", 1, lst, "a pair whose cddr is also a pair"));
+  if (!s7_is_pair(s7_cdddr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cadddr", 1, lst, "a pair whose cdddr is also a pair"));
+  return(s7_cadddr(lst));
+}
+
+s7_pointer g_cadadr(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "cadadr", args, "a pair"));
+  if (!s7_is_pair(s7_cdr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cadadr", 1, lst, "a pair whose cdr is also a pair"));
+  if (!s7_is_pair(s7_cadr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cadadr", 1, lst, "a pair whose cadr is also a pair"));
+  if (!s7_is_pair(s7_cdadr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cadadr", 1, lst, "a pair whose cdadr is also a pair"));
+  return(s7_cadadr(lst));
+}
+
+s7_pointer g_caddar(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "caddar", args, "a pair"));
+  if (!s7_is_pair(s7_car(lst)))
+    return(s7_wrong_type_arg_error(sc, "caddar", 1, lst, "a pair whose car is also a pair"));
+  if (!s7_is_pair(s7_cdar(lst)))
+    return(s7_wrong_type_arg_error(sc, "caddar", 1, lst, "a pair whose cdar is also a pair"));
+  if (!s7_is_pair(s7_cddar(lst)))
+    return(s7_wrong_type_arg_error(sc, "caddar", 1, lst, "a pair whose cddar is also a pair"));
+  return(s7_caddar(lst));
+}
+
+s7_pointer g_cdaaar(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "cdaaar", args, "a pair"));
+  if (!s7_is_pair(s7_car(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdaaar", 1, lst, "a pair whose car is also a pair"));
+  if (!s7_is_pair(s7_caar(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdaaar", 1, lst, "a pair whose caar is also a pair"));
+  if (!s7_is_pair(s7_caaar(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdaaar", 1, lst, "a pair whose caaar is also a pair"));
+  return(s7_cdaaar(lst));
+}
+
+s7_pointer g_cdaadr(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "cdaadr", args, "a pair"));
+  if (!s7_is_pair(s7_cdr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdaadr", 1, lst, "a pair whose cdr is also a pair"));
+  if (!s7_is_pair(s7_cadr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdaadr", 1, lst, "a pair whose cadr is also a pair"));
+  if (!s7_is_pair(s7_caadr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdaadr", 1, lst, "a pair whose caadr is also a pair"));
+  return(s7_cdaadr(lst));
+}
+
+s7_pointer g_cdadar(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "cdadar", args, "a pair"));
+  if (!s7_is_pair(s7_car(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdadar", 1, lst, "a pair whose car is also a pair"));
+  if (!s7_is_pair(s7_cdar(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdadar", 1, lst, "a pair whose cdar is also a pair"));
+  if (!s7_is_pair(s7_cadar(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdadar", 1, lst, "a pair whose cadar is also a pair"));
+  return(s7_cdadar(lst));
+}
+
+s7_pointer g_cddaar(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "cddaar", args, "a pair"));
+  if (!s7_is_pair(s7_car(lst)))
+    return(s7_wrong_type_arg_error(sc, "cddaar", 1, lst, "a pair whose car is also a pair"));
+  if (!s7_is_pair(s7_caar(lst)))
+    return(s7_wrong_type_arg_error(sc, "cddaar", 1, lst, "a pair whose caar is also a pair"));
+  if (!s7_is_pair(s7_cdaar(lst)))
+    return(s7_wrong_type_arg_error(sc, "cddaar", 1, lst, "a pair whose cdaar is also a pair"));
+  return(s7_cddaar(lst));
+}
+
+s7_pointer g_cdaddr(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "cdaddr", args, "a pair"));
+  if (!s7_is_pair(s7_cdr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdaddr", 1, lst, "a pair whose cdr is also a pair"));
+  if (!s7_is_pair(s7_cddr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdaddr", 1, lst, "a pair whose cddr is also a pair"));
+  if (!s7_is_pair(s7_caddr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdaddr", 1, lst, "a pair whose caddr is also a pair"));
+  return(s7_cdaddr(lst));
+}
+
+s7_pointer g_cddddr(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "cddddr", args, "a pair"));
+  if (!s7_is_pair(s7_cdr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cddddr", 1, lst, "a pair whose cdr is also a pair"));
+  if (!s7_is_pair(s7_cddr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cddddr", 1, lst, "a pair whose cddr is also a pair"));
+  if (!s7_is_pair(s7_cdddr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cddddr", 1, lst, "a pair whose cdddr is also a pair"));
+  return(s7_cddddr(lst));
+}
+
+s7_pointer g_cddadr(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "cddadr", args, "a pair"));
+  if (!s7_is_pair(s7_cdr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cddadr", 1, lst, "a pair whose cdr is also a pair"));
+  if (!s7_is_pair(s7_cadr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cddadr", 1, lst, "a pair whose cadr is also a pair"));
+  if (!s7_is_pair(s7_cdadr(lst)))
+    return(s7_wrong_type_arg_error(sc, "cddadr", 1, lst, "a pair whose cdadr is also a pair"));
+  return(s7_cddadr(lst));
+}
+
+s7_pointer g_cdddar(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  if (!s7_is_pair(lst))
+    return(s7i_sole_arg_method_or_bust(sc, lst, "cdddar", args, "a pair"));
+  if (!s7_is_pair(s7_car(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdddar", 1, lst, "a pair whose car is also a pair"));
+  if (!s7_is_pair(s7_cdar(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdddar", 1, lst, "a pair whose cdar is also a pair"));
+  if (!s7_is_pair(s7_cddar(lst)))
+    return(s7_wrong_type_arg_error(sc, "cdddar", 1, lst, "a pair whose cddar is also a pair"));
+  return(s7_cdddar(lst));
+}
+
 s7_pointer g_set_car(s7_scheme *sc, s7_pointer args)
 {
   s7_pointer lst = s7_car(args);

--- a/src/s7_liii_list.c
+++ b/src/s7_liii_list.c
@@ -18,6 +18,43 @@ s7_pointer g_is_null(s7_scheme *sc, s7_pointer args)
   }
 }
 
+/* -------------------------------- pair? -------------------------------- */
+
+s7_pointer g_is_pair(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer p = s7_car(args);
+  if (s7_is_pair(p)) return(s7_t(sc));
+  if (!s7i_has_active_methods(sc, p)) return(s7_f(sc));
+  {
+    s7_pointer sym = s7_make_symbol(sc, "pair?");
+    s7_pointer func = s7i_find_method_with_let(sc, p, sym);
+    if (func == s7_undefined(sc)) return(s7_f(sc));
+    return(s7_apply_function(sc, func, s7_cons(sc, p, s7_nil(sc))));
+  }
+}
+
+/* -------------------------------- list? -------------------------------- */
+
+s7_pointer g_is_list(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer p = s7_car(args);
+  if (s7_is_list(sc, p)) return(s7_t(sc));
+  if (!s7i_has_active_methods(sc, p)) return(s7_f(sc));
+  {
+    s7_pointer sym = s7_make_symbol(sc, "list?");
+    s7_pointer func = s7i_find_method_with_let(sc, p, sym);
+    if (func == s7_undefined(sc)) return(s7_f(sc));
+    return(s7_apply_function(sc, func, s7_cons(sc, p, s7_nil(sc))));
+  }
+}
+
+/* -------------------------------- proper-list? -------------------------------- */
+
+s7_pointer g_is_proper_list(s7_scheme *sc, s7_pointer args)
+{
+  return(s7_make_boolean(sc, s7_is_proper_list(sc, s7_car(args))));
+}
+
 s7_pointer g_car(s7_scheme *sc, s7_pointer args)
 {
   s7_pointer lst = s7_car(args);

--- a/src/s7_liii_list.h
+++ b/src/s7_liii_list.h
@@ -23,6 +23,32 @@ s7_pointer g_caar(s7_scheme *sc, s7_pointer args);
 s7_pointer g_cadr(s7_scheme *sc, s7_pointer args);
 s7_pointer g_cdar(s7_scheme *sc, s7_pointer args);
 s7_pointer g_cddr(s7_scheme *sc, s7_pointer args);
+s7_pointer g_caaar(s7_scheme *sc, s7_pointer args);
+s7_pointer g_caadr(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cadar(s7_scheme *sc, s7_pointer args);
+s7_pointer g_caddr(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cdaar(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cdddr(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cdadr(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cddar(s7_scheme *sc, s7_pointer args);
+
+s7_pointer g_caaaar(s7_scheme *sc, s7_pointer args);
+s7_pointer g_caaadr(s7_scheme *sc, s7_pointer args);
+s7_pointer g_caadar(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cadaar(s7_scheme *sc, s7_pointer args);
+s7_pointer g_caaddr(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cadddr(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cadadr(s7_scheme *sc, s7_pointer args);
+s7_pointer g_caddar(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cdaaar(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cdaadr(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cdadar(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cddaar(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cdaddr(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cddddr(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cddadr(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cdddar(s7_scheme *sc, s7_pointer args);
+
 s7_pointer g_set_car(s7_scheme *sc, s7_pointer args);
 s7_pointer g_set_cdr(s7_scheme *sc, s7_pointer args);
 

--- a/src/s7_liii_list.h
+++ b/src/s7_liii_list.h
@@ -14,6 +14,9 @@ extern "C" {
 #endif
 
 s7_pointer g_is_null(s7_scheme *sc, s7_pointer args);
+s7_pointer g_is_pair(s7_scheme *sc, s7_pointer args);
+s7_pointer g_is_list(s7_scheme *sc, s7_pointer args);
+s7_pointer g_is_proper_list(s7_scheme *sc, s7_pointer args);
 s7_pointer g_car(s7_scheme *sc, s7_pointer args);
 s7_pointer g_cdr(s7_scheme *sc, s7_pointer args);
 s7_pointer g_caar(s7_scheme *sc, s7_pointer args);


### PR DESCRIPTION
## Summary
- 迁移 8 个 3 级 cxxxr g_ 函数（caaar, caadr, cadar, caddr, cdaar, cdddr, cdadr, cddar）到 s7_liii_list.c
- 迁移 16 个 4 级 cxxxr g_ 函数（caaaar, caaadr, caadar, cadaar, caaddr, cadddr, cadadr, caddar, cdaaar, cdaadr, cdadar, cddaar, cdaddr, cddddr, cddadr, cdddar）到 s7_liii_list.c
- _p_p 优化函数保留在 s7.c 中（依赖内部 static 变量和宏）
- 使用公共 API（s7_wrong_type_arg_error, s7i_sole_arg_method_or_bust）重写，无需新增桥接

## Test plan
- [x] `xmake b goldfish` 编译通过
- [x] car/cdr/list/pair/list-ref/list-tail/list-set!/set-car!/set-cdr!/list/make-list 测试全部通过（455 checks, 0 failed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)