### PR TITLE
[0071] 补充任务文档 devel/0071.md

### DIFF
--- a/devel/0071.md
+++ b/devel/0071.md
@@ -1,0 +1,38 @@
+# [0071] 将 liii hashlib 相关的 glue 实现从 goldfish.hpp 迁移到 src/liii_hashlib.cpp
+
+## 1. 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+
+## 2. 任务相关的代码文件
+- src/goldfish.hpp
+- src/liii_hashlib.cpp
+
+## 3. 如何测试
+
+### 3.1 确定性测试（单元测试）
+```
+xmake b goldfish
+bin/gf tests/goldfish/liii/hashlib-test.scm
+```
+
+## 4. 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+bin/gf test --changed-since=main
+```
+
+## 5. 2026-05-29 将 liii hashlib 相关的 glue 实现从 goldfish.hpp 迁移到 src/liii_hashlib.cpp
+### 5.1 What
+将 `liii hashlib` 相关的 C++ glue 实现从 `goldfish.hpp` 迁移到独立的 `src/liii_hashlib.cpp` 文件。
+
+1. 新建 `src/liii_hashlib.cpp`，包含 `glue_liii_hashlib` 函数及相关辅助函数
+2. 在 `goldfish.hpp` 中移除原有的内联实现
+3. 在 `xmake.lua` 中添加 `src/liii_hashlib.cpp` 到构建目标
+
+### 5.2 Why
+继续推进 goldfish.hpp 的拆分工作，将不同模块的 glue 实现拆分到独立文件，降低 goldfish.hpp 的复杂度和维护成本。
+
+### 5.3 How
+采用与 `liii_os.cpp`、`liii_path.cpp` 相同的迁移模式：将静态函数和 glue 注册函数整体搬移到新的 `.cpp` 文件，在 `goldfish.hpp` 中仅保留声明。


### PR DESCRIPTION
## Summary
- 补充 `devel/0071.md` 任务文档，记录将 liii hashlib 相关的 glue 实现从 goldfish.hpp 迁移到 src/liii_hashlib.cpp 的任务信息

## Test plan
- [x] 文档内容与 commit ce6c22c0 一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)