### PR TITLE
[0064] 清理 goldfish.hpp 中的 cpr 和 njson-schema 头文件残留

### DIFF
--- a/src/goldfish.hpp
+++ b/src/goldfish.hpp
@@ -61,9 +61,7 @@
 #endif
 #endif
 
-#include <cpr/cpr.h>
 #include <nlohmann/json.hpp>
-#include <nlohmann/json-schema.hpp>
 
 #ifdef GOLDFISH_WITH_REPL
 #include <functional>


### PR DESCRIPTION
## Summary
- 移除 `goldfish.hpp` 中残留的 `#include <cpr/cpr.h>` 和 `#include <nlohmann/json-schema.hpp>`
- 这些头文件已分别在 `liii_http.cpp` 和 `liii_njson.cpp` 中引入，goldfish.hpp 自身不需要

## Test plan
- [x] `xmake b goldfish` 编译通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)