### PR TITLE
[0090] 用 C 实现 take-right / drop-right 提升性能

### DIFF
--- a/bench/drop.scm
+++ b/bench/drop.scm
@@ -1,0 +1,46 @@
+;; drop 性能基准测试
+;; drop 在 srfi-1 中定义为 list-tail 的别名，而 list-tail 是带 p_pp 快速路径的
+;; C 内置函数。本基准用于验证 drop 是否已有 C 级性能，以及别名是否有额外开销。
+
+(import (liii timeit) (liii list) (scheme base))
+
+(define (bench name stmt number)
+  (let ((elapsed (timeit stmt '() number)))
+    (display name)
+    (display ": ")
+    (display elapsed)
+    (display " 秒 (")
+    (display number)
+    (display " 次)\n")
+  ) ;let
+) ;define
+
+(define (run-benchmarks)
+  (display "=== drop 性能测试 ===\n\n")
+
+  (let ((small (iota 10)))
+    (bench "小列表(10) drop 5    " (lambda () (drop small 5)) 100000)
+  ) ;let
+
+  (let ((medium (iota 100)))
+    (bench "中列表(100) drop 50  " (lambda () (drop medium 50)) 100000)
+  ) ;let
+
+  (let ((large (iota 1000)))
+    (bench "大列表(1000) drop 500" (lambda () (drop large 500)) 10000)
+  ) ;let
+
+  (let ((xlarge (iota 10000)))
+    (bench "超大列表(10000) 5000 " (lambda () (drop xlarge 5000)) 1000)
+  ) ;let
+
+  ;; 直调 list-tail：验证 (define drop list-tail) 别名没有额外开销
+  (let ((medium (iota 100)))
+    (bench "list-tail直调(100)   " (lambda () (list-tail medium 50)) 100000)
+  ) ;let
+  (let ((xlarge (iota 10000)))
+    (bench "list-tail直调(10000) " (lambda () (list-tail xlarge 5000)) 1000)
+  ) ;let
+) ;define
+
+(run-benchmarks)

--- a/bench/take-right-drop-right.scm
+++ b/bench/take-right-drop-right.scm
@@ -1,0 +1,77 @@
+;; take-right / drop-right 性能基准测试
+;; 测试 (liii list) 中 take-right 和 drop-right 的性能，为 C 实现提供基准数据
+
+(import (liii timeit) (liii list) (scheme base))
+
+(define (bench name stmt number)
+  (let ((elapsed (timeit stmt '() number)))
+    (display name)
+    (display ": ")
+    (display elapsed)
+    (display " 秒 (")
+    (display number)
+    (display " 次)\n")
+  ) ;let
+) ;define
+
+(define (run-benchmarks)
+  (display "=== take-right / drop-right 性能测试 ===\n\n")
+
+  (let ((small (iota 10)))
+    (bench "小列表(10) take-right 5   " (lambda () (take-right small 5)) 100000)
+  ) ;let
+  (let ((small (iota 10)))
+    (bench "小列表(10) drop-right 5   " (lambda () (drop-right small 5)) 100000)
+  ) ;let
+
+  (let ((medium (iota 100)))
+    (bench "中列表(100) take-right 50 "
+      (lambda () (take-right medium 50))
+      100000
+    ) ;bench
+  ) ;let
+  (let ((medium (iota 100)))
+    (bench "中列表(100) drop-right 50 "
+      (lambda () (drop-right medium 50))
+      100000
+    ) ;bench
+  ) ;let
+
+  (let ((large (iota 1000)))
+    (bench "大列表(1000) take-right   " (lambda () (take-right large 500)) 10000)
+  ) ;let
+  (let ((large (iota 1000)))
+    (bench "大列表(1000) drop-right   " (lambda () (drop-right large 500)) 10000)
+  ) ;let
+
+  (let ((xlarge (iota 10000)))
+    (bench "超大列表(10000) take-right"
+      (lambda () (take-right xlarge 5000))
+      1000
+    ) ;bench
+  ) ;let
+  (let ((xlarge (iota 10000)))
+    (bench "超大列表(10000) drop-right"
+      (lambda () (drop-right xlarge 5000))
+      1000
+    ) ;bench
+  ) ;let
+
+  ;; 直调 rootlet 的 g_take_right / g_drop_right：验证别名没有额外开销
+  (when (defined? 'g_take_right)
+    (let ((medium (iota 100)))
+      (bench "g_take_right直调(100)     "
+        (lambda () (g_take_right medium 50))
+        100000
+      ) ;bench
+    ) ;let
+    (let ((medium (iota 100)))
+      (bench "g_drop_right直调(100)     "
+        (lambda () (g_drop_right medium 50))
+        100000
+      ) ;bench
+    ) ;let
+  ) ;when
+) ;define
+
+(run-benchmarks)

--- a/devel/0090.md
+++ b/devel/0090.md
@@ -1,0 +1,70 @@
+# [0090] 用 C 实现 take-right / drop-right 提升性能
+
+## 任务相关的代码文件
+- src/s7_liii_list.c （新增 g_take_right / g_drop_right)
+- src/s7_liii_list.h （声明 g_take_right / g_drop_right)
+- src/s7.c （注册 g_take_right / g_drop_right 为 semisafe typed function)
+- goldfish/srfi/srfi-1.scm (take-right / drop-right 改为 C 实现的别名）
+- tests/liii/list/take-right-test.scm （补充结构共享/GC 回归测试）
+- tests/liii/list/drop-right-test.scm （补充结构拷贝/GC 回归测试）
+- bench/take-right-drop-right.scm （性能基准）
+- bench/drop.scm （验证 drop 已是 C 级性能）
+
+## 如何测试
+
+```bash
+xmake b goldfish
+bin/gf tests/liii/list/take-right-test.scm
+bin/gf tests/liii/list/drop-right-test.scm
+bin/gf test --all
+bin/gf bench/take-right-drop-right.scm
+bin/gf bench/drop.scm
+```
+
+## 2026-07-20 用 C 实现 take-right / drop-right
+
+### What
+1. 确认 drop 无需迁移：srfi-1 中 `(define drop list-tail)`，list-tail 本身就是
+   带 p_pp 快速路径的 C 内置函数，bench/drop.scm 验证别名直调与 list-tail
+   直调性能一致（100 元素 100000 次约 0.007 秒）
+2. 在 bench/take-right-drop-right.scm 中对原 Scheme 实现做性能基线评测
+3. 在 src/s7_liii_list.c 中新增 g_take_right / g_drop_right，并在 src/s7.c
+   中注册为 `g_take_right` / `g_drop_right`
+4. goldfish/srfi/srfi-1.scm 中 `(define take-right g_take_right)`、
+   `(define drop-right g_drop_right)`，替换原递归 Scheme 实现
+5. tests/liii/list/ 补充测试：take-right 与原列表共享节点（eq? 为 #t)、
+   drop-right 总是创建新列表结构（eq? 为 #f)、修改结果不影响原列表、
+   大列表 + GC 压力回归测试（take-right 24 项、drop-right 44 项全部通过，
+   `bin/gf test --all` 1472 项全部通过）
+
+性能对比（秒，越少越好）：
+
+| 场景 | Scheme 基线 | C 实现 | 加速比 |
+|---|---|---|---|
+| 小列表（10) take-right 5 (100000 次） | 0.0212 | 0.0100 | ~2.1x |
+| 小列表（10) drop-right 5 (100000 次） | 0.0325 | 0.0104 | ~3.1x |
+| 中列表（100) take-right 50 (100000 次） | 0.0564 | 0.0192 | ~2.9x |
+| 中列表（100) drop-right 50 (100000 次） | 0.1505 | 0.0741 | ~2.0x |
+| 大列表（1000) take-right 500 (10000 次） | 0.0480 | 0.0163 | ~2.9x |
+| 大列表（1000) drop-right 500 (10000 次） | 0.1656 | 0.0810 | ~2.0x |
+| 超大列表（10000) take-right 5000 (1000 次） | 0.0471 | 0.0252 | ~1.9x |
+| 超大列表（10000) drop-right 5000 (1000 次） | 0.1398 | 0.0729 | ~1.9x |
+
+### Why
+take-right / drop-right 是 srfi-1 中仅剩的 Scheme 递归实现的取子列表函数，
+沿用 0088 (filter) / 0089 (take) 的思路下沉为 C 实现。
+
+### How
+- 两个函数共用 lead 指针先行 k 步的校验逻辑（take_right_lead 静态函数）：
+  k 非整数抛 wrong-type-arg，k 为负数或超过列表长度（含 dotted list 提前结束）
+  抛 out-of-range，lst 非列表抛 wrong-type-arg，与原实现的错误符号逐一对应
+- take-right 无任何分配：lead 走完后 lag/lead 同步前进直到 lead 不是 pair,
+  返回 lag（原列表的子列表），保留参考实现的结构共享语义，因此也无需 GC anchor
+- drop-right 采用与 g_take 相同的 dummy head anchor 模式：s7_cons 后立即
+  链接进结果，保证对 GC 可见；没有 Scheme 回调，args 不会被求值器覆写
+- 语义差异固化进测试：take-right 共享节点（eq? 为 #t)，drop-right 总是
+  新建列表结构（eq? 为 #f)
+- take-right 可能返回 dotted list 的非 pair 尾部，返回值签名用 #t
+  （与 list-tail 的处理一致）
+- 接入模式沿用 0088/0089：注册名 g_take_right / g_drop_right + 库内别名，
+  benchmark 中直调与别名性能一致，无额外开销

--- a/goldfish/srfi/srfi-1.scm
+++ b/goldfish/srfi/srfi-1.scm
@@ -136,19 +136,9 @@
 
     (define drop list-tail)
 
-    (define (take-right l k)
-      (let loop
-        ((lag l) (lead (drop l k)))
-        (if (pair? lead) (loop (cdr lag) (cdr lead)) lag)
-      ) ;let
-    ) ;define
+    (define take-right g_take_right)
 
-    (define (drop-right l k)
-      (let loop
-        ((lag l) (lead (drop l k)))
-        (if (pair? lead) (cons (car lag) (loop (cdr lag) (cdr lead))) '())
-      ) ;let
-    ) ;define
+    (define drop-right g_drop_right)
 
     (define (split-at lst i)
       (when (< i 0)

--- a/src/s7.c
+++ b/src/s7.c
@@ -86908,6 +86908,15 @@ is #t, the string is also sent to the current-output-port."
   #define Q_take s7_make_signature(sc, 3, sc->is_list_symbol, sc->is_list_symbol, sc->is_integer_symbol)
   s7_define_semisafe_typed_function(sc, "g_take", g_take, 2, 0, false, H_take, Q_take);
 
+  /* take-right can return the non-pair tail of a dotted list, hence the #t return signature */
+  #define H_take_right "(g_take_right lst k) returns the last k elements of lst"
+  #define Q_take_right s7_make_signature(sc, 3, sc->T, sc->is_list_symbol, sc->is_integer_symbol)
+  s7_define_semisafe_typed_function(sc, "g_take_right", g_take_right, 2, 0, false, H_take_right, Q_take_right);
+
+  #define H_drop_right "(g_drop_right lst k) returns a list of all but the last k elements of lst"
+  #define Q_drop_right s7_make_signature(sc, 3, sc->is_list_symbol, sc->is_list_symbol, sc->is_integer_symbol)
+  s7_define_semisafe_typed_function(sc, "g_drop_right", g_drop_right, 2, 0, false, H_drop_right, Q_drop_right);
+
   sc->length_symbol =                defun("length",		length,			1, 0, false);
   sc->copy_symbol =                  defun("copy",		copy,			1, 3, false);
   /* set_is_definer(sc->copy_symbol); */ /* (copy (inlet 'a 1) (curlet)), but this check needs to be smarter */

--- a/src/s7_liii_list.c
+++ b/src/s7_liii_list.c
@@ -589,6 +589,69 @@ s7_pointer g_take(s7_scheme *sc, s7_pointer args)
   return(s7_cdr(head));
 }
 
+/* -------------------------------- take-right / drop-right -------------------------------- */
+
+/* shared lead walk: returns NULL on success (lead advanced n pairs),
+ * otherwise the error object to return */
+static s7_pointer take_right_lead(s7_scheme *sc, const char *name, s7_pointer lst, s7_pointer k, s7_int n, s7_pointer *lead)
+{
+  if (!s7_is_integer(k))
+    return(s7_wrong_type_arg_error(sc, name, 2, k, "an integer"));
+  if (n < 0)
+    return(s7_out_of_range_error(sc, name, 2, k, "it is negative"));
+  if (!s7_is_pair(lst) && !s7_is_null(sc, lst))
+    return(s7_wrong_type_arg_error(sc, name, 1, lst, "a list"));
+  s7_pointer p = lst;
+  for (s7_int i = 0; i < n; i++)
+    {
+      if (!s7_is_pair(p))
+        return(s7_out_of_range_error(sc, name, 2, k, "it is too large"));
+      p = s7_cdr(p);
+    }
+  (*lead) = p;
+  return(NULL);
+}
+
+s7_pointer g_take_right(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  s7_pointer k = s7_cadr(args);
+  s7_pointer lead;
+  s7_pointer err = take_right_lead(sc, "take-right", lst, k, s7_is_integer(k) ? s7_integer(k) : 0, &lead);
+  if (err) return(err);
+  /* no allocation and no Scheme callbacks: result is a sublist of lst */
+  s7_pointer lag = lst;
+  while (s7_is_pair(lead))
+    {
+      lag = s7_cdr(lag);
+      lead = s7_cdr(lead);
+    }
+  return(lag);
+}
+
+s7_pointer g_drop_right(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_car(args);
+  s7_pointer k = s7_cadr(args);
+  s7_pointer lead;
+  s7_pointer err = take_right_lead(sc, "drop-right", lst, k, s7_is_integer(k) ? s7_integer(k) : 0, &lead);
+  if (err) return(err);
+  /* dummy head anchor, same GC pattern as g_take */
+  s7_pointer head = s7_cons(sc, s7_nil(sc), s7_nil(sc));
+  s7_gc_protect_via_stack(sc, head);
+  s7_pointer tail = head;
+  s7_pointer lag = lst;
+  while (s7_is_pair(lead))
+    {
+      s7_set_cdr(tail, s7_cons(sc, s7_car(lag), s7_nil(sc)));
+      tail = s7_cdr(tail);
+      lag = s7_cdr(lag);
+      lead = s7_cdr(lead);
+    }
+  s7_gc_unprotect_via_stack(sc, head);
+  return(s7_cdr(head));
+}
+
 s7_pointer g_list(s7_scheme *sc, s7_pointer args)
 {
   return(s7i_copy_proper_list(sc, args));

--- a/src/s7_liii_list.h
+++ b/src/s7_liii_list.h
@@ -59,6 +59,8 @@ s7_pointer g_cons(s7_scheme *sc, s7_pointer args);
 s7_pointer g_list(s7_scheme *sc, s7_pointer args);
 s7_pointer g_filter(s7_scheme *sc, s7_pointer args);
 s7_pointer g_take(s7_scheme *sc, s7_pointer args);
+s7_pointer g_take_right(s7_scheme *sc, s7_pointer args);
+s7_pointer g_drop_right(s7_scheme *sc, s7_pointer args);
 
 s7_pointer g_list_set(s7_scheme *sc, s7_pointer args);
 s7_pointer g_list_set_i(s7_scheme *sc, s7_pointer args);

--- a/tests/liii/list/drop-right-test.scm
+++ b/tests/liii/list/drop-right-test.scm
@@ -122,4 +122,29 @@
 (check-catch 'wrong-type-arg (drop-right '(1 2 3) "not a number"))
 
 
+;; drop-right 总是创建新的列表结构，即使 k 为 0 也不共享节点
+(let ((l (list 1 2 3)))
+  (check (eq? (drop-right l 0) l) => #f)
+  (check (drop-right l 0) => '(1 2 3))
+  ;; 修改结果不影响原列表
+  (let ((r (drop-right l 1)))
+    (set-car! r 99)
+    (check l => '(1 2 3))
+  ) ;let
+) ;let
+
+
+;; 大列表 + GC 压力回归测试
+(let ((l (iota 10000)))
+  (check (drop-right l 5000) => (iota 5000))
+  (check (length (drop-right l 0)) => 10000)
+  (check l => (iota 10000))
+) ;let
+
+(do ((i 0 (+ i 1)))
+  ((= i 1000))
+  (drop-right (iota 100) 50)
+) ;do
+
+
 (check-report)

--- a/tests/liii/list/take-right-test.scm
+++ b/tests/liii/list/take-right-test.scm
@@ -76,4 +76,25 @@
 (check-catch 'wrong-type-arg (take-right '(1 2 3) "not a number"))
 
 
+;; take-right 与原列表共享节点：返回的是原列表的子列表
+(let ((l (list 1 2 3 4 5)))
+  (check (eq? (take-right l 2) (cdddr l)) => #t)
+  (check (eq? (take-right l 5) l) => #t)
+  (check (eq? (take-right l 0) '()) => #t)
+) ;let
+
+
+;; 大列表 + GC 压力回归测试
+(let ((l (iota 10000)))
+  (check (take-right l 5000) => (iota 5000 5000))
+  (check (length (take-right l 10000)) => 10000)
+  (check l => (iota 10000))
+) ;let
+
+(do ((i 0 (+ i 1)))
+  ((= i 1000))
+  (take-right (iota 100) 50)
+) ;do
+
+
 (check-report)


### PR DESCRIPTION
## Summary
- 在 src/s7_liii_list.c 新增 g_take_right / g_drop_right 并在 src/s7.c 注册，srfi-1 的 take-right / drop-right 改为 C 实现别名，性能提升约 1.9x~3.1x
- drop 经核实已是 C 内置 list-tail 的别名，无需迁移，附 bench/drop.scm 验证
- 补充结构共享（take-right）/结构拷贝（drop-right）语义测试与 GC 压力回归测试（take-right 24 项、drop-right 44 项通过，全量 1472 项通过）
- 新增 bench/take-right-drop-right.scm 性能基准与 devel/0090.md 开发文档

## Test plan
- [x] xmake b goldfish
- [x] bin/gf tests/liii/list/take-right-test.scm
- [x] bin/gf tests/liii/list/drop-right-test.scm
- [x] bin/gf test --all
- [x] bin/gf bench/take-right-drop-right.scm
- [x] bin/gf bench/drop.scm

🤖 Generated with [Claude Code](https://claude.com/claude-code)