### PR TITLE
[0078] 添加 base64 性能基准测试

### DIFF
--- a/bench/base64-perf.scm
+++ b/bench/base64-perf.scm
@@ -1,0 +1,271 @@
+;;
+;; Copyright (C) 2026 The Goldfish Scheme Authors
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+;; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+;; License for the specific language governing permissions and limitations
+;; under the License.
+;;
+
+(import (liii base) (liii base64) (liii timeit))
+
+(define (build-ascii-string n)
+  (let ((out (open-output-string)))
+    (do ((i 0 (+ i 1)))
+      ((= i n))
+      (display (integer->char (+ 97 (modulo i 26))) out)
+    ) ;do
+    (get-output-string out)
+  ) ;let
+) ;define
+
+(define (build-binary-bv n)
+  (let ((bv (make-bytevector n)))
+    (do ((i 0 (+ i 1)))
+      ((= i n))
+      (bytevector-u8-set! bv i (modulo (* i 31) 256))
+    ) ;do
+    bv
+  ) ;let
+) ;define
+
+(define tiny-n 8)
+
+(define small-n 100)
+
+(define medium-n 1024)
+
+(define large-n (* 10 1024))
+
+(define ascii-tiny (build-ascii-string tiny-n))
+
+(define ascii-small (build-ascii-string small-n))
+
+(define ascii-medium (build-ascii-string medium-n))
+
+(define ascii-large (build-ascii-string large-n))
+
+(define bv-tiny (build-binary-bv tiny-n))
+
+(define bv-small (build-binary-bv small-n))
+
+(define bv-medium (build-binary-bv medium-n))
+
+(define bv-large (build-binary-bv large-n))
+
+(define enc-ascii-tiny (string-base64-encode ascii-tiny))
+
+(define enc-ascii-small (string-base64-encode ascii-small))
+
+(define enc-ascii-medium (string-base64-encode ascii-medium))
+
+(define enc-ascii-large (string-base64-encode ascii-large))
+
+(define enc-bv-tiny (bytevector-base64-encode bv-tiny))
+
+(define enc-bv-small (bytevector-base64-encode bv-small))
+
+(define enc-bv-medium (bytevector-base64-encode bv-medium))
+
+(define enc-bv-large (bytevector-base64-encode bv-large))
+
+(define (report title iterations time-val)
+  (display "[")
+  (display title)
+  (display "] iterations=")
+  (display iterations)
+  (display " time=")
+  (display time-val)
+  (display "s")
+  (newline)
+) ;define
+
+(do ((i 0 (+ i 1)))
+  ((= i 20))
+  (string-base64-encode ascii-medium)
+  (string-base64-decode enc-ascii-medium)
+  (bytevector-base64-encode bv-medium)
+  (bytevector-base64-decode enc-bv-medium)
+) ;do
+
+(define str-enc-tiny-iter 5000)
+
+(define str-enc-small-iter 2000)
+
+(define str-enc-medium-iter 500)
+
+(define str-enc-large-iter 100)
+
+(define str-decode-tiny-iter 5000)
+
+(define str-decode-small-iter 2000)
+
+(define str-decode-medium-iter 500)
+
+(define str-decode-large-iter 100)
+
+(define bv-enc-tiny-iter 5000)
+
+(define bv-enc-small-iter 2000)
+
+(define bv-enc-medium-iter 500)
+
+(define bv-enc-large-iter 100)
+
+(define bv-decode-tiny-iter 5000)
+
+(define bv-decode-small-iter 2000)
+
+(define bv-decode-medium-iter 500)
+
+(define bv-decode-large-iter 100)
+
+(define unified-enc-iter 500)
+
+(define unified-decode-iter 500)
+
+(display "=== (liii base64) 性能基准测试 ===")
+(newline)
+(newline)
+
+(display "--- string-base64-encode ---")
+(newline)
+(let ((t (timeit (lambda () (string-base64-encode ascii-tiny)) '() str-enc-tiny-iter))
+     ) ;
+  (report "string-base64-encode tiny(8B)" str-enc-tiny-iter t)
+) ;let
+(let ((t (timeit (lambda () (string-base64-encode ascii-small)) '() str-enc-small-iter)
+      ) ;t
+     ) ;
+  (report "string-base64-encode small(100B)" str-enc-small-iter t)
+) ;let
+(let ((t (timeit (lambda () (string-base64-encode ascii-medium)) '() str-enc-medium-iter)
+      ) ;t
+     ) ;
+  (report "string-base64-encode medium(1KB)" str-enc-medium-iter t)
+) ;let
+(let ((t (timeit (lambda () (string-base64-encode ascii-large)) '() str-enc-large-iter)
+      ) ;t
+     ) ;
+  (report "string-base64-encode large(10KB)" str-enc-large-iter t)
+) ;let
+(newline)
+
+(display "--- string-base64-decode ---")
+(newline)
+(let ((t (timeit (lambda () (string-base64-decode enc-ascii-tiny))
+           '()
+           str-decode-tiny-iter
+         ) ;timeit
+      ) ;t
+     ) ;
+  (report "string-base64-decode tiny(8B)" str-decode-tiny-iter t)
+) ;let
+(let ((t (timeit (lambda () (string-base64-decode enc-ascii-small))
+           '()
+           str-decode-small-iter
+         ) ;timeit
+      ) ;t
+     ) ;
+  (report "string-base64-decode small(100B)" str-decode-small-iter t)
+) ;let
+(let ((t (timeit (lambda () (string-base64-decode enc-ascii-medium))
+           '()
+           str-decode-medium-iter
+         ) ;timeit
+      ) ;t
+     ) ;
+  (report "string-base64-decode medium(1KB)" str-decode-medium-iter t)
+) ;let
+(let ((t (timeit (lambda () (string-base64-decode enc-ascii-large))
+           '()
+           str-decode-large-iter
+         ) ;timeit
+      ) ;t
+     ) ;
+  (report "string-base64-decode large(10KB)" str-decode-large-iter t)
+) ;let
+(newline)
+
+(display "--- bytevector-base64-encode ---")
+(newline)
+(let ((t (timeit (lambda () (bytevector-base64-encode bv-tiny)) '() bv-enc-tiny-iter))
+     ) ;
+  (report "bytevector-base64-encode tiny(8B)" bv-enc-tiny-iter t)
+) ;let
+(let ((t (timeit (lambda () (bytevector-base64-encode bv-small)) '() bv-enc-small-iter)
+      ) ;t
+     ) ;
+  (report "bytevector-base64-encode small(100B)" bv-enc-small-iter t)
+) ;let
+(let ((t (timeit (lambda () (bytevector-base64-encode bv-medium)) '() bv-enc-medium-iter)
+      ) ;t
+     ) ;
+  (report "bytevector-base64-encode medium(1KB)" bv-enc-medium-iter t)
+) ;let
+(let ((t (timeit (lambda () (bytevector-base64-encode bv-large)) '() bv-enc-large-iter)
+      ) ;t
+     ) ;
+  (report "bytevector-base64-encode large(10KB)" bv-enc-large-iter t)
+) ;let
+(newline)
+
+(display "--- bytevector-base64-decode ---")
+(newline)
+(let ((t (timeit (lambda () (bytevector-base64-decode enc-bv-tiny))
+           '()
+           bv-decode-tiny-iter
+         ) ;timeit
+      ) ;t
+     ) ;
+  (report "bytevector-base64-decode tiny(8B)" bv-decode-tiny-iter t)
+) ;let
+(let ((t (timeit (lambda () (bytevector-base64-decode enc-bv-small))
+           '()
+           bv-decode-small-iter
+         ) ;timeit
+      ) ;t
+     ) ;
+  (report "bytevector-base64-decode small(100B)" bv-decode-small-iter t)
+) ;let
+(let ((t (timeit (lambda () (bytevector-base64-decode enc-bv-medium))
+           '()
+           bv-decode-medium-iter
+         ) ;timeit
+      ) ;t
+     ) ;
+  (report "bytevector-base64-decode medium(1KB)" bv-decode-medium-iter t)
+) ;let
+(let ((t (timeit (lambda () (bytevector-base64-decode enc-bv-large))
+           '()
+           bv-decode-large-iter
+         ) ;timeit
+      ) ;t
+     ) ;
+  (report "bytevector-base64-decode large(10KB)" bv-decode-large-iter t)
+) ;let
+(newline)
+
+(display "--- base64-encode / base64-decode 统一入口 ---")
+(newline)
+(let ((t (timeit (lambda () (base64-encode ascii-medium)) '() unified-enc-iter)))
+  (report "base64-encode string(1KB)" unified-enc-iter t)
+) ;let
+(let ((t (timeit (lambda () (base64-encode bv-medium)) '() unified-enc-iter)))
+  (report "base64-encode bytevector(1KB)" unified-enc-iter t)
+) ;let
+(let ((t (timeit (lambda () (base64-decode enc-ascii-medium)) '() unified-decode-iter)
+      ) ;t
+     ) ;
+  (report "base64-decode string(1KB)" unified-decode-iter t)
+) ;let
+(let ((t (timeit (lambda () (base64-decode enc-bv-medium)) '() unified-decode-iter)))
+  (report "base64-decode bytevector(1KB)" unified-decode-iter t)
+) ;let

--- a/devel/0078.md
+++ b/devel/0078.md
@@ -1,0 +1,35 @@
+# [0078] base64 性能基准测试
+
+## 任务相关的代码文件
+- bench/base64-perf.scm
+- goldfish/liii/base64.scm
+
+## 如何测试
+```
+xmake config --yes
+xmake b goldfish
+bin/gf fmt bench/base64-perf.scm
+bin/gf bench/base64-perf.scm
+```
+
+## 2026/06/26 base64 性能基准测试
+### What
+为 `(liii base64)` 模块添加性能基准测试，覆盖字符串/字节向量编解码及统一入口在不同数据规模下的表现。
+
+1. 新增 `bench/base64-perf.scm`，使用 `(liii timeit)` 的 `timeit` 过程统计耗时
+2. 覆盖 tiny（8B）、small（100B）、medium（1KB）、large（10KB）四种数据规模
+3. 覆盖 ASCII 文本字符串与二进制字节向量两种数据类型
+4. 覆盖 `string-base64-encode` / `string-base64-decode` 字符串接口
+5. 覆盖 `bytevector-base64-encode` / `bytevector-base64-decode` 字节向量接口
+6. 覆盖 `base64-encode` / `base64-decode` 统一入口
+7. 在测试顶部一次性生成固定测试数据，避免每次迭代重复构造输入
+
+### Why
+建立 `(liii base64)` 的性能基线，为后续优化（例如下沉到 C/C++ 层）提供可量化的对比依据。
+
+### How
+- 使用 `(liii timeit)` 的 `timeit` 过程，对给定 lambda 在指定次数内累计耗时
+- 在文件顶部用 `open-output-string` 和 `make-bytevector` 预生成各档规模输入
+- 按数据规模调整迭代次数：小数据高频次（5000）、大数据低频次（100），确保总耗时可控
+- 增加 warmup 环节，循环 20 次预热以减少冷启动影响
+- 通过 `report` 过程统一输出标题、迭代次数与累计耗时（秒）


### PR DESCRIPTION
## Summary
- 新增 `bench/base64-perf.scm`，使用 `(liii timeit)` 对 `(liii base64)` 模块进行性能基准测试
- 覆盖 `string-base64-encode/decode`、`bytevector-base64-encode/decode` 以及 `base64-encode/decode` 统一入口
- 覆盖 tiny(8B)/small(100B)/medium(1KB)/large(10KB) 四种数据规模，以及 ASCII 文本与二进制字节向量两种数据类型
- 新增 `devel/0078.md` 记录任务说明，为后续 C/C++ 层下沉优化提供性能基线

## Test plan
- [x] `xmake b goldfish` 构建通过
- [x] `bin/gf fmt bench/base64-perf.scm` 格式化通过
- [x] `bin/gf bench/base64-perf.scm` 运行通过，得到各档规模耗时数据

🤖 Generated with [Claude Code](https://claude.com/claude-code)