### PR TITLE
[0091] 修复装饰导入绕过库加载缓存导致重复 load 的问题

### DIFF
--- a/bench/library-name-symbol-perf.scm
+++ b/bench/library-name-symbol-perf.scm
@@ -1,0 +1,217 @@
+;;
+;; Copyright (C) 2026 The Goldfish Scheme Authors
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+;; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+;; License for the specific language governing permissions and limitations
+;; under the License.
+;;
+
+;; 评估 define-library / import 路径上"库名 -> 符号"转换的性能
+;; 现状实现: (symbol (object->string libname))
+;;   - boot.scm define-library 宏: 库定义时一次
+;;   - boot.scm r7rs-import-library-filename: defined? 缓存检查每次 import 一次
+;;   - boot.scm import 宏各分支: symbol->value 取库环境每次 import 一次
+;; 候选实现: string-append + string->symbol 直接拼接，不走 write 到字符串端口
+
+(import (liii check)
+        (liii timeit))
+
+(check-set-mode! 'report-failed)
+
+(define (report title iterations time-val)
+  (display "[")
+  (display title)
+  (display "] iterations=")
+  (display iterations)
+  (display " total=")
+  (display time-val)
+  (display "s avg=")
+  (display (/ time-val iterations))
+  (display "s")
+  (newline)
+) ;define
+
+;; 候选实现：与 object->string 对库名列表的输出保持一致
+;; 库名元素只有符号（liii list）和数字（srfi 1）两种
+(define (library-name->symbol libname)
+  (string->symbol
+    (string-append
+      "("
+      (let loop ((parts libname) (first #t))
+        (if (null? parts)
+          ")"
+          (string-append
+            (if first "" " ")
+            (if (symbol? (car parts))
+              (symbol->string (car parts))
+              (number->string (car parts)))
+            (loop (cdr parts) #f))))))
+) ;define
+
+;; 正确性：两种实现产出的符号必须一致
+(check (library-name->symbol '(liii list)) => (symbol (object->string '(liii list))))
+(check (library-name->symbol '(srfi 1)) => (symbol (object->string '(srfi 1))))
+(check (library-name->symbol '(scheme base)) => (symbol (object->string '(scheme base))))
+;; 产出的符号必须能取到 define-library 定义的全局库环境
+(check (symbol->value (library-name->symbol '(liii check))) => (symbol->value (symbol (object->string '(liii check)))))
+
+(display "=== 库名 -> 符号转换性能基准 ===")
+(newline)
+
+(define iterations 100000)
+
+(define t1
+  (timeit (lambda () (symbol (object->string '(liii list)))) '() iterations))
+(report "现状 (symbol (object->string '(liii list)))" iterations t1)
+
+(define t2
+  (timeit (lambda () (library-name->symbol '(liii list))) '() iterations))
+(report "候选 (library-name->symbol '(liii list))" iterations t2)
+
+(define t3
+  (timeit (lambda () (symbol (object->string '(srfi 1)))) '() iterations))
+(report "现状 (symbol (object->string '(srfi 1)))" iterations t3)
+
+(define t4
+  (timeit (lambda () (library-name->symbol '(srfi 1))) '() iterations))
+(report "候选 (library-name->symbol '(srfi 1))" iterations t4)
+
+(newline)
+(display "加速比 ((liii list)): ")
+(display (/ t1 t2))
+(newline)
+(display "加速比 ((srfi 1)): ")
+(display (/ t3 t4))
+(newline)
+
+(newline)
+(display "=== 测试完成 ===")
+(newline)
+
+;; 第二部分：归因热导入 (import (liii json)) 的各环节开销
+;; 对比"注册表直查"方案：define-library 时把库环境按库名列表注册进
+;; hash-table,import 时按列表直接查表，完全跳过 字符串转换 + 符号查找
+(import (liii json) (liii hash-table))
+
+(newline)
+(display "=== 热导入各环节归因（库已加载） ===")
+(newline)
+
+(define *library-registry* (make-hash-table))
+(hash-table-set! *library-registry* '(liii json)
+  (symbol->value (symbol (object->string '(liii json)))))
+
+(define t5
+  (timeit (lambda () (defined? (symbol (object->string '(liii json))))) '() iterations))
+(report "现状 defined? 缓存检查" iterations t5)
+
+(define t6
+  (timeit (lambda () (hash-table-ref *library-registry* '(liii json))) '() iterations))
+(report "候选 注册表查库环境" iterations t6)
+
+(define t7
+  (timeit (lambda () (symbol->value (symbol (object->string '(liii json))))) '() iterations))
+(report "现状 symbol->value 取库环境" iterations t7)
+
+(define t8
+  (timeit (lambda () (import (liii json))) '() iterations))
+(report "现状 完整热导入 (import (liii json))" iterations t8)
+
+;; 第三部分：归因 r7rs-import-library-filename 与 varlet 的开销
+(newline)
+(display "=== r7rs-import-library-filename / varlet 归因 ===")
+(newline)
+
+(define json-env
+  (symbol->value (symbol (object->string '(liii json)))))
+
+(define t9
+  (timeit (lambda () (r7rs-import-library-filename '((liii json)))) '() iterations))
+(report "现状 r7rs-import-library-filename(已加载)" iterations t9)
+
+(define t10
+  (timeit (lambda () (varlet (inlet) json-env)) '() iterations))
+(report "现状 varlet 复制库环境" iterations t10)
+
+;; 候选：defined? 命中时跳过文件名拼接（先查缓存再构造文件名）
+(define (r7rs-import-library-filename-opt libs)
+  (when (pair? libs)
+    (let ((lib (if (memq (caar libs) '(only except prefix rename))
+                 (cadar libs)
+                 (car libs))))
+      (when (not (defined? (symbol (object->string lib))))
+        (load (let loop ((lib lib) (name ""))
+                (set! name (string-append name (symbol->string (car lib))))
+                (if (null? (cdr lib))
+                  (string-append name ".scm")
+                  (begin
+                    (set! name (string-append name "/"))
+                    (loop (cdr lib) name))))))
+      (r7rs-import-library-filename-opt (cdr libs))))
+) ;define
+
+(define t11
+  (timeit (lambda () (r7rs-import-library-filename-opt '((liii json)))) '() iterations))
+(report "候选 先查缓存(已加载)" iterations t11)
+
+;; 第四部分：拆解 import 展开的各环节，定位剩余开销
+(newline)
+(display "=== import 展开形态拆解 ===")
+(newline)
+
+(define t12
+  (timeit (lambda ()
+            (let ((sym (symbol (object->string '(liii json)))))
+              (if (not (defined? sym))
+                (format () "~A not loaded~%" sym)
+                (symbol->value sym))))
+          '() iterations))
+(report "展开 else 分支(取库环境)" iterations t12)
+
+(define t13
+  (timeit (lambda () (varlet (curlet) json-env)) '() iterations))
+(report "varlet 进当前环境" iterations t13)
+
+(define t14
+  (timeit (lambda ()
+            (begin
+              (r7rs-import-library-filename '((liii json)))
+              (varlet (curlet) json-env)))
+          '() iterations))
+(report "手工展开(预取环境)" iterations t14)
+
+(define t15
+  (timeit (lambda ()
+            (begin
+              (r7rs-import-library-filename '((liii json)))
+              (varlet (curlet)
+                (let ((sym (symbol (object->string '(liii json)))))
+                  (if (not (defined? sym))
+                    (format () "~A not loaded~%" sym)
+                    (symbol->value sym))))))
+          '() iterations))
+(report "手工完整展开(等价 import)" iterations t15)
+
+;; 第五部分：验证 only/except/prefix/rename 装饰导入是否绕过 defined? 缓存
+(newline)
+(display "=== 装饰导入的缓存行为 ===")
+(newline)
+
+(display "(defined? 未剥离装饰的库名) => ")
+(display (defined? (symbol (object->string '(only (liii json) json-read)))))
+(newline)
+(display "(defined? 剥离后的库名) => ")
+(display (defined? (symbol (object->string '(liii json)))))
+(newline)
+
+(define t16
+  (timeit (lambda () (import (only (liii json) json-read))) '() 1000))
+(report "现状 热导入 (only (liii json) json-read)" 1000 t16)

--- a/devel/0091.md
+++ b/devel/0091.md
@@ -1,0 +1,75 @@
+# [0091] 修复装饰导入绕过库加载缓存导致重复 load 的性能问题
+
+## 1. 相关文档
+- [dddd.md](dddd.md) - 任务文档模板
+- [0090.md](0090.md) - take-right / drop-right 性能优化（同类性能任务参考）
+
+## 2. 任务相关的代码文件
+- goldfish/scheme/boot.scm (r7rs-import-library-filename 缓存逻辑）
+- tests/scheme/boot-test.scm （新增装饰导入缓存回归测试）
+- bench/library-name-symbol-perf.scm （新增：库名转换与热导入归因基准）
+- bench/json-import-perf.scm （现有 import 冷/热加载基准）
+- bench/list-import-perf.scm （现有 import 分层冷加载基准）
+
+## 3. 如何测试
+
+### 3.1 确定性测试（单元测试）
+```bash
+xmake b goldfish
+bin/gf tests/scheme/boot-test.scm
+bin/gf test --all
+```
+
+### 3.2 非确定性测试（性能基准）
+```bash
+bin/gf bench/library-name-symbol-perf.scm
+bin/gf bench/json-import-perf.scm
+bin/gf bench/list-import-perf.scm
+```
+
+## 4. 如何提交
+
+提交前执行以下最少步骤：
+
+```bash
+bin/gf test --changed-since=main
+```
+
+## 5. 2026-07-24 修复装饰导入绕过库加载缓存
+
+### 5.1 What
+1. 新增 bench/library-name-symbol-perf.scm，先量化"库名 -> 符号"转换：
+   (symbol (object->string libname)) 每次约 100ns,C 级 write 已经很快，
+   而 Scheme 层 string-append 候选实现反而慢 4-5 倍，推翻原优化假设
+2. 归因热导入各环节时发现真正瓶颈：r7rs-import-library-filename 的
+   defined? 缓存检查对 (only (liii json) json-read) 这类装饰导入
+   用的是未剥离装饰的库名，符号 "(only (liii json) json-read)" 永远不会
+   被 define，缓存永远不命中，导致每次装饰导入都重新 load 整个库文件
+3. 修复：先剥离 only/except/prefix/rename 装饰得到真实库名再做 defined?
+   检查；同时把文件名拼接移到缓存未命中的分支内（缓存命中时不再白算）
+4. tests/scheme/boot-test.scm 新增回归测试：库文件内放置加载计数器，
+   依次以裸名、only、rename 三种形式导入，断言文件只被 load 一次
+   （修复前计数为 3，修复后为 1);bin/gf test --all 1472 项全部通过
+
+性能对比（秒，越少越好）：
+
+| 场景 | 修复前 | 修复后 | 加速比 |
+|---|---|---|---|
+| 热导入 (only (liii json) json-read) (1000 次 avg) | 1.16ms | 1.99us | ~580x |
+| 热导入 (liii json) (1000 次 avg) | 2.30us | 1.79us | ~1.3x |
+| 冷加载 (liii json) | 2.85ms | 2.09ms | ~1.4x |
+
+### 5.2 Why
+库加载是 gf 启动和脚本运行的基础路径。装饰导入（only/except/prefix/rename)
+在 goldfish 库内部有 6 处（liii/string、liii/set、liii/bag、scheme/time、
+srfi/srfi-19、srfi/srfi-267)，用户代码中也常见。缓存不命中意味着每次装饰
+导入都要重新读盘、重新求值整个库文件（含其依赖链），单次约 1ms,
+比缓存命中路径（约 2us）慢约 580 倍。
+
+### 5.3 How
+- 原实现把装饰形式原样传给 (symbol (object->string (car libs))) 做
+  defined? 检查，而 define-library 只定义真实库名的符号，二者永远不相等
+- 修复后先求出真实库名 lib(only/except/prefix/rename 取 cadr，否则取 car),
+  defined? 检查与文件名拼接都基于 lib；文件名拼接延迟到确认需要 load 时
+  才执行，缓存命中路径只剩 memq + object->string + defined? 三个低开销操作
+- 回归测试通过加载计数器直接观测 load 次数，避免依赖计时，保证测试确定性

--- a/goldfish/scheme/boot.scm
+++ b/goldfish/scheme/boot.scm
@@ -52,26 +52,22 @@
 (unless (defined? 'r7rs-import-library-filename)
   (define (r7rs-import-library-filename libs)
     (when (pair? libs)
-      (let ((lib-filename (let loop
-                            ((lib (if (memq (caar libs) '(only except
-                                                           prefix
-                                                           rename)) (cadar libs) (car libs))
-                             ) ;lib
-                             (name "")
-                            ) ;
-                            (set! name (string-append name (symbol->string (car lib))))
-                            (if (null? (cdr lib))
-                              (string-append name ".scm")
-                              (begin
-                                (set! name (string-append name "/"))
-                                (loop (cdr lib) name)
-                              ) ;begin
-                            ) ;if
-                          ) ;let
-            ) ;lib-filename
+      (let ((lib (if (memq (caar libs) '(only except prefix rename)) (cadar libs) (car libs))
+            ) ;lib
            ) ;
-        (when (not (defined? (symbol (object->string (car libs)))))
-          (load lib-filename)
+        (when (not (defined? (symbol (object->string lib))))
+          (load (let loop
+                  ((parts lib) (name ""))
+                  (set! name (string-append name (symbol->string (car parts))))
+                  (if (null? (cdr parts))
+                    (string-append name ".scm")
+                    (begin
+                      (set! name (string-append name "/"))
+                      (loop (cdr parts) name)
+                    ) ;begin
+                  ) ;if
+                ) ;let
+          ) ;load
         ) ;when
         (r7rs-import-library-filename (cdr libs))
       ) ;let

--- a/tests/scheme/boot-test.scm
+++ b/tests/scheme/boot-test.scm
@@ -1,4 +1,4 @@
-(import (liii list) (liii check) (liii os))
+(import (liii list) (liii check) (liii os) (liii path))
 (check-set-mode! 'report-failed)
 (when (not (os-windows?))
   (check (file-exists? "/tmp") => #t)
@@ -26,4 +26,46 @@
   (if (= start end) start (+ (sum start (- end 1)) end))
 ) ;define
 (check (sum 2 4) => 9)
+
+;; 装饰导入（only/except/prefix/rename）不应绕过库加载缓存：
+;; 同一个库无论以何种形式导入，磁盘文件只应被 load 一次
+(let* ((probe-root (path-join (path-temp-dir)
+                     (string-append "goldfish-import-cache-" (number->string (getpid)))
+                   ) ;path-join
+       ) ;probe-root
+       (probe-liii (path-join probe-root "liii"))
+       (probe-file (path-join probe-liii "cacheprobe.scm"))
+       (old-load-path *load-path*)
+      ) ;
+  (mkdir (path->string probe-root))
+  (mkdir (path->string probe-liii))
+  (path-write-text probe-file
+    (string-append "(define *cacheprobe-load-count*\n"
+      "  (if (defined? '*cacheprobe-load-count*) (+ *cacheprobe-load-count* 1) 1))\n"
+      "(define-library (liii cacheprobe)\n"
+      "  (export probe-func)\n"
+      "  (import (scheme base))\n"
+      "  (begin (define (probe-func) 42)))\n"
+    ) ;string-append
+  ) ;path-write-text
+  (dynamic-wind (lambda ()
+                  (set! *load-path* (append *load-path* (list (path->string probe-root))))
+                ) ;lambda
+    (lambda ()
+      (import (liii cacheprobe))
+      (import (only (liii cacheprobe) probe-func))
+      (import (rename (liii cacheprobe) (probe-func probe-func-renamed)))
+      (check *cacheprobe-load-count* => 1)
+      (check (probe-func) => 42)
+      (check (probe-func-renamed) => 42)
+    ) ;lambda
+    (lambda ()
+      (set! *load-path* old-load-path)
+      (path-unlink probe-file #t)
+      (path-rmdir (path->string probe-liii))
+      (path-rmdir (path->string probe-root))
+    ) ;lambda
+  ) ;dynamic-wind
+) ;let*
+
 (check-report "\n\nCheck report of boot-test.scm => ")


### PR DESCRIPTION
## 问题

`r7rs-import-library-filename` 的 `defined?` 缓存检查对 `(only (liii json) json-read)` 这类装饰导入使用的是**未剥离装饰的库名**，符号 `(only (liii json) json-read)` 永远不会被 define，缓存永远不命中 —— 每次装饰导入都重新从磁盘 load 整个库文件（含依赖链重新求值）。

基准实测（bench/library-name-symbol-perf.scm）：

| 场景 | 修复前 | 修复后 | 加速比 |
|---|---|---|---|
| 热导入 `(only (liii json) json-read)` | 1.16ms | 1.99µs | **~580x** |
| 热导入 `(liii json)` | 2.30µs | 1.79µs | ~1.3x |
| 冷加载 `(liii json)` | 2.85ms | 2.09ms | ~1.4x |

## 修复

1. 先剥离 `only/except/prefix/rename` 装饰得到真实库名，再做 `defined?` 缓存检查
2. 文件名拼接延迟到缓存未命中分支内（命中时不再白算）

## 过程备注

最初假设的瓶颈是 `object->string` 转换开销，先写基准量化后推翻：`object->string` 每次约 100ns（C 级 write 已经很快），Scheme 层 `string-append` 候选实现反而慢 4-5 倍。归因分析才定位到真正的缓存绕过问题。详见 devel/0091.md。

## 测试

- tests/scheme/boot-test.scm 新增回归测试：库文件内放置加载计数器，依次以裸名、`only`、`rename` 三种形式导入，断言文件只被 load 一次（修复前计数为 3，修复后为 1)
- `bin/gf test --all` 1472 项全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)