### PR TITLE
[0088] 用 C 实现 filter 提升性能

### DIFF
--- a/bench/filter.scm
+++ b/bench/filter.scm
@@ -1,0 +1,96 @@
+;; filter 性能基准测试
+;; 测试 (liii list) 中 filter 的性能，为 C 实现（s7_liii_list.c）提供基准数据
+
+(import (liii timeit) (liii list) (scheme base))
+
+;; 运行单次 benchmark
+
+(define (bench name stmt number)
+  (let ((elapsed (timeit stmt '() number)))
+    (display name)
+    (display ": ")
+    (display elapsed)
+    (display " 秒 (")
+    (display number)
+    (display " 次)\n")
+  ) ;let
+) ;define
+
+;; 性能测试
+
+(define (run-benchmarks)
+  (display "=== filter 性能测试 ===\n\n")
+
+  ;; 空列表
+  (let ((empty '()))
+    (bench "空列表            "
+      (lambda () (filter (lambda (x) #t) empty))
+      100000
+    ) ;bench
+  ) ;let
+
+  ;; 小列表 (10 元素)，全部匹配
+  (let ((small (iota 10)))
+    (bench "小列表(10)全匹配  "
+      (lambda () (filter (lambda (x) #t) small))
+      100000
+    ) ;bench
+  ) ;let
+
+  ;; 小列表 (10 元素)，匹配一半
+  (let ((small (iota 10)))
+    (bench "小列表(10)半匹配  " (lambda () (filter even? small)) 100000)
+  ) ;let
+
+  ;; 小列表 (10 元素)，全不匹配
+  (let ((small (iota 10)))
+    (bench "小列表(10)全不匹配"
+      (lambda () (filter (lambda (x) #f) small))
+      100000
+    ) ;bench
+  ) ;let
+
+  ;; 中列表 (100 元素)，匹配一半
+  (let ((medium (iota 100)))
+    (bench "中列表(100)半匹配 " (lambda () (filter even? medium)) 100000)
+  ) ;let
+
+  ;; 大列表 (1000 元素)，匹配一半
+  (let ((large (iota 1000)))
+    (bench "大列表(1000)半匹配" (lambda () (filter even? large)) 10000)
+  ) ;let
+
+  ;; 超大列表 (10000 元素)，匹配一半
+  (let ((xlarge (iota 10000)))
+    (bench "超大列表(10000)   " (lambda () (filter even? xlarge)) 1000)
+  ) ;let
+
+  ;; 前半不匹配后半全匹配 (10000 元素)：最能体现结构共享的场景
+  (let ((l (iota 10000)))
+    (bench "后半全匹配(10000) "
+      (lambda () (filter (lambda (x) (>= x 5000)) l))
+      1000
+    ) ;bench
+  ) ;let
+
+  ;; 前半全匹配后半不匹配 (10000 元素)：无法共享结构，全部重新 cons
+  (let ((l (iota 10000)))
+    (bench "前半全匹配(10000) "
+      (lambda () (filter (lambda (x) (< x 5000)) l))
+      1000
+    ) ;bench
+  ) ;let
+
+  ;; 直调 rootlet 的 g_filter：验证 (define filter g_filter) 别名没有额外开销
+  (let ((medium (iota 100)))
+    (bench "g_filter直调(100) " (lambda () (g_filter even? medium)) 100000)
+  ) ;let
+  (let ((l (iota 10000)))
+    (bench "g_filter直调10000 "
+      (lambda () (g_filter (lambda (x) (< x 5000)) l))
+      1000
+    ) ;bench
+  ) ;let
+) ;define
+
+(run-benchmarks)

--- a/devel/0088.md
+++ b/devel/0088.md
@@ -1,0 +1,67 @@
+# [0088] 用 C 实现 filter 提升性能
+
+## 任务相关的代码文件
+- src/s7_liii_list.c （新增 g_filter)
+- src/s7_liii_list.h （声明 g_filter)
+- src/s7.c （注册 g_filter 为 semisafe typed function)
+- goldfish/srfi/srfi-1.scm (filter 改为 C 实现的别名）
+- tests/liii/list/filter-test.scm （补充边界/错误/GC 回归测试）
+- bench/filter.scm （性能基准）
+
+## 如何测试
+
+```bash
+xmake b goldfish
+bin/gf tests/liii/list/filter-test.scm
+bin/gf test --all
+bin/gf bench/filter.scm
+```
+
+## 2026-07-20 用 C 实现 filter
+
+### What
+1. 在 bench/filter.scm 中对原 Scheme 实现做性能基线评测
+2. 在 src/s7_liii_list.c 中新增 g_filter，并在 src/s7.c 中注册为 `g_filter`
+3. goldfish/srfi/srfi-1.scm 中 `(define filter g_filter)`，替换原递归 Scheme 实现
+4. tests/liii/list/filter-test.scm 补充测试：结构共享（eq?)、wrong-type-arg 错误用例、
+   空列表不调用 pred、GC 压力回归测试（30 项全部通过，`bin/gf test --all` 1472 项全部通过）
+
+性能对比（秒，越少越好）：
+
+| 场景 | Scheme 基线 | C 实现 | 加速比 |
+|---|---|---|---|
+| 空列表 (100000 次） | 0.0167 | 0.0023 | ~7x |
+| 小列表（10）全匹配 (100000 次） | 0.1587 | 0.0431 | ~3.7x |
+| 小列表（10）半匹配 (100000 次） | 0.1533 | 0.0302 | ~5.1x |
+| 小列表（10）全不匹配 (100000 次） | 0.1589 | 0.0469 | ~3.4x |
+| 中列表（100）半匹配 (100000 次） | 1.4708 | 0.2290 | ~6.4x |
+| 大列表（1000）半匹配 (10000 次） | 1.4846 | 0.2252 | ~6.6x |
+| 超大列表（10000）半匹配 (1000 次） | 1.4388 | 0.2086 | ~6.9x |
+| 后半全匹配（10000) (1000 次） | 1.5297 | 0.4128 | ~3.7x |
+| 前半全匹配（10000) (1000 次） | 1.5720 | 0.5185 | ~3.0x |
+
+### Why
+filter 是列表处理的高频函数，最终目标是用 (liii list) 的 filter 替代
+mogan (TeXmacs/progs/kernel/library/list.scm) 里的 list-filter，降低 mogan 启动和运行的开销。
+
+### How
+- 单次遍历，每个元素只调用一次 pred（通过 s7_apply_function + s7i_set_plist_1)
+- 保留参考实现的结构共享语义：末尾连续通过 pred 的最长后缀直接复用原列表节点，
+  全部匹配时返回原列表本身（eq? 为 #t)
+- GC 安全：s7 求值器可能把 c 函数的 args 放在被复用的临时 cell 里（如 with_list_t3),
+  嵌套求值会覆写这些 cell，导致 pred 失去引用被 GC 回收（曾复现
+  "attempt to apply a free cell")。因此把 pred/lst 复制进自己分配的 anchor pair,
+  并用 s7_gc_protect_via_stack 保护；构建中的中间列表挂在 anchor 的 car/cdr 上，
+  保证每次 s7_cons 之后立即对 GC 可见
+- mogan 侧适配方式（后续在 mogan 仓库进行）：list-filter 参数顺序为 (l pred?),
+  可用 `(define (list-filter l pred?) (filter pred? l))` 包装
+
+### 方案讨论：注册名 g_filter + 库内别名（已定稿）
+- `(define filter g_filter)` 别名无性能损失：benchmark 直调 g_filter 与别名对比，
+  两轮差异 ±2~5% 且方向不一致，属运行噪声（s7 优化器在调用点解析 slot 值，
+  最终调用同一个 c-function 指针）
+- 不能注册为 "filter" 后只在库里象征性 export:boot.scm 的 define-library
+  通过遍历库自身 (curlet) 收集导出项，只有本地 define 或 import 注入的绑定
+  才会被带出，rootlet 绑定不会被导出
+- 结论：注册名 g_filter（不污染 rootlet 命名空间）+ 库内别名，沿用 0087
+  (scheme char) 的接入模式

--- a/goldfish/srfi/srfi-1.scm
+++ b/goldfish/srfi/srfi-1.scm
@@ -268,22 +268,7 @@
       (apply append (apply map proc lists))
     ) ;define
 
-    (define (filter pred l)
-      (let recur
-        ((l l))
-        (if (null-list? l)
-          l
-          (let ((head (car l)) (tail (cdr l)))
-            (if (pred head)
-              (let ((new-tail (recur tail)))
-                (if (eq? tail new-tail) l (cons head new-tail))
-              ) ;let
-              (recur tail)
-            ) ;if
-          ) ;let
-        ) ;if
-      ) ;let
-    ) ;define
+    (define filter g_filter)
 
     (define (partition pred l)
       (let loop

--- a/src/s7.c
+++ b/src/s7.c
@@ -86900,6 +86900,10 @@ is #t, the string is also sent to the current-output-port."
   sc->list_tail_symbol =             defun("list-tail",	        list_tail,		2, 0, false);
   sc->make_list_symbol =             defun("make-list",  	make_list,		1, 1, false); set_is_saver(sc->make_list_symbol);
 
+  #define H_filter "(g_filter pred lst) returns a list of the elements of lst for which (pred element) is not #f"
+  #define Q_filter s7_make_signature(sc, 3, sc->is_list_symbol, sc->is_procedure_symbol, sc->is_list_symbol)
+  s7_define_semisafe_typed_function(sc, "g_filter", g_filter, 2, 0, false, H_filter, Q_filter);
+
   sc->length_symbol =                defun("length",		length,			1, 0, false);
   sc->copy_symbol =                  defun("copy",		copy,			1, 3, false);
   /* set_is_definer(sc->copy_symbol); */ /* (copy (inlet 'a 1) (curlet)), but this check needs to be smarter */

--- a/src/s7_liii_list.c
+++ b/src/s7_liii_list.c
@@ -7,6 +7,8 @@
 #include "s7_liii_list.h"
 #include "s7_internal_helpers.h"
 
+#include <stddef.h>
+
 s7_pointer g_is_null(s7_scheme *sc, s7_pointer args)
 {
   s7_pointer p = s7_car(args);
@@ -497,6 +499,61 @@ s7_pointer g_list_tail(s7_scheme *sc, s7_pointer args)
 s7_pointer g_cons(s7_scheme *sc, s7_pointer args)
 {
   return(s7_cons(sc, s7_car(args), s7_cadr(args)));
+}
+
+/* -------------------------------- filter -------------------------------- */
+
+s7_pointer g_filter(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_cadr(args);
+  if (!s7_is_pair(lst))
+    {
+      if (s7_is_null(sc, lst)) return(s7_nil(sc));
+      return(s7_wrong_type_arg_error(sc, "filter", 2, lst, "a proper list"));
+    }
+  /* args may live in evaluator-recycled cells, so keep pred and lst in our own pairs.
+   *   anchor = ((pred lst) . work), work's car holds the reversed kept elements before
+   *   the current all-passing run, work's cdr later holds the result; one protected
+   *   pair keeps everything GC-reachable while pred runs */
+  s7_pointer keep = s7_cons(sc, s7_car(args), s7_cons(sc, lst, s7_nil(sc)));
+  s7_pointer anchor = s7_cons(sc, keep, s7_cons(sc, s7_nil(sc), s7_nil(sc)));
+  s7_gc_protect_via_stack(sc, anchor);
+  s7_pointer work = s7_cdr(anchor);
+  s7_pointer pred = s7_car(keep);
+  s7_pointer run_start = NULL;
+  s7_pointer p = lst;
+  while (s7_is_pair(p))
+    {
+      if (s7i_is_true(sc, s7_apply_function(sc, pred, s7i_set_plist_1(sc, s7_car(p)))))
+        {
+          if (!run_start) run_start = p;
+        }
+      else
+        {
+          if (run_start)
+            {
+              for (s7_pointer q = run_start; q != p; q = s7_cdr(q))
+                s7_set_car(work, s7_cons(sc, s7_car(q), s7_car(work)));
+              run_start = NULL;
+            }
+        }
+      p = s7_cdr(p);
+    }
+  if (!s7_is_null(sc, p))
+    {
+      s7_gc_unprotect_via_stack(sc, anchor);
+      return(s7_wrong_type_arg_error(sc, "filter", 2, lst, "a proper list"));
+    }
+  /* share the longest all-passing suffix, like the reference implementation */
+  s7_pointer result = (run_start) ? run_start : s7_nil(sc);
+  s7_set_cdr(work, result);
+  for (s7_pointer q = s7_car(work); s7_is_pair(q); q = s7_cdr(q))
+    {
+      result = s7_cons(sc, s7_car(q), result);
+      s7_set_cdr(work, result);
+    }
+  s7_gc_unprotect_via_stack(sc, anchor);
+  return(result);
 }
 
 s7_pointer g_list(s7_scheme *sc, s7_pointer args)

--- a/src/s7_liii_list.h
+++ b/src/s7_liii_list.h
@@ -57,6 +57,7 @@ s7_pointer g_list_tail(s7_scheme *sc, s7_pointer args);
 
 s7_pointer g_cons(s7_scheme *sc, s7_pointer args);
 s7_pointer g_list(s7_scheme *sc, s7_pointer args);
+s7_pointer g_filter(s7_scheme *sc, s7_pointer args);
 
 s7_pointer g_list_set(s7_scheme *sc, s7_pointer args);
 s7_pointer g_list_set_i(s7_scheme *sc, s7_pointer args);

--- a/tests/liii/list/filter-test.scm
+++ b/tests/liii/list/filter-test.scm
@@ -41,7 +41,8 @@
 ;; --------
 ;; - 空列表返回空列表
 ;; - 如果没有元素满足条件返回空列表
-;; - 如果所有元素都满足条件返回原列表的拷贝
+;; - 如果所有元素都满足条件，返回原列表本身（结构共享）
+;; - 末尾连续满足条件的最长后缀与原列表共享
 ;; - 可以保持原始列表的顺序
 ;;
 ;; 注意事项
@@ -117,6 +118,41 @@
   (check (length (filter (lambda (x) #t) large-list)) => 1000)
   (check (length (filter (lambda (x) (> x 0)) large-list)) => 1000)
   (check (length (filter (lambda (x) (> x 5)) large-list)) => 0)
+) ;let
+
+
+;; 结构共享：全部匹配时返回原列表本身
+(let ((l (list 1 2 3)))
+  (check (eq? (filter (lambda (x) #t) l) l) => #t)
+) ;let
+
+;; 结构共享：末尾连续匹配的最长后缀与原列表共享
+(let* ((l (list 1 2 3 4 5 6)) (r (filter (lambda (x) (> x 3)) l)))
+  (check r => '(4 5 6))
+  (check (eq? r (cdddr l)) => #t)
+) ;let*
+
+
+;; 错误用例：非列表参数
+(check-catch 'wrong-type-arg (filter even? 5))
+(check-catch 'wrong-type-arg (filter even? '(1 2 . 3)))
+
+;; 空列表不会调用 pred，pred 不是函数也不报错
+(check (filter 5 '()) => '())
+
+
+;; GC 压力回归测试：闭包 pred + 大量临时 cons，反复触发 GC
+;; （曾导致 g_filter 中 pred 被误回收：attempt to apply a free cell）
+(let ((l (iota 10000)))
+  (do ((i 0 (+ i 1)))
+    ((= i 200))
+    (filter (lambda (x) (< x 5000)) l)
+    (filter (lambda (x) (>= x 5000)) l)
+    (filter (lambda (x) #f) l)
+  ) ;do
+  (check (length (filter (lambda (x) (< x 5000)) l)) => 5000)
+  (check (length (filter (lambda (x) (>= x 5000)) l)) => 5000)
+  (check (filter (lambda (x) #f) l) => '())
 ) ;let
 
 


### PR DESCRIPTION
## Summary
- 在 src/s7_liii_list.c 新增 g_filter 并在 src/s7.c 注册，(srfi srfi-1) 的 filter 由 Scheme 递归实现切换为 C 实现，性能提升 3~7 倍
- 保留参考实现的结构共享语义（全匹配返回原列表、末尾全通过后缀共享），pred 每元素只调用一次
- 补充 filter 单元测试至 30 项（结构共享 eq?、wrong-type-arg 错误用例、GC 压力回归测试）；新增 bench/filter.scm 基准
- 详细设计与性能数据见 devel/0088.md；最终目标：替代 mogan 内核的 list-filter

## Test plan
- [x] bin/gf tests/liii/list/filter-test.scm（30 项通过）
- [x] bin/gf test --all（1472 项全部通过）
- [x] bin/gf bench/filter.scm（C vs Scheme 基线 3~7x）