### PR TITLE
[0089] 用 C 实现 take 提升性能

### DIFF
--- a/bench/take.scm
+++ b/bench/take.scm
@@ -1,0 +1,73 @@
+;; take 性能基准测试
+;; 测试 (liii list) 中 take 的性能，为 C 实现（s7_liii_list.c）提供基准数据
+
+(import (liii timeit) (liii list) (scheme base))
+
+;; 运行单次 benchmark
+
+(define (bench name stmt number)
+  (let ((elapsed (timeit stmt '() number)))
+    (display name)
+    (display ": ")
+    (display elapsed)
+    (display " 秒 (")
+    (display number)
+    (display " 次)\n")
+  ) ;let
+) ;define
+
+;; 性能测试
+
+(define (run-benchmarks)
+  (display "=== take 性能测试 ===\n\n")
+
+  ;; 空列表
+  (let ((empty '()))
+    (bench "空列表 take 0      " (lambda () (take empty 0)) 100000)
+  ) ;let
+
+  ;; 小列表 (10 元素)，取前 0 个
+  (let ((small (iota 10)))
+    (bench "小列表(10) take 0  " (lambda () (take small 0)) 100000)
+  ) ;let
+
+  ;; 小列表 (10 元素)，取前 5 个
+  (let ((small (iota 10)))
+    (bench "小列表(10) take 5  " (lambda () (take small 5)) 100000)
+  ) ;let
+
+  ;; 小列表 (10 元素)，全部取走
+  (let ((small (iota 10)))
+    (bench "小列表(10) take 10 " (lambda () (take small 10)) 100000)
+  ) ;let
+
+  ;; 中列表 (100 元素)，取一半
+  (let ((medium (iota 100)))
+    (bench "中列表(100) take 50" (lambda () (take medium 50)) 100000)
+  ) ;let
+
+  ;; 大列表 (1000 元素)，取一半
+  (let ((large (iota 1000)))
+    (bench "大列表(1000) 500   " (lambda () (take large 500)) 10000)
+  ) ;let
+
+  ;; 超大列表 (10000 元素)，取一半
+  (let ((xlarge (iota 10000)))
+    (bench "超大列表(10000)    " (lambda () (take xlarge 5000)) 1000)
+  ) ;let
+
+  ;; 超大列表 (10000 元素)，全部取走
+  (let ((xlarge (iota 10000)))
+    (bench "全取(10000)        " (lambda () (take xlarge 10000)) 1000)
+  ) ;let
+
+  ;; 直调 rootlet 的 g_take：验证 (define take g_take) 别名没有额外开销
+  (let ((medium (iota 100)))
+    (bench "g_take直调(100)    " (lambda () (g_take medium 50)) 100000)
+  ) ;let
+  (let ((xlarge (iota 10000)))
+    (bench "g_take直调(10000)  " (lambda () (g_take xlarge 5000)) 1000)
+  ) ;let
+) ;define
+
+(run-benchmarks)

--- a/devel/0089.md
+++ b/devel/0089.md
@@ -1,0 +1,58 @@
+# [0089] 用 C 实现 take 提升性能
+
+## 任务相关的代码文件
+- src/s7_liii_list.c （新增 g_take)
+- src/s7_liii_list.h （声明 g_take)
+- src/s7.c （注册 g_take 为 semisafe typed function)
+- goldfish/srfi/srfi-1.scm (take 改为 C 实现的别名）
+- tests/liii/list/take-test.scm （补充结构拷贝/GC 回归测试）
+- bench/take.scm （性能基准）
+
+## 如何测试
+
+```bash
+xmake b goldfish
+bin/gf tests/liii/list/take-test.scm
+bin/gf test --all
+bin/gf bench/take.scm
+```
+
+## 2026-07-20 用 C 实现 take
+
+### What
+1. 在 bench/take.scm 中对原 Scheme 实现做性能基线评测
+2. 在 src/s7_liii_list.c 中新增 g_take，并在 src/s7.c 中注册为 `g_take`
+3. goldfish/srfi/srfi-1.scm 中 `(define take g_take)`，替换原递归 Scheme 实现
+4. tests/liii/list/take-test.scm 补充测试：结果总是新列表结构（不共享节点）、
+   修改结果不影响原列表、大列表 + GC 压力回归测试
+   （22 项全部通过，`bin/gf test --all` 1472 项全部通过）
+
+性能对比（秒，越少越好）：
+
+| 场景 | Scheme 基线 | C 实现 | 加速比 |
+|---|---|---|---|
+| 空列表 take 0 (100000 次） | 0.0103 | 0.0031 | ~3.3x |
+| 小列表（10) take 0 (100000 次） | 0.0116 | 0.0028 | ~4.1x |
+| 小列表（10) take 5 (100000 次） | 0.0198 | 0.0099 | ~2.0x |
+| 小列表（10) take 10 (100000 次） | 0.0268 | 0.0166 | ~1.6x |
+| 中列表（100) take 50 (100000 次） | 0.1224 | 0.0636 | ~1.9x |
+| 大列表（1000) take 500 (10000 次） | 0.1277 | 0.0636 | ~2.0x |
+| 超大列表（10000) take 5000 (1000 次） | 0.1329 | 0.0613 | ~2.2x |
+| 全取（10000) (1000 次） | 0.2737 | 0.1244 | ~2.2x |
+
+### Why
+take 是列表处理的高频函数，沿用 0088 (filter) 的思路，将 srfi-1 中的递归
+Scheme 实现下沉为 C 实现，降低 mogan 等上层应用的列表处理开销。
+
+### How
+- 单次循环构建结果：先分配一个 dummy head pair 作为 anchor 并用
+  s7_gc_protect_via_stack 保护，逐个 s7_cons 新节点挂到尾部，
+  每个新 pair 在 s7_cons 后立即链接进结果，保证对 GC 可见
+- 与 filter 不同：take 中没有 Scheme 回调（不调用 pred)，args 不会被
+  求值器覆写，无需像 g_filter 那样为 pred 自建 anchor
+- 语义与参考实现一致：take 总是创建新的列表结构，即使 k 等于列表长度
+  也不共享节点（用 eq? 测试固化该行为）
+- 错误处理：k 非整数或为负数、k 超过列表长度（含 dotted list 提前结束）
+  均抛 wrong-type-arg，与原测试用例的预期保持一致
+- 接入模式沿用 0088：注册名 g_take（不污染 rootlet 命名空间）+ 库内别名，
+  benchmark 中 g_take 直调与别名性能一致，无额外开销

--- a/goldfish/srfi/srfi-1.scm
+++ b/goldfish/srfi/srfi-1.scm
@@ -132,12 +132,7 @@
       (list-ref x 9)
     ) ;define
 
-    (define (take l k)
-      (let loop
-        ((l l) (k k))
-        (if (zero? k) '() (cons (car l) (loop (cdr l) (- k 1))))
-      ) ;let
-    ) ;define
+    (define take g_take)
 
     (define drop list-tail)
 

--- a/src/s7.c
+++ b/src/s7.c
@@ -86904,6 +86904,10 @@ is #t, the string is also sent to the current-output-port."
   #define Q_filter s7_make_signature(sc, 3, sc->is_list_symbol, sc->is_procedure_symbol, sc->is_list_symbol)
   s7_define_semisafe_typed_function(sc, "g_filter", g_filter, 2, 0, false, H_filter, Q_filter);
 
+  #define H_take "(g_take lst k) returns a list of the first k elements of lst"
+  #define Q_take s7_make_signature(sc, 3, sc->is_list_symbol, sc->is_list_symbol, sc->is_integer_symbol)
+  s7_define_semisafe_typed_function(sc, "g_take", g_take, 2, 0, false, H_take, Q_take);
+
   sc->length_symbol =                defun("length",		length,			1, 0, false);
   sc->copy_symbol =                  defun("copy",		copy,			1, 3, false);
   /* set_is_definer(sc->copy_symbol); */ /* (copy (inlet 'a 1) (curlet)), but this check needs to be smarter */

--- a/src/s7_liii_list.c
+++ b/src/s7_liii_list.c
@@ -556,6 +556,39 @@ s7_pointer g_filter(s7_scheme *sc, s7_pointer args)
   return(result);
 }
 
+/* -------------------------------- take -------------------------------- */
+
+s7_pointer g_take(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  s7_pointer k = s7_cadr(args);
+  if (!s7_is_integer(k))
+    return(s7_wrong_type_arg_error(sc, "take", 2, k, "an integer"));
+  s7_int n = s7_integer(k);
+  if (n < 0)
+    return(s7_wrong_type_arg_error(sc, "take", 2, k, "a non-negative integer"));
+  if (n == 0) return(s7_nil(sc));
+  /* no Scheme callbacks here, so args stay put; only the result being built
+   * needs a GC anchor, with each new pair linked in right after s7_cons */
+  s7_pointer head = s7_cons(sc, s7_nil(sc), s7_nil(sc));
+  s7_gc_protect_via_stack(sc, head);
+  s7_pointer tail = head;
+  s7_pointer p = lst;
+  for (s7_int i = 0; i < n; i++)
+    {
+      if (!s7_is_pair(p))
+        {
+          s7_gc_unprotect_via_stack(sc, head);
+          return(s7_wrong_type_arg_error(sc, "take", 1, lst, "a list of sufficient length"));
+        }
+      s7_set_cdr(tail, s7_cons(sc, s7_car(p), s7_nil(sc)));
+      tail = s7_cdr(tail);
+      p = s7_cdr(p);
+    }
+  s7_gc_unprotect_via_stack(sc, head);
+  return(s7_cdr(head));
+}
+
 s7_pointer g_list(s7_scheme *sc, s7_pointer args)
 {
   return(s7i_copy_proper_list(sc, args));

--- a/src/s7_liii_list.h
+++ b/src/s7_liii_list.h
@@ -58,6 +58,7 @@ s7_pointer g_list_tail(s7_scheme *sc, s7_pointer args);
 s7_pointer g_cons(s7_scheme *sc, s7_pointer args);
 s7_pointer g_list(s7_scheme *sc, s7_pointer args);
 s7_pointer g_filter(s7_scheme *sc, s7_pointer args);
+s7_pointer g_take(s7_scheme *sc, s7_pointer args);
 
 s7_pointer g_list_set(s7_scheme *sc, s7_pointer args);
 s7_pointer g_list_set_i(s7_scheme *sc, s7_pointer args);

--- a/tests/liii/list/take-test.scm
+++ b/tests/liii/list/take-test.scm
@@ -76,4 +76,29 @@
 (check-catch 'wrong-type-arg (take '(1 2 3) "not a number"))
 
 
+;; take 总是创建新的列表结构，即使取走全部元素也不共享节点
+(let ((l (list 1 2 3)))
+  (check (eq? (take l 3) l) => #f)
+  (check (take l 3) => '(1 2 3))
+  ;; 修改结果不影响原列表
+  (let ((r (take l 2)))
+    (set-car! r 99)
+    (check l => '(1 2 3))
+  ) ;let
+) ;let
+
+
+;; 大列表 + GC 压力回归测试
+(let ((l (iota 10000)))
+  (check (take l 5000) => (iota 5000))
+  (check (length (take l 10000)) => 10000)
+  (check l => (iota 10000))
+) ;let
+
+(do ((i 0 (+ i 1)))
+  ((= i 1000))
+  (take (iota 100) 50)
+) ;do
+
+
 (check-report)


### PR DESCRIPTION
## Summary
- 在 src/s7_liii_list.c 新增 g_take 并在 src/s7.c 注册，srfi-1 的 take 改为 C 实现别名，性能提升约 1.6x~4.1x
- tests/liii/list/take-test.scm 补充结构拷贝语义、大列表与 GC 压力回归测试（22 项通过，全量 1472 项通过）
- 新增 bench/take.scm 性能基准与 devel/0089.md 开发文档

## Test plan
- [x] xmake b goldfish
- [x] bin/gf tests/liii/list/take-test.scm
- [x] bin/gf test --all
- [x] bin/gf bench/take.scm

🤖 Generated with [Claude Code](https://claude.com/claude-code)