### PR TITLE
[0092] 在 (liii base) 导出 20 个 let 相关函数并补齐文档与测试

### DIFF
--- a/devel/0092.md
+++ b/devel/0092.md
@@ -1,0 +1,75 @@
+# [0092] 拆分 s7_scheme_let.c 并在 (liii base) 导出 let 相关函数
+
+## 任务相关的代码文件
+- src/s7.c （后续子任务：拆出 s7_scheme_let.c）
+- src/s7_scheme_let.c （后续子任务：新增）
+- src/s7_scheme_let.h （后续子任务：新增）
+- goldfish/liii/base.scm （已修改：新增 20 个 let 相关函数的 export）
+- tests/liii/base/*-test.scm （已新增 20 个测试文件）
+- devel/0092.md
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf doc --build-json
+
+# 验证 doc 可访问
+bin/gf doc funclet
+bin/gf doc let-set!
+bin/gf doc symbol->value
+
+# 运行新增的 20 个测试
+for f in curlet rootlet owlet outlet let-p funclet-p funclet inlet sublet varlet cutlet openlet coverlet unlet openlet-p let-ref let-set-bang let-to-list symbol-to-value symbol-to-dynamic-value; do
+  bin/gf tests/liii/base/$f-test.scm
+done
+
+# 完整测试套件
+bin/gf test --all
+```
+
+## 2026-07-29 第一个子任务：在 (liii base) 导出 20 个 let 相关函数并补齐文档与测试
+
+### What
+1. 在 `goldfish/liii/base.scm` 的 export 列表中新增 20 个 let 相关函数：
+   `let?` `openlet?` `funclet?` （谓词）
+   `curlet` `outlet` `rootlet` `owlet` `funclet` （环境获取）
+   `inlet` `sublet` `varlet` `cutlet` `openlet` `coverlet` `unlet` （环境构造与操作）
+   `let-ref` `let-set!` `let->list` （绑定访问）
+   `symbol->value` `symbol->dynamic-value` （符号查找，`defined?` 此前已导出）
+2. 在 `tests/liii/base/` 下为这 20 个函数各写一个文档化测试文件
+   （文件名遵循 `gf doc` 的特殊字符映射规则：`?` → `-p`、`!` → `-bang`、
+   `->` → `-to-` 等），共新增 20 个测试文件、111 个 check。
+3. 执行 `bin/gf doc --build-json` 重建函数索引，确认
+   `bin/gf doc funclet`、`bin/gf doc let-set!`、`bin/gf doc symbol->value`
+   等命令都能正确显示 `(liii base)` 下的文档和测试用例。
+4. `bin/gf test --all` 共 1492 项全部通过（其中新增 111 个 check）。
+
+### Why
+这些 let 相关函数是 s7 的核心环境操作 API，此前虽然通过 `(scheme base)`
+在 `(liii base)` 中可见，但并未正式 export，因此 `gf doc` 无法把它们识别为
+`(liii base)` 的公开 API。正式 export 后，`gf doc funclet` 等命令才能工作，
+这些函数也才成为 `(liii base)` 的稳定公开接口。
+
+### How
+- **export 顺序优先**：`gf doc --build-json` 扫的是 `*load-path*` 里各库的
+  export 列表，必须先 export 才能被识别。所以先改 `base.scm`、再写测试、
+  最后重建索引。
+- **测试文件即文档**：每个测试文件开头用注释块写明语法 / 参数 / 返回值 / 说明，
+  `gf doc` 直接展示测试文件内容作为文档。
+- **语义探查**：s7 的环境语义有几处不直观，需先探查再写断言：
+  - `(curlet)` 每次调用返回不同对象（不能假设 `eq?` 为 #t）
+  - 顶层 `define` 的过程，其 `funclet` 包含参数槽（`(inlet 'x ())`），
+    而非 rootlet；只有 C 内建函数的 funclet 才是 rootlet
+  - `sublet` 创建新 let（不改父），`varlet`/`cutlet` 就地修改 target-let
+    并返回同一对象
+  - `unlet` 返回包含内建函数原始绑定的 let，典型用法是
+    `(with-let (unlet) ...)` 以访问被遮蔽的原始版本
+
+## 后续子任务（待做）
+- 从 `src/s7.c` 拆出 `s7_scheme_let.c` / `s7_scheme_let.h`
+- 拆分边界：`g_unlet`（9606）到 `g_is_defined`（11471）的密集块，
+  外加 `g_funclet`（34666）和 `g_owlet`（40690）
+- 关键约束：`g_simple_inlet` / `g_sublet_curlet` / `g_cdr_let_ref` /
+  `g_rootlet_ref` / `g_unlet_ref` / `g_cdr_let_set` / `g_unlet_set` /
+  `g_starlet_set` 被 s7.c 内部通过 `fn_proc() ==` 比较 和 `sc->xxx` 缓存
+  槽位引用，外迁时需去 `static` 通过头文件暴露符号

--- a/goldfish/liii/base.scm
+++ b/goldfish/liii/base.scm
@@ -30,6 +30,26 @@
     call-with-output-string
     reverse!
     format
+    let?
+    openlet?
+    funclet?
+    curlet
+    outlet
+    rootlet
+    owlet
+    funclet
+    inlet
+    sublet
+    varlet
+    cutlet
+    openlet
+    coverlet
+    unlet
+    let-ref
+    let-set!
+    let->list
+    symbol->value
+    symbol->dynamic-value
   ) ;export
   (begin
 

--- a/tests/liii/base/coverlet-test.scm
+++ b/tests/liii/base/coverlet-test.scm
@@ -1,0 +1,48 @@
+(import (liii check))
+(import (liii base))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; coverlet
+;; 撤销此前 openlet 对一个 let 的 "open" 标记。返回该 let 自身。
+;;
+;; 语法
+;; ----
+;; (coverlet let)
+;;
+;; 参数
+;; ----
+;; let : let?
+;; 要撤销 open 标记的 let。
+;;
+;; 返回值
+;; ------
+;; let?
+;; 返回传入的 let（已撤销 open 标记）。
+;;
+;; 说明
+;; ----
+;; coverlet 是 openlet 的逆操作：
+;; openlet 把 let 标记为 open，使内建函数查询其方法；
+;; coverlet 撤销该标记，使内建函数不再查询其方法。
+
+
+;; coverlet 返回传入的 let
+(check (let ((e (inlet 'a 1))) (eq? (coverlet e) e)) => #t)
+
+
+;; openlet 后再 coverlet，openlet? 变回 #f
+(check (let ((e (openlet (inlet 'a 1)))) (coverlet e) (openlet? e)) => #f)
+
+
+;; 未经 openlet 的 let，coverlet 后 openlet? 仍为 #f
+(check (openlet? (coverlet (inlet 'a 1))) => #f)
+
+
+;; coverlet 后内部绑定仍可访问
+(check (let-ref (coverlet (openlet (inlet 'a 42))) 'a) => 42)
+
+
+(check-report)

--- a/tests/liii/base/curlet-test.scm
+++ b/tests/liii/base/curlet-test.scm
@@ -1,0 +1,52 @@
+(import (liii check))
+(import (liii base))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; curlet
+;; 返回当前环境的 let（即当前词法环境）。
+;;
+;; 语法
+;; ----
+;; (curlet)
+;;
+;; 参数
+;; ----
+;; 无参数。
+;;
+;; 返回值
+;; ------
+;; let?
+;; 当前词法环境对应的 let。
+;;
+;; 说明
+;; ----
+;; curlet 返回当前求值环境的 let 对象。
+;; 在不同位置调用 curlet 会得到不同的 let。
+;; rootlet 是所有环境的根环境，curlet 在顶层调用时返回的环境
+;; 其 outlet 链最终指向 rootlet。
+
+
+;; curlet 返回一个 let
+(check (let? (curlet)) => #t)
+
+
+;; 在 let 内部调用 curlet，得到包含该 let 绑定的环境
+(check (let-ref (let ((a 42)) (curlet)) 'a) => 42)
+
+
+;; 在 lambda 内部，curlet 反映函数的环境
+(check (let-ref ((lambda () (let ((x 99)) (curlet)))) 'x) => 99)
+
+
+;; 多次调用 curlet 在同一位置返回的 let 内容一致（都包含 a）
+(check (let-ref (let ((a 7)) (curlet)) 'a) => 7)
+
+
+;; curlet 的 outlet 链可达 rootlet
+(check (let? (outlet (curlet))) => #t)
+
+
+(check-report)

--- a/tests/liii/base/cutlet-test.scm
+++ b/tests/liii/base/cutlet-test.scm
@@ -1,0 +1,50 @@
+(import (liii check))
+(import (liii base))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; cutlet
+;; 从 let 中移除指定的符号绑定（就地修改），返回该 let。
+;;
+;; 语法
+;; ----
+;; (cutlet let symbol ...)
+;;
+;; 参数
+;; ----
+;; let : let?
+;; 要从中移除绑定的 let。
+;;
+;; symbol : symbol?
+;; 要移除的绑定名（可多个）。
+;;
+;; 返回值
+;; ------
+;; let?
+;; 返回传入的 let（已被就地修改）。
+;;
+;; 说明
+;; ----
+;; cutlet 就地从 let 中移除指定的符号绑定，返回该 let 本身。
+;; 可一次移除多个符号。
+
+
+;; cutlet 移除指定符号
+(check (let ((e (inlet 'a 1 'b 2 'c 3))) (cutlet e 'b) (length e)) => 2)
+
+
+;; cutlet 返回的就是传入的 let（eq? 为 #t）
+(check (let ((e (inlet 'a 1))) (eq? (cutlet e 'a) e)) => #t)
+
+
+;; cutlet 一次移除多个符号
+(check (let ((e (inlet 'a 1 'b 2 'c 3))) (cutlet e 'a 'c) (length e)) => 1)
+
+
+;; cutlet 后剩余的绑定仍可访问
+(check (let ((e (inlet 'a 1 'b 2 'c 3))) (cutlet e 'b) (let-ref e 'a)) => 1)
+
+
+(check-report)

--- a/tests/liii/base/funclet-p-test.scm
+++ b/tests/liii/base/funclet-p-test.scm
@@ -1,0 +1,68 @@
+(import (liii check))
+(import (liii base))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; funclet?
+;; 判断对象是否为 funclet（函数闭包环境）。
+;;
+;; 语法
+;; ----
+;; (funclet? obj)
+;;
+;; 参数
+;; ----
+;; obj : any
+;; 要判断的对象。
+;;
+;; 返回值
+;; ------
+;; boolean?
+;; 如果 obj 是函数的闭包环境（funclet）则返回 #t，否则返回 #f。
+;;
+;; 说明
+;; ----
+;; funclet? 专门判断 let 是否为某个函数的闭包环境。
+;; 普通 inlet、curlet、rootlet 都不是 funclet。
+;; 通过 (funclet proc) 获取的过程闭包环境是 funclet。
+
+
+;; 普通 inlet 不是 funclet
+(check (funclet? (inlet 'a 1)) => #f)
+
+
+;; rootlet 不是 funclet
+(check (funclet? (rootlet)) => #f)
+
+
+;; curlet 在顶层不是 funclet
+(check (funclet? (curlet)) => #f)
+
+
+;; 顶层定义的、捕获了变量的闭包过程，其 funclet 是 funclet
+
+(define make-adder (lambda (n) (lambda (x) (+ x n))))
+
+(define add5 (make-adder 5))
+(check (funclet? (funclet add5)) => #t)
+
+
+;; 无闭包变量的 lambda，其 funclet 退化为 rootlet，不是 funclet
+(check (funclet? (funclet (lambda (x) x))) => #f)
+
+
+;; C 函数的 funclet 是 rootlet，不是 funclet
+(check (funclet? (funclet car)) => #f)
+
+
+;; 整数不是 funclet
+(check (funclet? 42) => #f)
+
+
+;; 字符串不是 funclet
+(check (funclet? "hello") => #f)
+
+
+(check-report)

--- a/tests/liii/base/funclet-test.scm
+++ b/tests/liii/base/funclet-test.scm
@@ -1,0 +1,63 @@
+(import (liii check))
+(import (liii base))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; funclet
+;; 返回过程的闭包环境（funclet）。
+;;
+;; 语法
+;; ----
+;; (funclet proc)
+;;
+;; 参数
+;; ----
+;; proc : procedure?
+;; 过程（函数）。
+;;
+;; 返回值
+;; ------
+;; let?
+;; 该过程的闭包环境。
+;;
+;; 说明
+;; ----
+;; funclet 返回过程定义时所处的词法环境。
+;; 带捕获变量的闭包过程，其 funclet 包含被捕获的变量绑定。
+;; 顶层 define 的过程，其 funclet 还包含其参数槽。
+;; C 内建函数（如 car）的 funclet 为 rootlet。
+
+
+;; funclet 返回 let
+(check (let? (funclet car)) => #t)
+
+
+;; C 内建函数的 funclet 是 rootlet
+(check (eq? (funclet car) (rootlet)) => #t)
+
+
+;; 带闭包变量的过程，其 funclet 包含捕获的变量
+
+(define make-adder (lambda (n) (lambda (x) (+ x n))))
+
+(define add5 (make-adder 5))
+(check (let-ref (funclet add5) 'n) => 5)
+
+
+;; 带闭包的 funclet 是 funclet?
+(check (funclet? (funclet add5)) => #t)
+
+
+;; 顶层 define 的简单过程，其 funclet 包含参数槽
+
+(define simple-f (lambda (x) x))
+(check (let->list (funclet simple-f)) => (list (list 'x)))
+
+
+;; 同一过程的 funclet 多次获取得到同一对象
+(check (eq? (funclet add5) (funclet add5)) => #t)
+
+
+(check-report)

--- a/tests/liii/base/inlet-test.scm
+++ b/tests/liii/base/inlet-test.scm
@@ -1,0 +1,69 @@
+(import (liii check))
+(import (liii base))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; inlet
+;; 创建一个新的 let（环境对象），可带初始绑定。
+;;
+;; 语法
+;; ----
+;; (inlet)
+;; (inlet symbol value ...)
+;;
+;; 参数
+;; ----
+;; symbol : symbol?
+;; 绑定名。
+;;
+;; value : any
+;; 绑定值。
+;;
+;; 返回值
+;; ------
+;; let?
+;; 新创建的 let。
+;;
+;; 说明
+;; ----
+;; inlet 是构造 let 的基本方式。
+;; 无参数调用 (inlet) 创建空 let。
+;; (inlet 'a 1 'b 2) 创建包含 a=1、b=2 的 let。
+;; inlet 创建的 let 是一个独立环境，其 outlet 是 rootlet。
+
+
+;; 空 inlet 是 let
+(check (let? (inlet)) => #t)
+
+
+;; 带绑定的 inlet
+(check (let? (inlet 'a 1)) => #t)
+
+
+;; inlet 创建的 let 可以通过 let-ref 访问绑定
+(check (let-ref (inlet 'a 42) 'a) => 42)
+
+
+;; 多个绑定的 inlet
+(check (let-ref (inlet 'a 1 'b 2 'c 3) 'b) => 2)
+
+
+;; inlet 的长度反映绑定数量
+(check (length (inlet 'a 1 'b 2)) => 2)
+
+
+;; inlet 的 outlet 是 rootlet
+(check (eq? (outlet (inlet 'a 1)) (rootlet)) => #t)
+
+
+;; 两次 inlet 创建不同的 let 对象
+(check (eq? (inlet 'a 1) (inlet 'a 1)) => #f)
+
+
+;; 空 inlet 长度为 0
+(check (length (inlet)) => 0)
+
+
+(check-report)

--- a/tests/liii/base/inlet-test.scm
+++ b/tests/liii/base/inlet-test.scm
@@ -95,7 +95,9 @@
 
 
 ;; ---- 封装式：方法改闭包变量 -------------------------------------
-;; age 是闭包变量，外部只能通过 :get-age / :inc-age 操作
+;; age 是闭包变量，inlet 暴露 :get-age / :inc-age 方法
+;; 调用时避免 ((obj :method) obj) 的冗余写法，
+;; 定义顶层封装函数，调用处更自然
 
 (define* (make-person (name "?") (age 0))
   (inlet :get-age
@@ -105,10 +107,18 @@
   ) ;inlet
 ) ;define*
 
+(define (get-age obj)
+ ((obj :get-age) obj)
+) ;define
+
+(define (increase-age obj)
+ ((obj :inc-age) obj)
+) ;define
+
 (define p2 (make-person :name "Bob" :age 25))
 
-;; 方法修改 age（闭包变量）
-(check (begin ((p2 :inc-age) p2) ((p2 :get-age) p2)) => 26)
+;; increase-age 修改 age，get-age 读取
+(check (begin (increase-age p2) (get-age p2)) => 26)
 
 
 (check-report)

--- a/tests/liii/base/inlet-test.scm
+++ b/tests/liii/base/inlet-test.scm
@@ -28,10 +28,32 @@
 ;;
 ;; 说明
 ;; ----
-;; inlet 是构造 let 的基本方式。
+;; inlet 是构造 let（环境对象）的基本方式。
 ;; 无参数调用 (inlet) 创建空 let。
 ;; (inlet 'a 1 'b 2) 创建包含 a=1、b=2 的 let。
 ;; inlet 创建的 let 是一个独立环境，其 outlet 是 rootlet。
+;;
+;; inlet 是可变的：通过 (set! (obj :key) v) 修改内部绑定。
+;; 关键性质：set! 只改绑定值，不创建新对象——对象身份（eq?）恒定不变。
+;; 因此 inlet 适合做需要就地更新、身份稳定的数据载体（如 data class）。
+;;
+;; 示例
+;; ----
+;; (define p (inlet :name "Bob" :age 25))
+;; (define alias p)
+;; (set! (p :age) 26)        ; 改 :age 绑定
+;; (eq? p alias)             ; => #t，对象身份没变
+;; (alias :age)              ; => 26，别名看到新值
+
+
+;; inlet 是可变环境：set! 改绑定值，但对象身份不变（核心不变式）
+(check (let* ((p (inlet :name "Bob" :age 25)) (alias p))
+         (set! (p :age) 26)
+         (list (eq? p alias) (alias :age))
+       ) ;let*
+  =>
+  '(#t 26)
+) ;check
 
 
 ;; 空 inlet 是 let

--- a/tests/liii/base/inlet-test.scm
+++ b/tests/liii/base/inlet-test.scm
@@ -1,5 +1,6 @@
 (import (liii check))
 (import (liii base))
+(import (liii json))
 
 
 (check-set-mode! 'report-failed)
@@ -131,6 +132,61 @@
 (check (person-age p2) => 30)
 
 (check (begin (person-inc-age! p2) (person-age p2)) => 31)
+
+
+;; ---- data class：inlet + 顶层序列化函数 ---------------------------
+;; person data class 的正确做法：对象就是 inlet，字段就是绑定，
+;; 序列化/反序列化用顶层函数，无需 openlet、无需闭包封装。
+;; 字段用 keyword 键；序列化为 (liii json) 兼容的字符串键 alist。
+
+(define (make-person name age)
+  (inlet :name name :age age)
+) ;define
+
+(define (person->json p)
+  (list (cons "name" (p :name)) (cons "age" (p :age)))
+) ;define
+
+(define (json->person j)
+  (inlet :name (cdr (assoc "name" j)) :age (cdr (assoc "age" j)))
+) ;define
+
+(define (string->person s)
+  (json->person (string->json s))
+) ;define
+
+
+;; 字段访问
+(check (let ((p (make-person "Bob" 25)))
+         (list (p :name) (p :age))
+       ) ;let
+  =>
+  '("Bob" 25)
+) ;check
+
+;; 序列化：person -> alist -> JSON 字符串
+(check (let ((p (make-person "Bob" 25)))
+         (person->json p)
+       ) ;let
+  =>
+  '(("name" . "Bob") ("age" . 25))
+) ;check
+
+;; 反序列化：JSON 字符串 -> person
+(check (let ((p (string->person "{\"name\":\"Alice\",\"age\":30}")))
+         (list (p :name) (p :age))
+       ) ;let
+  =>
+  '("Alice" 30)
+) ;check
+
+;; 完整往返：JSON -> person -> JSON
+(check (let ((p (string->person "{\"name\":\"Alice\",\"age\":30}")))
+         (json->string (person->json p))
+       ) ;let
+  =>
+  "{\"name\":\"Alice\",\"age\":30}"
+) ;check
 
 
 (check-report)

--- a/tests/liii/base/inlet-test.scm
+++ b/tests/liii/base/inlet-test.scm
@@ -87,4 +87,28 @@
 (check (begin (set! (p1 :age) (+ (p1 :age) 1)) (p1 :age)) => 27)
 
 
+;; ---- 顶层函数封装 -------------------------------------------------
+;; 复合操作写多遍会啰嗦，封装成 person-age / person-inc-age! 等顶层函数，
+;; 内部仍操作 inlet 绑定，对象本身保持简单
+
+(define (person-age p)
+  (p :age)
+) ;define
+
+(define (person-set-age! p v)
+  (set! (p :age) v)
+) ;define
+
+(define (person-inc-age! p)
+  (person-set-age! p (+ (person-age p) 1))
+) ;define
+
+(define p2 (inlet :name "Alice" :age 30))
+
+;; 通过封装函数读写 age
+(check (person-age p2) => 30)
+
+(check (begin (person-inc-age! p2) (person-age p2)) => 31)
+
+
 (check-report)

--- a/tests/liii/base/inlet-test.scm
+++ b/tests/liii/base/inlet-test.scm
@@ -148,7 +148,7 @@
 ) ;define
 
 (define (json->person j)
-  (make-person (cdr (assoc "name" j)) (cdr (assoc "age" j)))
+  (make-person (json-ref j "name") (json-ref j "age"))
 ) ;define
 
 (define (string->person s)

--- a/tests/liii/base/inlet-test.scm
+++ b/tests/liii/base/inlet-test.scm
@@ -70,17 +70,10 @@
 ;; inlet 是可变的
 ;; =========================================================================
 ;;
-;; inlet 的绑定可以通过 set! 修改，有两种风格：
-;;
-;;   开放式：字段直接挂 inlet，外部用 (set! (obj :field) v) 改值。
-;;           字段公开可见、可改，封装弱。
-;;
-;;   封装式：字段是工厂函数的闭包变量，inlet 只暴露读写方法。
-;;           字段外部不可直接访问，封装强。
+;; inlet 是可调用环境，(obj :key) 取值，set! 其返回位置即可改值。
 
 
-;; ---- 开放式：直接改 inlet 绑定 ----------------------------------
-;; inlet 是可调用环境，(obj :key) 取值，set! 其返回位置即可改值
+;; ---- inlet 是可变的：直接改绑定 ----------------------------------
 
 (define p1 (inlet :name "Bob" :age 25))
 
@@ -92,33 +85,6 @@
 
 ;; 复合操作：age + 1
 (check (begin (set! (p1 :age) (+ (p1 :age) 1)) (p1 :age)) => 27)
-
-
-;; ---- 封装式：方法改闭包变量 -------------------------------------
-;; age 是闭包变量，inlet 暴露 :get-age / :inc-age 方法
-;; 调用时避免 ((obj :method) obj) 的冗余写法，
-;; 定义顶层封装函数，调用处更自然
-
-(define* (make-person (name "?") (age 0))
-  (inlet :get-age
-    (lambda (self) age)
-    :inc-age
-    (lambda (self) (set! age (+ age 1)) age)
-  ) ;inlet
-) ;define*
-
-(define (get-age obj)
- ((obj :get-age) obj)
-) ;define
-
-(define (increase-age obj)
- ((obj :inc-age) obj)
-) ;define
-
-(define p2 (make-person :name "Bob" :age 25))
-
-;; increase-age 修改 age，get-age 读取
-(check (begin (increase-age p2) (get-age p2)) => 26)
 
 
 (check-report)

--- a/tests/liii/base/inlet-test.scm
+++ b/tests/liii/base/inlet-test.scm
@@ -66,4 +66,49 @@
 (check (length (inlet)) => 0)
 
 
+;; =========================================================================
+;; inlet 是可变的
+;; =========================================================================
+;;
+;; inlet 的绑定可以通过 set! 修改，有两种风格：
+;;
+;;   开放式：字段直接挂 inlet，外部用 (set! (obj :field) v) 改值。
+;;           字段公开可见、可改，封装弱。
+;;
+;;   封装式：字段是工厂函数的闭包变量，inlet 只暴露读写方法。
+;;           字段外部不可直接访问，封装强。
+
+
+;; ---- 开放式：直接改 inlet 绑定 ----------------------------------
+;; inlet 是可调用环境，(obj :key) 取值，set! 其返回位置即可改值
+
+(define p1 (inlet :name "Bob" :age 25))
+
+;; (p1 :age) 取值
+(check (p1 :age) => 25)
+
+;; set! 修改 :age 绑定
+(check (begin (set! (p1 :age) 26) (p1 :age)) => 26)
+
+;; 复合操作：age + 1
+(check (begin (set! (p1 :age) (+ (p1 :age) 1)) (p1 :age)) => 27)
+
+
+;; ---- 封装式：方法改闭包变量 -------------------------------------
+;; age 是闭包变量，外部只能通过 :get-age / :inc-age 操作
+
+(define* (make-person (name "?") (age 0))
+  (inlet :get-age
+    (lambda (self) age)
+    :inc-age
+    (lambda (self) (set! age (+ age 1)) age)
+  ) ;inlet
+) ;define*
+
+(define p2 (make-person :name "Bob" :age 25))
+
+;; 方法修改 age（闭包变量）
+(check (begin ((p2 :inc-age) p2) ((p2 :get-age) p2)) => 26)
+
+
 (check-report)

--- a/tests/liii/base/inlet-test.scm
+++ b/tests/liii/base/inlet-test.scm
@@ -148,7 +148,7 @@
 ) ;define
 
 (define (json->person j)
-  (inlet :name (cdr (assoc "name" j)) :age (cdr (assoc "age" j)))
+  (make-person (cdr (assoc "name" j)) (cdr (assoc "age" j)))
 ) ;define
 
 (define (string->person s)

--- a/tests/liii/base/let-p-test.scm
+++ b/tests/liii/base/let-p-test.scm
@@ -1,0 +1,80 @@
+(import (liii check))
+(import (liii base))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; let?
+;; 判断对象是否为 let（环境对象）。
+;;
+;; 语法
+;; ----
+;; (let? obj)
+;;
+;; 参数
+;; ----
+;; obj : any
+;; 要判断的对象。
+;;
+;; 返回值
+;; ------
+;; boolean?
+;; 如果 obj 是 let 则返回 #t，否则返回 #f。
+;;
+;; 说明
+;; ----
+;; let? 判断对象是否为环境（let）类型。
+;; inlet、curlet、rootlet、owlet 等返回的对象都是 let。
+;; funclet（函数闭包环境）也是 let。
+
+
+;; curlet 返回的对象是 let
+(check (let? (curlet)) => #t)
+
+
+;; rootlet 是 let
+(check (let? (rootlet)) => #t)
+
+
+;; owlet 是 let
+(check (let? (owlet)) => #t)
+
+
+;; inlet 创建的对象是 let
+(check (let? (inlet 'a 1)) => #t)
+
+
+;; sublet 创建的对象是 let
+(check (let? (sublet (inlet 'a 1) 'b 2)) => #t)
+
+
+;; funclet 返回的对象是 let
+(check (let? (funclet car)) => #t)
+
+
+;; 整数不是 let
+(check (let? 42) => #f)
+
+
+;; 字符串不是 let
+(check (let? "hello") => #f)
+
+
+;; 符号不是 let
+(check (let? 'sym) => #f)
+
+
+;; 列表不是 let
+(check (let? (list 1 2 3)) => #f)
+
+
+;; #t 不是 let
+(check (let? #t) => #f)
+
+
+;; '() 不是 let
+(check (let? '()) => #f)
+
+
+(check-report)

--- a/tests/liii/base/let-ref-test.scm
+++ b/tests/liii/base/let-ref-test.scm
@@ -1,0 +1,60 @@
+(import (liii check))
+(import (liii base))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; let-ref
+;; 返回 let 中指定符号的绑定值。
+;;
+;; 语法
+;; ----
+;; (let-ref let sym)
+;;
+;; 参数
+;; ----
+;; let : let?
+;; 要查询的 let。
+;;
+;; sym : symbol?
+;; 要查询的符号。
+;;
+;; 返回值
+;; ------
+;; any
+;; 该符号在 let 中的绑定值。
+;;
+;; 说明
+;; ----
+;; let-ref 从 let 中查找指定符号的值。
+;; 若 let 中没有该符号的绑定，返回 #<undefined>。
+;; let-ref 只查找 let 的直接绑定，不递归到 outlet。
+;; rootlet-ref 是 let-ref 的快速路径变体（针对 rootlet）。
+
+
+;; 从 inlet 中获取绑定
+(check (let-ref (inlet 'a 42) 'a) => 42)
+
+
+;; 获取字符串绑定
+(check (let-ref (inlet 'name "hello") 'name) => "hello")
+
+
+;; 多绑定的 let 中获取指定符号
+(check (let-ref (inlet 'a 1 'b 2 'c 3) 'b) => 2)
+
+
+;; 未绑定的符号返回 #<undefined>
+(check (undefined? (let-ref (inlet 'a 1) 'z)) => #t)
+
+
+;; let-ref 只查直接绑定，不递归 outlet
+(check (let ((parent (inlet 'a 1))) (let-ref (sublet parent 'b 2) 'a)) => 1)
+
+
+;; 从 rootlet 中获取内建函数 +
+(check (let-ref (rootlet) '+) => +)
+
+
+(check-report)

--- a/tests/liii/base/let-set-bang-test.scm
+++ b/tests/liii/base/let-set-bang-test.scm
@@ -1,0 +1,76 @@
+(import (liii check))
+(import (liii base))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; let-set!
+;; 设置 let 中指定符号的绑定值（就地修改）。
+;;
+;; 语法
+;; ----
+;; (let-set! let sym val)
+;;
+;; 参数
+;; ----
+;; let : let?
+;; 要修改的 let。
+;;
+;; sym : symbol?
+;; 要设置的符号。
+;;
+;; val : any
+;; 新的绑定值。
+;;
+;; 返回值
+;; ------
+;; unspecified
+;; 返回值未指定（副作用操作）。
+;;
+;; 说明
+;; ----
+;; let-set! 就地修改 let 中指定符号的绑定值。
+;; 若 let 中已有该符号，则更新其值；否则行为依实现而定。
+;; 修改后通过 let-ref 可读到新值。
+
+
+;; let-set! 更新已有绑定
+(check (let ((e (inlet 'a 1))) (let-set! e 'a 99) (let-ref e 'a)) => 99)
+
+
+;; let-set! 设置新值后，原值被覆盖
+(check (let ((e (inlet 'a 1 'b 2))) (let-set! e 'a 100) (let-ref e 'b)) => 2)
+
+
+;; let-set! 可设置字符串值
+(check (let ((e (inlet 'name "old")))
+         (let-set! e 'name "new")
+         (let-ref e 'name)
+       ) ;let
+  =>
+  "new"
+) ;check
+
+
+;; let-set! 可设置列表值
+(check (let ((e (inlet 'items (list 1 2))))
+         (let-set! e 'items (list 1 2 3))
+         (let-ref e 'items)
+       ) ;let
+  =>
+  (list 1 2 3)
+) ;check
+
+
+;; let-set! 可设置 #f / #t
+(check (let ((e (inlet 'flag #t)))
+         (let-set! e 'flag #f)
+         (let-ref e 'flag)
+       ) ;let
+  =>
+  #f
+) ;check
+
+
+(check-report)

--- a/tests/liii/base/let-to-list-test.scm
+++ b/tests/liii/base/let-to-list-test.scm
@@ -1,0 +1,62 @@
+(import (liii check))
+(import (liii base))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; let->list
+;; 将 let 的所有直接绑定转换为点对列表。
+;;
+;; 语法
+;; ----
+;; (let->list let)
+;;
+;; 参数
+;; ----
+;; let : let?
+;; 要转换的 let。
+;;
+;; 返回值
+;; ------
+;; list?
+;; 由 (symbol . value) 点对组成的列表，每个点对对应一个直接绑定。
+;;
+;; 说明
+;; ----
+;; let->list 返回 let 的所有直接绑定（不包含 outlet 链上的绑定）。
+;; 每个绑定表示为 (symbol . value) 点对。
+;; 返回列表的长度等于 let 的直接绑定数量。
+
+
+;; 空 inlet 转换为空列表
+(check (let->list (inlet)) => (list))
+
+
+;; 单绑定的 inlet
+(check (let->list (inlet 'a 1)) => (list (cons 'a 1)))
+
+
+;; 多绑定的 inlet
+(check (let->list (inlet 'a 1 'b 2)) => (list (cons 'a 1) (cons 'b 2)))
+
+
+;; let->list 的长度等于绑定数
+(check (length (let->list (inlet 'a 1 'b 2 'c 3))) => 3)
+
+
+;; let->list 只包含直接绑定，不含 outlet 链上的
+(check (let->list (sublet (inlet 'a 1) 'b 2)) => (list (cons 'b 2)))
+
+
+;; let-set! 后 let->list 反映新值
+(check (let ((e (inlet 'a 1)))
+         (let-set! e 'a 99)
+         (let->list e)
+       ) ;let
+  =>
+  (list (cons 'a 99))
+) ;check
+
+
+(check-report)

--- a/tests/liii/base/openlet-p-test.scm
+++ b/tests/liii/base/openlet-p-test.scm
@@ -1,0 +1,56 @@
+(import (liii check))
+(import (liii base))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; openlet?
+;; 判断 let 是否被 openlet 标记为 "open"。
+;;
+;; 语法
+;; ----
+;; (openlet? obj)
+;;
+;; 参数
+;; ----
+;; obj : any
+;; 要判断的对象。
+;;
+;; 返回值
+;; ------
+;; boolean?
+;; 如果 obj 是一个被 openlet 标记过的 let，返回 #t，否则返回 #f。
+;;
+;; 说明
+;; ----
+;; openlet? 判断一个 let 是否处于 open 状态。
+;; open 状态下，内建函数作用于该 let 时会查询其是否覆盖了方法。
+;; 新建的 inlet 默认不是 open。
+
+
+;; 新建的 inlet 不是 openlet
+(check (openlet? (inlet 'a 1)) => #f)
+
+
+;; openlet 标记后的 let 是 openlet
+(check (openlet? (openlet (inlet 'a 1))) => #t)
+
+
+;; coverlet 撤销后不再是 openlet
+(check (openlet? (coverlet (openlet (inlet 'a 1)))) => #f)
+
+
+;; rootlet 不是 openlet
+(check (openlet? (rootlet)) => #f)
+
+
+;; 整数不是 openlet
+(check (openlet? 42) => #f)
+
+
+;; 字符串不是 openlet
+(check (openlet? "hello") => #f)
+
+
+(check-report)

--- a/tests/liii/base/openlet-test.scm
+++ b/tests/liii/base/openlet-test.scm
@@ -1,0 +1,51 @@
+(import (liii check))
+(import (liii base))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; openlet
+;; 标记一个 let 为 "open"，使内建函数会查询该 let 是否覆盖了某个方法。
+;; 返回该 let 自身。
+;;
+;; 语法
+;; ----
+;; (openlet let)
+;;
+;; 参数
+;; ----
+;; let : let?
+;; 要标记为 open 的 let。
+;;
+;; 返回值
+;; ------
+;; let?
+;; 返回传入的 let（已被标记为 open）。
+;;
+;; 说明
+;; ----
+;; openlet 用于对象系统：当一个 let 被 open 后，
+;; 内建函数（如 +、display 等）在作用于该 let 的内容时，
+;; 会先查询该 let 是否定义了同名的方法，若有则调用之。
+;; coverlet 可撤销 openlet 的效果。
+;; openlet 就地修改并返回原 let。
+
+
+;; openlet 返回传入的 let（eq? 为 #t）
+(check (let ((e (inlet 'a 1))) (eq? (openlet e) e)) => #t)
+
+
+;; openlet 标记后，openlet? 返回 #t
+(check (let ((e (inlet 'a 1))) (openlet e) (openlet? e)) => #t)
+
+
+;; 未经 openlet 的 inlet，openlet? 为 #f
+(check (openlet? (inlet 'a 1)) => #f)
+
+
+;; openlet 后内部绑定仍可访问
+(check (let-ref (openlet (inlet 'a 42)) 'a) => 42)
+
+
+(check-report)

--- a/tests/liii/base/openlet-test.scm
+++ b/tests/liii/base/openlet-test.scm
@@ -1,5 +1,6 @@
 (import (liii check))
 (import (liii base))
+(import (liii json))
 
 
 (check-set-mode! 'report-failed)
@@ -166,6 +167,65 @@
        ) ;let
   =>
   '(2 3)
+) ;check
+
+
+;; 应用示例：用 openlet 模拟 data class（带 JSON 序列化）
+;; make-person 支持 :name/:age 直接构造，也支持 :from-json 从 alist 构造
+;; 返回的对象支持 :to-json 方法，导出为 (liii json) 兼容的 alist
+;;
+;; 与 (liii json) 的配合：
+;; - string->json 解析 JSON 字符串得到字符串键 alist
+;; - json->string 把 alist 序列化为 JSON 字符串
+;; - person 的 :to-json / :from-json 正好衔接两端
+
+(define (alist-get alist key)
+  (let ((pair (assoc key alist)))
+    (if pair (cdr pair) #f)
+  ) ;let
+) ;define
+
+(define* (make-person-dc (name #f) (age #f) (from-json #f))
+  (let* ((nm (or name (and from-json (alist-get from-json "name")) "?"))
+         (ag (or age (and from-json (alist-get from-json "age")) 0))
+        ) ;
+    (openlet (lambda (key)
+               (case key
+                ((:name) nm)
+                ((:age) ag)
+                ((:to-json) (list (cons "name" nm) (cons "age" ag)))
+               ) ;case
+             ) ;lambda
+    ) ;openlet
+  ) ;let*
+) ;define*
+
+
+;; :from-json 从 (liii json) 的 alist 构造对象
+(check (let ((p (make-person-dc :from-json (string->json "{\"name\":\"Alice\",\"age\":30}"))))
+         (list (p :name) (p :age))
+       ) ;let
+  =>
+  '("Alice" 30)
+) ;check
+
+
+;; :to-json 导出为字符串键 alist，可直接喂给 json->string
+(check (let ((p (make-person-dc :name "Bob" :age 25)))
+         (p :to-json)
+       ) ;let
+  =>
+  '(("name" . "Bob") ("age" . 25))
+) ;check
+
+
+;; 完整往返：JSON 字符串 -> person -> JSON 字符串
+(check (let ((p (make-person-dc :from-json (string->json "{\"name\":\"Alice\",\"age\":30}")))
+            ) ;
+         (json->string (p :to-json))
+       ) ;let
+  =>
+  "{\"name\":\"Alice\",\"age\":30}"
 ) ;check
 
 

--- a/tests/liii/base/openlet-test.scm
+++ b/tests/liii/base/openlet-test.scm
@@ -171,13 +171,11 @@
 
 
 ;; 应用示例：用 openlet 模拟 data class（带 JSON 序列化）
-;; make-person 支持 :name/:age 直接构造，也支持 :from-json 从 alist 构造
-;; 返回的对象支持 :to-json 方法，导出为 (liii json) 兼容的 alist
-;;
-;; 与 (liii json) 的配合：
-;; - string->json 解析 JSON 字符串得到字符串键 alist
-;; - json->string 把 alist 序列化为 JSON 字符串
-;; - person 的 :to-json / :from-json 正好衔接两端
+;; 提供三层 API：
+;; - make-person-dc :name/:age 直接构造对象
+;; - json->person  从 (liii json) 的 alist 构造
+;; - string->person 从 JSON 字符串构造（内部 string->json 后委托 json->person）
+;; 对象支持 :to-json 方法，导出为 (liii json) 兼容的 alist
 
 (define (alist-get alist key)
   (let ((pair (assoc key alist)))
@@ -185,24 +183,46 @@
   ) ;let
 ) ;define
 
-(define* (make-person-dc (name #f) (age #f) (from-json #f))
-  (let* ((nm (or name (and from-json (alist-get from-json "name")) "?"))
-         (ag (or age (and from-json (alist-get from-json "age")) 0))
-        ) ;
-    (openlet (lambda (key)
-               (case key
-                ((:name) nm)
-                ((:age) ag)
-                ((:to-json) (list (cons "name" nm) (cons "age" ag)))
-               ) ;case
-             ) ;lambda
-    ) ;openlet
-  ) ;let*
+(define* (make-person-dc (name "?") (age 0))
+  (openlet (lambda (key)
+             (case key
+              ((:name) name)
+              ((:age) age)
+              ((:to-json) (list (cons "name" name) (cons "age" age)))
+             ) ;case
+           ) ;lambda
+  ) ;openlet
 ) ;define*
 
+(define (json->person j)
+  (make-person-dc :name (alist-get j "name") :age (alist-get j "age"))
+) ;define
 
-;; :from-json 从 (liii json) 的 alist 构造对象
-(check (let ((p (make-person-dc :from-json (string->json "{\"name\":\"Alice\",\"age\":30}"))))
+(define (string->person s)
+  (json->person (string->json s))
+) ;define
+
+
+;; make-person-dc :name/:age 直接构造
+(check (let ((p (make-person-dc :name "Bob" :age 25)))
+         (list (p :name) (p :age))
+       ) ;let
+  =>
+  '("Bob" 25)
+) ;check
+
+
+;; json->person 从 (liii json) 的 alist 构造对象
+(check (let ((p (json->person (string->json "{\"name\":\"Alice\",\"age\":30}"))))
+         (list (p :name) (p :age))
+       ) ;let
+  =>
+  '("Alice" 30)
+) ;check
+
+
+;; string->person 从 JSON 字符串构造对象
+(check (let ((p (string->person "{\"name\":\"Alice\",\"age\":30}")))
          (list (p :name) (p :age))
        ) ;let
   =>
@@ -220,8 +240,7 @@
 
 
 ;; 完整往返：JSON 字符串 -> person -> JSON 字符串
-(check (let ((p (make-person-dc :from-json (string->json "{\"name\":\"Alice\",\"age\":30}")))
-            ) ;
+(check (let ((p (string->person "{\"name\":\"Alice\",\"age\":30}")))
          (json->string (p :to-json))
        ) ;let
   =>

--- a/tests/liii/base/openlet-test.scm
+++ b/tests/liii/base/openlet-test.scm
@@ -248,4 +248,84 @@
 ) ;check
 
 
+;; =========================================================================
+;; inlet 与 openlet 的区别
+;; =========================================================================
+;;
+;; 两者都能模拟面向对象，但机制不同：
+;;
+;;   inlet：对象就是环境（键值容器），(obj :key) 直接取绑定值。
+;;          天然支持继承（outlet 链），但内建函数不会特殊处理它。
+;;
+;;   openlet：给环境/闭包打标记，使内建函数（length、object->string 等）
+;;            遇到该对象时，查询其内部同名方法并调用（方法分派）。
+;;
+;; 关键差异：
+;; ┌─────────────────┬──────────────────────┬───────────────────────┐
+;; │ 维度            │ 纯 inlet              │ openlet 闭包          │
+;; ├─────────────────┼──────────────────────┼───────────────────────┤
+;; │ 对象本质        │ 环境（键值容器）      │ 闭包（lambda）        │
+;; │ (obj :key)      │ 直接取绑定值          │ case 手动分派         │
+;; │ 字段封装        │ 弱（绑定可见）        │ 强（闭包变量）        │
+;; │ 继承            │ outlet 链天然支持     │ 需手动委托            │
+;; │ 内建函数方法分派│ ✗ 不触发              │ ✓ 触发                │
+;; └─────────────────┴──────────────────────┴───────────────────────┘
+;;
+;; 最后一行是核心区别：openlet 让对象能"改写"内建函数对它的处理方式，
+;; inlet 做不到。下面用计数器对象演示两种实现。
+
+
+;; ---- 纯 inlet 版计数器 -----------------------------------------
+;; 对象是 inlet，字段/方法都是绑定，方法签名 (lambda (self) ...)
+;; 状态 count 是闭包变量，多个实例状态独立
+
+(define (make-counter-inlet)
+  (let ((count 0))
+    (inlet :get
+      (lambda (self) count)
+      :inc
+      (lambda (self) (set! count (+ count 1)) count)
+    ) ;inlet
+  ) ;let
+) ;define
+
+(define ci (make-counter-inlet))
+
+;; 方法调用：((ci :inc) ci) —— 取出方法后传 self
+(check (begin ((ci :inc) ci) ((ci :inc) ci) ((ci :get) ci)) => 2)
+
+;; 纯 inlet 的局限：length 不认识它，不会调用 :length 方法
+;; 下面这个 inlet 定义了 :length，但 (length ci) 仍返回绑定数（2 个方法）
+(check (length (inlet :length (lambda (self) 99) :get (lambda (self) 0))) => 2)
+
+
+;; ---- openlet 版计数器 ------------------------------------------
+;; 同样的逻辑，但用 openlet 包装后，length 会查询 :length 方法
+
+(define (make-counter-openlet)
+  (let ((count 0))
+    (openlet (inlet :get
+               (lambda (self) count)
+               :inc
+               (lambda (self) (set! count (+ count 1)) count)
+               :length
+               (lambda (self) count)
+             ) ;inlet
+    ) ;openlet
+  ) ;let
+) ;define
+
+(define co (make-counter-openlet))
+((co :inc) co)
+((co :inc) co)
+
+;; openlet 触发方法分派：length 查询到 :length 方法，返回 count 值
+(check (length co) => 2)
+
+
+;; ---- 封装性对比 -------------------------------------------------
+;; inlet 的绑定对外可见：(ci :get) 直接返回方法 lambda
+;; openlet 闭包模式（见前面 make-person）：字段是闭包变量，外部无法直接访问
+
+
 (check-report)

--- a/tests/liii/base/openlet-test.scm
+++ b/tests/liii/base/openlet-test.scm
@@ -1,13 +1,12 @@
 (import (liii check))
 (import (liii base))
-(import (liii json))
 
 
 (check-set-mode! 'report-failed)
 
 
 ;; openlet
-;; 标记一个 let 为 "open"，使内建函数会查询该 let 是否覆盖了某个方法。
+;; 标记一个 let（环境）为 "open"，使内建函数会查询该 let 是否覆盖了某个方法。
 ;; 返回该 let 自身。
 ;;
 ;; 语法
@@ -26,106 +25,20 @@
 ;;
 ;; 说明
 ;; ----
-;; openlet 用于对象系统：当一个 let 被 open 后，
-;; 内建函数（如 +、display 等）在作用于该 let 的内容时，
-;; 会先查询该 let 是否定义了同名的方法，若有则调用之。
+;; openlet 的唯一作用：让内建函数（length、object->string、display、
+;; copy 等忽略参数类型的函数）遇到该对象时，查询对象内部同名方法并调用。
+;; 这称为"方法分派"。
+;;
 ;; coverlet 可撤销 openlet 的效果。
 ;; openlet 就地修改并返回原 let。
 ;;
-;; 示例
-;; ----
-;; ;; 让 length 内建函数在遇到 e 时调用 e 自己的 'length 方法
-;; (length (openlet (inlet 'length (lambda (x) 99))))
-;; ;; => 99
-;;
-;; ;; 让 object->string 查询 e 内的同名方法，自定义字符串表示
-;; (object->string (openlet (inlet 'object->string (lambda args "#<myobj>"))))
-;; ;; => "#<myobj>"
-;;
 ;; 注意
 ;; ----
-;; 仅对"忽略参数类型"的内建函数（如 length、object->string、display、
-;; copy 等）才会触发方法分派；带严格类型检查的函数（如 abs 要求参数
-;; 为 number）不会查询 openlet 的方法。
-;;
-;; =========================================================================
-;; inlet 与 openlet 的区别（先读这段，再看下面的具体示例）
-;; =========================================================================
-;;
-;; 两者都能模拟面向对象，但机制不同：
-;;
-;;   inlet：对象就是环境（键值容器），(obj :key) 直接取绑定值。
-;;          天然支持继承（outlet 链），但内建函数不会特殊处理它。
-;;
-;;   openlet：给环境/闭包打标记，使内建函数（length、object->string 等）
-;;            遇到该对象时，查询其内部同名方法并调用（方法分派）。
-;;
-;; 关键差异：
-;; ┌─────────────────┬──────────────────────┬───────────────────────┐
-;; │ 维度            │ 纯 inlet              │ openlet 闭包          │
-;; ├─────────────────┼──────────────────────┼───────────────────────┤
-;; │ 对象本质        │ 环境（键值容器）      │ 闭包（lambda）        │
-;; │ (obj :key)      │ 直接取绑定值          │ case 手动分派         │
-;; │ 字段封装        │ 弱（绑定可见）        │ 强（闭包变量）        │
-;; │ 继承            │ outlet 链天然支持     │ 需手动委托            │
-;; │ 内建函数方法分派│ ✗ 不触发              │ ✓ 触发                │
-;; └─────────────────┴──────────────────────┴───────────────────────┘
-;;
-;; 最后一行是核心区别：openlet 让对象能"改写"内建函数对它的处理方式，
-;; inlet 做不到。下面先用计数器对象演示这个差异，再展开 openlet 的其他用法。
-
-
-;; ---- 计数器对象：同一逻辑的两种实现 ----------------------------
-;; 纯 inlet 版：(obj :key) 直接取绑定；length 不触发方法分派
-
-(define (make-counter-inlet)
-  (let ((count 0))
-    (inlet :get
-      (lambda (self) count)
-      :inc
-      (lambda (self) (set! count (+ count 1)) count)
-    ) ;inlet
-  ) ;let
-) ;define
-
-(define ci (make-counter-inlet))
-((ci :inc) ci)
-((ci :inc) ci)
-
-;; inlet 版计数器本身工作正常：((ci :get) ci) 能取到 count
-(check ((ci :get) ci) => 2)
-
-;; 纯 inlet 的局限：定义了 :length 方法，但 length 不理它，返回绑定数
-(check (length (inlet :length (lambda (self) 99) :get (lambda (self) 0))) => 2)
-
-;; openlet 版：同样的结构加 openlet 包装后，length 会查询 :length 方法
-
-(define (make-counter-openlet)
-  (let ((count 0))
-    (openlet (inlet :get
-               (lambda (self) count)
-               :inc
-               (lambda (self) (set! count (+ count 1)) count)
-               :length
-               (lambda (self) count)
-             ) ;inlet
-    ) ;openlet
-  ) ;let
-) ;define
-
-(define co (make-counter-openlet))
-((co :inc) co)
-((co :inc) co)
-
-;; openlet 触发方法分派：length 查询到 :length 方法，返回 count 值（也是 2）
-(check (length co) => 2)
-
-;; 同样返回 2，语义不同：inlet 是"碰巧有 2 个绑定"，openlet 是"count 等于 2"。
-
-
-;; =========================================================================
-;; 以下是 openlet 的基础用法与更多应用示例
-;; =========================================================================
+;; 1. 仅对"忽略参数类型"的内建函数生效；带类型检查的函数（如 abs 要求
+;;    参数为 number）不会查询 openlet 的方法。
+;; 2. openlet 不对用户自定义函数生效——自定义函数调用不会触发方法分派。
+;; 3. 做面向对象 / data class 通常用 inlet + 顶层函数即可，无需 openlet。
+;;    只有需要改写内建函数行为时才用 openlet。
 
 
 ;; openlet 返回传入的 let（eq? 为 #t）
@@ -144,187 +57,25 @@
 (check (let-ref (openlet (inlet 'a 42)) 'a) => 42)
 
 
-;; 关键用法：openlet 让内建 length 查询到 let 内的同名方法并调用
+;; 关键用法 1：length 方法分派
+;; 纯 inlet 的 :length 方法不会被 length 调用，返回绑定数
+(check (length (inlet 'length (lambda (x) 99) 'a 1)) => 2)
+
+;; openlet 标记后，length 查询到 :length 方法并调用，返回 99
 (check (length (openlet (inlet 'length (lambda (x) 99)))) => 99)
 
 
-;; openlet 让 object->string 查询同名方法，自定义字符串表示
+;; 关键用法 2：object->string 方法分派
+;; 自定义对象的字符串表示（display 时也走此方法）
 (check (object->string (openlet (inlet 'object->string (lambda args "#<myobj>"))))
   =>
   "#<myobj>"
 ) ;check
 
 
-;; coverlet 可撤销 openlet 的方法分派效果：
-;; 撤销后 length 不再调用自定义方法，而返回 inlet 的实际绑定数量（1 个：'length）
+;; coverlet 可撤销 openlet 的方法分派效果
+;; 撤销后 length 不再调用 :length 方法，返回绑定数
 (check (length (coverlet (openlet (inlet 'length (lambda (x) 99))))) => 1)
-
-
-;; 应用示例：用 openlet 定义带业务方法的 person 对象
-;; 工厂函数 make-person-greet 返回一个闭包，被 openlet 标记后：
-;; - 调用 (p :field) 时按 keyword 分派，返回字段值或业务结果
-;; - 字段 (name age) 被闭包捕获，外部无法直接访问，实现封装
-(define* (make-person-greet (name "?") (age 0))
-  (openlet (lambda (key)
-             (case key
-              ((:name) name)
-              ((:age) age)
-              ((:greet) (format #f "Hi, I'm ~A, ~A years old." name age))
-              (else (error 'unknown-method "person: ~A" key))
-             ) ;case
-           ) ;lambda
-  ) ;openlet
-) ;define*
-
-
-;; (p :greet) 自动分发到业务方法
-(check (let ((p (make-person-greet :name "Bob" :age 25)))
-         (p :greet)
-       ) ;let
-  =>
-  "Hi, I'm Bob, 25 years old."
-) ;check
-
-
-;; (p :name) / (p :age) 访问字段
-(check (let ((p (make-person-greet :name "Alice" :age 30)))
-         (list (p :name) (p :age))
-       ) ;let
-  =>
-  '("Alice" 30)
-) ;check
-
-
-;; 默认参数：缺省时 name 为 "?"、age 为 0
-(check (let ((p (make-person-greet))) (p :greet)) => "Hi, I'm ?, 0 years old.")
-
-
-;; 应用示例：用 openlet 定义 matrix 对象
-;; 工厂函数 make-matrix 返回一个被 openlet 标记的闭包：
-;; - (m i j) 或 (apply m '(i j)) 取出第 i 行第 j 列的元素
-;; - (m :rows) / (m :cols) 查询行列数
-;; 内部用 s7 多维 vector 存储，vector-ref 原生支持多维索引
-;;
-;; 注：此处用 subvector 从一维 vector 构造 2x3 矩阵以避开 #2d(...)
-;; 字面量（gf fmt 工具尚不支持该语法，会错误地将其重写为一维 vector）
-
-(define (make-matrix data)
-  (openlet (lambda args
-             (case (length args)
-                   ((1)
-                    (case (car args)
-                          ((:rows) (vector-dimension data 0))
-                          ((:cols) (vector-dimension data 1))
-                          (else (error 'unknown-method "matrix: ~A" (car args)))
-                    ) ;case
-                   ) ;
-                   ((2) (apply vector-ref data args))
-                   (else (error 'wrong-number-of-args "matrix expects 1 or 2 args, got ~A" (length args))
-                   ) ;else
-             ) ;case
-           ) ;lambda
-  ) ;openlet
-) ;define
-
-
-;; 构造 2x3 矩阵 [[1 2 3] [4 5 6]] 用于后续测试
-
-(define test-matrix (subvector #(1 2 3 4 5 6) 0 6 '(2 3)))
-
-
-;; (m i j) 直接取元素
-(check (let ((m (make-matrix test-matrix))) (m 1 2)) => 6)
-
-
-;; (apply m '(i j)) 也能取元素 —— 闭包原生支持 apply
-(check (let ((m (make-matrix test-matrix))) (apply m '(1 2))) => 6)
-
-
-;; (m :rows) / (m :cols) 查询维度
-(check (let ((m (make-matrix test-matrix)))
-         (list (m :rows) (m :cols))
-       ) ;let
-  =>
-  '(2 3)
-) ;check
-
-
-;; 应用示例：用 openlet 模拟 data class（带 JSON 序列化）
-;; 提供三层 API：
-;; - make-person :name/:age 直接构造对象
-;; - json->person  从 (liii json) 的 alist 构造
-;; - string->person 从 JSON 字符串构造（内部 string->json 后委托 json->person）
-;; 对象支持 :to-json 方法，导出为 (liii json) 兼容的 alist
-
-(define (alist-get alist key)
-  (let ((pair (assoc key alist)))
-    (if pair (cdr pair) #f)
-  ) ;let
-) ;define
-
-(define* (make-person (name "?") (age 0))
-  (openlet (lambda (key)
-             (case key
-              ((:name) name)
-              ((:age) age)
-              ((:to-json) (list (cons "name" name) (cons "age" age)))
-             ) ;case
-           ) ;lambda
-  ) ;openlet
-) ;define*
-
-(define (json->person j)
-  (make-person :name (alist-get j "name") :age (alist-get j "age"))
-) ;define
-
-(define (string->person s)
-  (json->person (string->json s))
-) ;define
-
-
-;; make-person :name/:age 直接构造
-(check (let ((p (make-person :name "Bob" :age 25)))
-         (list (p :name) (p :age))
-       ) ;let
-  =>
-  '("Bob" 25)
-) ;check
-
-
-;; json->person 从 (liii json) 的 alist 构造对象
-(check (let ((p (json->person (string->json "{\"name\":\"Alice\",\"age\":30}"))))
-         (list (p :name) (p :age))
-       ) ;let
-  =>
-  '("Alice" 30)
-) ;check
-
-
-;; string->person 从 JSON 字符串构造对象
-(check (let ((p (string->person "{\"name\":\"Alice\",\"age\":30}")))
-         (list (p :name) (p :age))
-       ) ;let
-  =>
-  '("Alice" 30)
-) ;check
-
-
-;; :to-json 导出为字符串键 alist，可直接喂给 json->string
-(check (let ((p (make-person :name "Bob" :age 25)))
-         (p :to-json)
-       ) ;let
-  =>
-  '(("name" . "Bob") ("age" . 25))
-) ;check
-
-
-;; 完整往返：JSON 字符串 -> person -> JSON 字符串
-(check (let ((p (string->person "{\"name\":\"Alice\",\"age\":30}")))
-         (json->string (p :to-json))
-       ) ;let
-  =>
-  "{\"name\":\"Alice\",\"age\":30}"
-) ;check
 
 
 (check-report)

--- a/tests/liii/base/openlet-test.scm
+++ b/tests/liii/base/openlet-test.scm
@@ -47,6 +47,85 @@
 ;; 仅对"忽略参数类型"的内建函数（如 length、object->string、display、
 ;; copy 等）才会触发方法分派；带严格类型检查的函数（如 abs 要求参数
 ;; 为 number）不会查询 openlet 的方法。
+;;
+;; =========================================================================
+;; inlet 与 openlet 的区别（先读这段，再看下面的具体示例）
+;; =========================================================================
+;;
+;; 两者都能模拟面向对象，但机制不同：
+;;
+;;   inlet：对象就是环境（键值容器），(obj :key) 直接取绑定值。
+;;          天然支持继承（outlet 链），但内建函数不会特殊处理它。
+;;
+;;   openlet：给环境/闭包打标记，使内建函数（length、object->string 等）
+;;            遇到该对象时，查询其内部同名方法并调用（方法分派）。
+;;
+;; 关键差异：
+;; ┌─────────────────┬──────────────────────┬───────────────────────┐
+;; │ 维度            │ 纯 inlet              │ openlet 闭包          │
+;; ├─────────────────┼──────────────────────┼───────────────────────┤
+;; │ 对象本质        │ 环境（键值容器）      │ 闭包（lambda）        │
+;; │ (obj :key)      │ 直接取绑定值          │ case 手动分派         │
+;; │ 字段封装        │ 弱（绑定可见）        │ 强（闭包变量）        │
+;; │ 继承            │ outlet 链天然支持     │ 需手动委托            │
+;; │ 内建函数方法分派│ ✗ 不触发              │ ✓ 触发                │
+;; └─────────────────┴──────────────────────┴───────────────────────┘
+;;
+;; 最后一行是核心区别：openlet 让对象能"改写"内建函数对它的处理方式，
+;; inlet 做不到。下面先用计数器对象演示这个差异，再展开 openlet 的其他用法。
+
+
+;; ---- 计数器对象：同一逻辑的两种实现 ----------------------------
+;; 纯 inlet 版：(obj :key) 直接取绑定；length 不触发方法分派
+
+(define (make-counter-inlet)
+  (let ((count 0))
+    (inlet :get
+      (lambda (self) count)
+      :inc
+      (lambda (self) (set! count (+ count 1)) count)
+    ) ;inlet
+  ) ;let
+) ;define
+
+(define ci (make-counter-inlet))
+((ci :inc) ci)
+((ci :inc) ci)
+
+;; inlet 版计数器本身工作正常：((ci :get) ci) 能取到 count
+(check ((ci :get) ci) => 2)
+
+;; 纯 inlet 的局限：定义了 :length 方法，但 length 不理它，返回绑定数
+(check (length (inlet :length (lambda (self) 99) :get (lambda (self) 0))) => 2)
+
+;; openlet 版：同样的结构加 openlet 包装后，length 会查询 :length 方法
+
+(define (make-counter-openlet)
+  (let ((count 0))
+    (openlet (inlet :get
+               (lambda (self) count)
+               :inc
+               (lambda (self) (set! count (+ count 1)) count)
+               :length
+               (lambda (self) count)
+             ) ;inlet
+    ) ;openlet
+  ) ;let
+) ;define
+
+(define co (make-counter-openlet))
+((co :inc) co)
+((co :inc) co)
+
+;; openlet 触发方法分派：length 查询到 :length 方法，返回 count 值（也是 2）
+(check (length co) => 2)
+
+;; 同样返回 2，语义不同：inlet 是"碰巧有 2 个绑定"，openlet 是"count 等于 2"。
+
+
+;; =========================================================================
+;; 以下是 openlet 的基础用法与更多应用示例
+;; =========================================================================
 
 
 ;; openlet 返回传入的 let（eq? 为 #t）
@@ -246,86 +325,6 @@
   =>
   "{\"name\":\"Alice\",\"age\":30}"
 ) ;check
-
-
-;; =========================================================================
-;; inlet 与 openlet 的区别
-;; =========================================================================
-;;
-;; 两者都能模拟面向对象，但机制不同：
-;;
-;;   inlet：对象就是环境（键值容器），(obj :key) 直接取绑定值。
-;;          天然支持继承（outlet 链），但内建函数不会特殊处理它。
-;;
-;;   openlet：给环境/闭包打标记，使内建函数（length、object->string 等）
-;;            遇到该对象时，查询其内部同名方法并调用（方法分派）。
-;;
-;; 关键差异：
-;; ┌─────────────────┬──────────────────────┬───────────────────────┐
-;; │ 维度            │ 纯 inlet              │ openlet 闭包          │
-;; ├─────────────────┼──────────────────────┼───────────────────────┤
-;; │ 对象本质        │ 环境（键值容器）      │ 闭包（lambda）        │
-;; │ (obj :key)      │ 直接取绑定值          │ case 手动分派         │
-;; │ 字段封装        │ 弱（绑定可见）        │ 强（闭包变量）        │
-;; │ 继承            │ outlet 链天然支持     │ 需手动委托            │
-;; │ 内建函数方法分派│ ✗ 不触发              │ ✓ 触发                │
-;; └─────────────────┴──────────────────────┴───────────────────────┘
-;;
-;; 最后一行是核心区别：openlet 让对象能"改写"内建函数对它的处理方式，
-;; inlet 做不到。下面用计数器对象演示两种实现。
-
-
-;; ---- 纯 inlet 版计数器 -----------------------------------------
-;; 对象是 inlet，字段/方法都是绑定，方法签名 (lambda (self) ...)
-;; 状态 count 是闭包变量，多个实例状态独立
-
-(define (make-counter-inlet)
-  (let ((count 0))
-    (inlet :get
-      (lambda (self) count)
-      :inc
-      (lambda (self) (set! count (+ count 1)) count)
-    ) ;inlet
-  ) ;let
-) ;define
-
-(define ci (make-counter-inlet))
-
-;; 方法调用：((ci :inc) ci) —— 取出方法后传 self
-(check (begin ((ci :inc) ci) ((ci :inc) ci) ((ci :get) ci)) => 2)
-
-;; 纯 inlet 的局限：length 不认识它，不会调用 :length 方法
-;; 下面这个 inlet 定义了 :length，但 (length ci) 仍返回绑定数（2 个方法）
-(check (length (inlet :length (lambda (self) 99) :get (lambda (self) 0))) => 2)
-
-
-;; ---- openlet 版计数器 ------------------------------------------
-;; 同样的逻辑，但用 openlet 包装后，length 会查询 :length 方法
-
-(define (make-counter-openlet)
-  (let ((count 0))
-    (openlet (inlet :get
-               (lambda (self) count)
-               :inc
-               (lambda (self) (set! count (+ count 1)) count)
-               :length
-               (lambda (self) count)
-             ) ;inlet
-    ) ;openlet
-  ) ;let
-) ;define
-
-(define co (make-counter-openlet))
-((co :inc) co)
-((co :inc) co)
-
-;; openlet 触发方法分派：length 查询到 :length 方法，返回 count 值
-(check (length co) => 2)
-
-
-;; ---- 封装性对比 -------------------------------------------------
-;; inlet 的绑定对外可见：(ci :get) 直接返回方法 lambda
-;; openlet 闭包模式（见前面 make-person）：字段是闭包变量，外部无法直接访问
 
 
 (check-report)

--- a/tests/liii/base/openlet-test.scm
+++ b/tests/liii/base/openlet-test.scm
@@ -30,6 +30,22 @@
 ;; 会先查询该 let 是否定义了同名的方法，若有则调用之。
 ;; coverlet 可撤销 openlet 的效果。
 ;; openlet 就地修改并返回原 let。
+;;
+;; 示例
+;; ----
+;; ;; 让 length 内建函数在遇到 e 时调用 e 自己的 'length 方法
+;; (length (openlet (inlet 'length (lambda (x) 99))))
+;; ;; => 99
+;;
+;; ;; 让 object->string 查询 e 内的同名方法，自定义字符串表示
+;; (object->string (openlet (inlet 'object->string (lambda args "#<myobj>"))))
+;; ;; => "#<myobj>"
+;;
+;; 注意
+;; ----
+;; 仅对"忽略参数类型"的内建函数（如 length、object->string、display、
+;; copy 等）才会触发方法分派；带严格类型检查的函数（如 abs 要求参数
+;; 为 number）不会查询 openlet 的方法。
 
 
 ;; openlet 返回传入的 let（eq? 为 #t）
@@ -46,6 +62,111 @@
 
 ;; openlet 后内部绑定仍可访问
 (check (let-ref (openlet (inlet 'a 42)) 'a) => 42)
+
+
+;; 关键用法：openlet 让内建 length 查询到 let 内的同名方法并调用
+(check (length (openlet (inlet 'length (lambda (x) 99)))) => 99)
+
+
+;; openlet 让 object->string 查询同名方法，自定义字符串表示
+(check (object->string (openlet (inlet 'object->string (lambda args "#<myobj>"))))
+  =>
+  "#<myobj>"
+) ;check
+
+
+;; coverlet 可撤销 openlet 的方法分派效果：
+;; 撤销后 length 不再调用自定义方法，而返回 inlet 的实际绑定数量（1 个：'length）
+(check (length (coverlet (openlet (inlet 'length (lambda (x) 99))))) => 1)
+
+
+;; 应用示例：用 openlet 定义 person 对象
+;; 工厂函数 make-person 返回一个闭包，被 openlet 标记后：
+;; - 调用 (p :field) 时按 keyword 分派，返回字段值或业务结果
+;; - 字段 (name age) 被闭包捕获，外部无法直接访问，实现封装
+(define* (make-person (name "?") (age 0))
+  (openlet (lambda (key)
+             (case key
+              ((:name) name)
+              ((:age) age)
+              ((:greet) (format #f "Hi, I'm ~A, ~A years old." name age))
+              (else (error 'unknown-method "person: ~A" key))
+             ) ;case
+           ) ;lambda
+  ) ;openlet
+) ;define*
+
+
+;; (p :greet) 自动分发到业务方法
+(check (let ((p (make-person :name "Bob" :age 25)))
+         (p :greet)
+       ) ;let
+  =>
+  "Hi, I'm Bob, 25 years old."
+) ;check
+
+
+;; (p :name) / (p :age) 访问字段
+(check (let ((p (make-person :name "Alice" :age 30)))
+         (list (p :name) (p :age))
+       ) ;let
+  =>
+  '("Alice" 30)
+) ;check
+
+
+;; 默认参数：缺省时 name 为 "?"、age 为 0
+(check (let ((p (make-person))) (p :greet)) => "Hi, I'm ?, 0 years old.")
+
+
+;; 应用示例：用 openlet 定义 matrix 对象
+;; 工厂函数 make-matrix 返回一个被 openlet 标记的闭包：
+;; - (m i j) 或 (apply m '(i j)) 取出第 i 行第 j 列的元素
+;; - (m :rows) / (m :cols) 查询行列数
+;; 内部用 s7 多维 vector 存储，vector-ref 原生支持多维索引
+;;
+;; 注：此处用 subvector 从一维 vector 构造 2x3 矩阵以避开 #2d(...)
+;; 字面量（gf fmt 工具尚不支持该语法，会错误地将其重写为一维 vector）
+
+(define (make-matrix data)
+  (openlet (lambda args
+             (case (length args)
+                   ((1)
+                    (case (car args)
+                          ((:rows) (vector-dimension data 0))
+                          ((:cols) (vector-dimension data 1))
+                          (else (error 'unknown-method "matrix: ~A" (car args)))
+                    ) ;case
+                   ) ;
+                   ((2) (apply vector-ref data args))
+                   (else (error 'wrong-number-of-args "matrix expects 1 or 2 args, got ~A" (length args))
+                   ) ;else
+             ) ;case
+           ) ;lambda
+  ) ;openlet
+) ;define
+
+
+;; 构造 2x3 矩阵 [[1 2 3] [4 5 6]] 用于后续测试
+
+(define test-matrix (subvector #(1 2 3 4 5 6) 0 6 '(2 3)))
+
+
+;; (m i j) 直接取元素
+(check (let ((m (make-matrix test-matrix))) (m 1 2)) => 6)
+
+
+;; (apply m '(i j)) 也能取元素 —— 闭包原生支持 apply
+(check (let ((m (make-matrix test-matrix))) (apply m '(1 2))) => 6)
+
+
+;; (m :rows) / (m :cols) 查询维度
+(check (let ((m (make-matrix test-matrix)))
+         (list (m :rows) (m :cols))
+       ) ;let
+  =>
+  '(2 3)
+) ;check
 
 
 (check-report)

--- a/tests/liii/base/openlet-test.scm
+++ b/tests/liii/base/openlet-test.scm
@@ -81,11 +81,11 @@
 (check (length (coverlet (openlet (inlet 'length (lambda (x) 99))))) => 1)
 
 
-;; 应用示例：用 openlet 定义 person 对象
-;; 工厂函数 make-person 返回一个闭包，被 openlet 标记后：
+;; 应用示例：用 openlet 定义带业务方法的 person 对象
+;; 工厂函数 make-person-greet 返回一个闭包，被 openlet 标记后：
 ;; - 调用 (p :field) 时按 keyword 分派，返回字段值或业务结果
 ;; - 字段 (name age) 被闭包捕获，外部无法直接访问，实现封装
-(define* (make-person (name "?") (age 0))
+(define* (make-person-greet (name "?") (age 0))
   (openlet (lambda (key)
              (case key
               ((:name) name)
@@ -99,7 +99,7 @@
 
 
 ;; (p :greet) 自动分发到业务方法
-(check (let ((p (make-person :name "Bob" :age 25)))
+(check (let ((p (make-person-greet :name "Bob" :age 25)))
          (p :greet)
        ) ;let
   =>
@@ -108,7 +108,7 @@
 
 
 ;; (p :name) / (p :age) 访问字段
-(check (let ((p (make-person :name "Alice" :age 30)))
+(check (let ((p (make-person-greet :name "Alice" :age 30)))
          (list (p :name) (p :age))
        ) ;let
   =>
@@ -117,7 +117,7 @@
 
 
 ;; 默认参数：缺省时 name 为 "?"、age 为 0
-(check (let ((p (make-person))) (p :greet)) => "Hi, I'm ?, 0 years old.")
+(check (let ((p (make-person-greet))) (p :greet)) => "Hi, I'm ?, 0 years old.")
 
 
 ;; 应用示例：用 openlet 定义 matrix 对象
@@ -172,7 +172,7 @@
 
 ;; 应用示例：用 openlet 模拟 data class（带 JSON 序列化）
 ;; 提供三层 API：
-;; - make-person-dc :name/:age 直接构造对象
+;; - make-person :name/:age 直接构造对象
 ;; - json->person  从 (liii json) 的 alist 构造
 ;; - string->person 从 JSON 字符串构造（内部 string->json 后委托 json->person）
 ;; 对象支持 :to-json 方法，导出为 (liii json) 兼容的 alist
@@ -183,7 +183,7 @@
   ) ;let
 ) ;define
 
-(define* (make-person-dc (name "?") (age 0))
+(define* (make-person (name "?") (age 0))
   (openlet (lambda (key)
              (case key
               ((:name) name)
@@ -195,7 +195,7 @@
 ) ;define*
 
 (define (json->person j)
-  (make-person-dc :name (alist-get j "name") :age (alist-get j "age"))
+  (make-person :name (alist-get j "name") :age (alist-get j "age"))
 ) ;define
 
 (define (string->person s)
@@ -203,8 +203,8 @@
 ) ;define
 
 
-;; make-person-dc :name/:age 直接构造
-(check (let ((p (make-person-dc :name "Bob" :age 25)))
+;; make-person :name/:age 直接构造
+(check (let ((p (make-person :name "Bob" :age 25)))
          (list (p :name) (p :age))
        ) ;let
   =>
@@ -231,7 +231,7 @@
 
 
 ;; :to-json 导出为字符串键 alist，可直接喂给 json->string
-(check (let ((p (make-person-dc :name "Bob" :age 25)))
+(check (let ((p (make-person :name "Bob" :age 25)))
          (p :to-json)
        ) ;let
   =>

--- a/tests/liii/base/outlet-test.scm
+++ b/tests/liii/base/outlet-test.scm
@@ -1,0 +1,57 @@
+(import (liii check))
+(import (liii base))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; outlet
+;; 返回给定 let 的外层（父）环境。
+;;
+;; 语法
+;; ----
+;; (outlet let)
+;;
+;; 参数
+;; ----
+;; let : let?
+;; 要查询外层环境的 let。
+;;
+;; 返回值
+;; ------
+;; let?
+;; 该 let 的外层环境。rootlet 的 outlet 是 rootlet 自身。
+;;
+;; 说明
+;; ----
+;; outlet 用于遍历环境的父链。
+;; 通过 sublet 等构造的环境，其 outlet 指向父环境。
+;; rootlet 是环境的根，其 outlet 指向自身。
+
+
+;; rootlet 的 outlet 是 rootlet 自身
+(check (eq? (outlet (rootlet)) (rootlet)) => #t)
+
+
+;; curlet 的 outlet 是一个 let
+(check (let? (outlet (curlet))) => #t)
+
+
+;; inlet 创建的独立环境，其 outlet 是 rootlet
+(check (eq? (outlet (inlet 'a 1)) (rootlet)) => #t)
+
+
+;; sublet 创建的环境，其 outlet 指向父 let
+(check (let ((parent (inlet 'a 1)))
+         (eq? (outlet (sublet parent 'b 2)) parent)
+       ) ;let
+  =>
+  #t
+) ;check
+
+
+;; outlet 链最终到达 rootlet
+(check (eq? (outlet (outlet (sublet (inlet 'a 1) 'b 2))) (rootlet)) => #t)
+
+
+(check-report)

--- a/tests/liii/base/owlet-test.scm
+++ b/tests/liii/base/owlet-test.scm
@@ -1,0 +1,44 @@
+(import (liii check))
+(import (liii base))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; owlet
+;; 返回当前的 outward let（模块环境）。
+;; owlet 反映当前正在求值的模块/库的环境。
+;;
+;; 语法
+;; ----
+;; (owlet)
+;;
+;; 参数
+;; ----
+;; 无参数。
+;;
+;; 返回值
+;; ------
+;; let?
+;; 当前的 outward（模块）环境。
+;;
+;; 说明
+;; ----
+;; owlet 与 curlet 不同：curlet 是最内层的词法环境，
+;; owlet 是当前所在的模块/库层环境。
+;; owlet 通常包含一些错误处理相关的元信息绑定。
+
+
+;; owlet 是一个 let
+(check (let? (owlet)) => #t)
+
+
+;; owlet 中包含 error-position 等错误元信息绑定
+(check (integer? (let-ref (owlet) 'error-position)) => #t)
+
+
+;; owlet 包含 error-file 绑定（布尔或字符串）
+(check (boolean? (let-ref (owlet) 'error-file)) => #t)
+
+
+(check-report)

--- a/tests/liii/base/rootlet-test.scm
+++ b/tests/liii/base/rootlet-test.scm
@@ -1,0 +1,50 @@
+(import (liii check))
+(import (liii base))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; rootlet
+;; 返回全局根环境（rootlet）。所有内建函数和全局绑定都位于此处。
+;;
+;; 语法
+;; ----
+;; (rootlet)
+;;
+;; 参数
+;; ----
+;; 无参数。
+;;
+;; 返回值
+;; ------
+;; let?
+;; 全局根环境。
+;;
+;; 说明
+;; ----
+;; rootlet 是所有环境的根。多次调用 rootlet 返回同一对象。
+;; 所有内建函数（如 +、car）都能在 rootlet 中通过 symbol->value 找到。
+
+
+;; rootlet 是一个 let
+(check (let? (rootlet)) => #t)
+
+
+;; 多次调用 rootlet 返回同一对象
+(check (eq? (rootlet) (rootlet)) => #t)
+
+
+;; rootlet 中包含内建符号 +
+(check (symbol->value '+ (rootlet)) => +)
+
+
+;; rootlet 中包含内建符号 car
+(check (symbol->value 'car (rootlet)) => car)
+
+
+;; rootlet 的 outlet 是 rootlet 自身
+(check (eq? (outlet (rootlet)) (rootlet)) => #t)
+
+
+(check-report)

--- a/tests/liii/base/sublet-test.scm
+++ b/tests/liii/base/sublet-test.scm
@@ -65,4 +65,81 @@
 (check (let? (sublet (inlet))) => #t)
 
 
+;; 应用示例：用 sublet + outlet 模拟继承
+;; 设计要点：
+;; - 类环境（inlet）作为方法载体，方法以符号为键，签名为 (lambda (self) ...)
+;; - 子类用 (sublet 父类 (inlet ...)) 继承，覆盖的方法就近定义
+;; - 实例用 (sublet 类 (inlet 字段...)) 构造，outlet 指向类环境
+;; - 方法调用：((let-ref 实例 '方法名) 实例) —— let-ref 沿 outlet 链查找
+;; - is-a 检查：遍历 outlet 链（到 rootlet 终止）判断实例是否属于某类
+
+;; 基类 Animal
+
+(define animal-class (inlet 'speak (lambda (self) "some sound")))
+
+;; Dog 继承 Animal，覆盖 speak
+
+(define dog-class (sublet animal-class (inlet 'speak (lambda (self) "woof"))))
+
+;; Cat 继承 Animal，覆盖 speak
+
+(define cat-class (sublet animal-class (inlet 'speak (lambda (self) "meow"))))
+
+;; is-a 检查：遍历 outlet 链找目标类
+
+(define (subclass-of? instance-let target-class)
+  (let loop
+    ((e instance-let))
+    (cond ((eq? e (rootlet)) #f)
+          ((not (let? e)) #f)
+          ((eq? e target-class) #t)
+          (else (loop (outlet e)))
+    ) ;cond
+  ) ;let
+) ;define
+
+;; 实例工厂
+
+(define (make-animal name)
+  (sublet animal-class (inlet 'name name))
+) ;define
+
+(define (make-dog name)
+  (sublet dog-class (inlet 'name name))
+) ;define
+
+(define (make-cat name)
+  (sublet cat-class (inlet 'name name))
+) ;define
+
+
+;; 方法覆盖：Dog.speak 返回 "woof"
+(check (let ((d (make-dog "Rex"))) ((let-ref d 'speak) d)) => "woof")
+
+
+;; 方法覆盖：Cat.speak 返回 "meow"
+(check (let ((c (make-cat "Whiskers"))) ((let-ref c 'speak) c)) => "meow")
+
+
+;; 未覆盖的方法继承自基类：Animal.speak 返回 "some sound"
+(check (let ((a (make-animal "generic")))
+         ((let-ref a 'speak) a)
+       ) ;let
+  =>
+  "some sound"
+) ;check
+
+
+;; is-a 检查：Dog 实例既是 dog 也是 animal
+(check (let ((d (make-dog "Rex")))
+         (list (subclass-of? d dog-class)
+           (subclass-of? d animal-class)
+           (subclass-of? d cat-class)
+         ) ;list
+       ) ;let
+  =>
+  '(#t #t #f)
+) ;check
+
+
 (check-report)

--- a/tests/liii/base/sublet-test.scm
+++ b/tests/liii/base/sublet-test.scm
@@ -1,0 +1,68 @@
+(import (liii check))
+(import (liii base))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; sublet
+;; 在已有 let 的环境内创建一个新的子 let，并初始化若干绑定。
+;;
+;; 语法
+;; ----
+;; (sublet parent-let)
+;; (sublet parent-let symbol value ...)
+;;
+;; 参数
+;; ----
+;; parent-let : let?
+;; 父环境（新 let 的 outlet 指向它）。
+;;
+;; symbol : symbol?
+;; 绑定名。
+;;
+;; value : any
+;; 绑定值。
+;;
+;; 返回值
+;; ------
+;; let?
+;; 新创建的子 let。
+;;
+;; 说明
+;; ----
+;; sublet 创建的新 let 本身只包含新加入的绑定，
+;; 但其 outlet 指向 parent-let，因此可通过环境链访问父绑定。
+;; 这与 varlet 不同：varlet 把绑定直接合并进 target-let。
+
+
+;; sublet 返回一个 let
+(check (let? (sublet (inlet 'a 1))) => #t)
+
+
+;; sublet 新 let 包含新加入的绑定
+(check (let-ref (sublet (inlet 'a 1) 'b 2) 'b) => 2)
+
+
+;; sublet 新 let 的 outlet 指向父 let
+(check (let ((parent (inlet 'a 1)))
+         (eq? (outlet (sublet parent 'b 2)) parent)
+       ) ;let
+  =>
+  #t
+) ;check
+
+
+;; sublet 新 let 本身不包含父绑定（let->list 只显示直接绑定）
+(check (let->list (sublet (inlet 'a 1) 'b 2)) => (list (cons 'b 2)))
+
+
+;; sublet 新 let 长度只反映直接绑定数
+(check (length (sublet (inlet 'a 1) 'b 2)) => 1)
+
+
+;; 空 sublet 也返回 let
+(check (let? (sublet (inlet))) => #t)
+
+
+(check-report)

--- a/tests/liii/base/sublet-test.scm
+++ b/tests/liii/base/sublet-test.scm
@@ -67,23 +67,24 @@
 
 ;; 应用示例：用 sublet + outlet 模拟继承
 ;; 设计要点：
-;; - 类环境（inlet）作为方法载体，方法以符号为键，签名为 (lambda (self) ...)
+;; - 类环境（inlet）作为方法载体，方法和字段都以 keyword 为键
+;; - 方法签名 (lambda (self) ...)，调用时显式传 self
 ;; - 子类用 (sublet 父类 (inlet ...)) 继承，覆盖的方法就近定义
 ;; - 实例用 (sublet 类 (inlet 字段...)) 构造，outlet 指向类环境
-;; - 方法调用：((let-ref 实例 '方法名) 实例) —— let-ref 沿 outlet 链查找
+;; - 方法调用：((实例 :方法名) 实例) —— inlet 可调用，keyword 取方法后传 self
 ;; - is-a 检查：遍历 outlet 链（到 rootlet 终止）判断实例是否属于某类
 
 ;; 基类 Animal
 
-(define animal-class (inlet 'speak (lambda (self) "some sound")))
+(define animal-class (inlet :speak (lambda (self) "some sound")))
 
 ;; Dog 继承 Animal，覆盖 speak
 
-(define dog-class (sublet animal-class (inlet 'speak (lambda (self) "woof"))))
+(define dog-class (sublet animal-class (inlet :speak (lambda (self) "woof"))))
 
 ;; Cat 继承 Animal，覆盖 speak
 
-(define cat-class (sublet animal-class (inlet 'speak (lambda (self) "meow"))))
+(define cat-class (sublet animal-class (inlet :speak (lambda (self) "meow"))))
 
 ;; is-a 检查：遍历 outlet 链找目标类
 
@@ -101,33 +102,32 @@
 ;; 实例工厂
 
 (define (make-animal name)
-  (sublet animal-class (inlet 'name name))
+  (sublet animal-class (inlet :name name))
 ) ;define
 
 (define (make-dog name)
-  (sublet dog-class (inlet 'name name))
+  (sublet dog-class (inlet :name name))
 ) ;define
 
 (define (make-cat name)
-  (sublet cat-class (inlet 'name name))
+  (sublet cat-class (inlet :name name))
 ) ;define
 
 
 ;; 方法覆盖：Dog.speak 返回 "woof"
-(check (let ((d (make-dog "Rex"))) ((let-ref d 'speak) d)) => "woof")
+(check (let ((d (make-dog "Rex"))) ((d :speak) d)) => "woof")
 
 
 ;; 方法覆盖：Cat.speak 返回 "meow"
-(check (let ((c (make-cat "Whiskers"))) ((let-ref c 'speak) c)) => "meow")
+(check (let ((c (make-cat "Whiskers"))) ((c :speak) c)) => "meow")
 
 
 ;; 未覆盖的方法继承自基类：Animal.speak 返回 "some sound"
-(check (let ((a (make-animal "generic")))
-         ((let-ref a 'speak) a)
-       ) ;let
-  =>
-  "some sound"
-) ;check
+(check (let ((a (make-animal "generic"))) ((a :speak) a)) => "some sound")
+
+
+;; 字段访问也用 keyword
+(check (let ((d (make-dog "Rex"))) (d :name)) => "Rex")
 
 
 ;; is-a 检查：Dog 实例既是 dog 也是 animal

--- a/tests/liii/base/symbol-to-dynamic-value-test.scm
+++ b/tests/liii/base/symbol-to-dynamic-value-test.scm
@@ -1,0 +1,49 @@
+(import (liii check))
+(import (liii base))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; symbol->dynamic-value
+;; 返回符号的动态绑定值。
+;;
+;; 语法
+;; ----
+;; (symbol->dynamic-value sym)
+;;
+;; 参数
+;; ----
+;; sym : symbol?
+;; 要查询的符号。
+;;
+;; 返回值
+;; ------
+;; any
+;; 该符号的动态绑定值。
+;;
+;; 说明
+;; ----
+;; symbol->dynamic-value 返回符号的动态绑定。
+;; 动态绑定与词法绑定 (symbol->value) 不同：
+;; 动态绑定反映符号在调用栈中的动态环境。
+;; 若符号无动态绑定，返回 #<undefined>。
+
+
+;; 未绑定的符号返回 #<undefined>
+(check (undefined? (symbol->dynamic-value 'nonexistent-xyz)) => #t)
+
+
+;; symbol->dynamic-value 接受符号参数，返回某个值
+(check (symbol? 'x) => #t)
+
+
+;; 对内建符号，dynamic-value 与 value 一致
+(check (eq? (symbol->dynamic-value '+) (symbol->value '+)) => #t)
+
+
+;; 在当前环境中，局部变量的 dynamic-value
+(check (let ((x 42)) (symbol->dynamic-value 'x)) => 42)
+
+
+(check-report)

--- a/tests/liii/base/symbol-to-value-test.scm
+++ b/tests/liii/base/symbol-to-value-test.scm
@@ -1,0 +1,61 @@
+(import (liii check))
+(import (liii base))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; symbol->value
+;; 返回符号在指定环境（默认 curlet）中的绑定值。
+;;
+;; 语法
+;; ----
+;; (symbol->value sym)
+;; (symbol->value sym let)
+;;
+;; 参数
+;; ----
+;; sym : symbol?
+;; 要查询的符号。
+;;
+;; let : let? 可选，默认为 (curlet)
+;; 查询的环境。
+;;
+;; 返回值
+;; ------
+;; any
+;; 该符号在给定环境中的绑定值。
+;;
+;; 说明
+;; ----
+;; symbol->value 返回符号的绑定值。
+;; 单参数形式在当前环境 (curlet) 中查找。
+;; 双参数形式在指定 let 中查找。
+;; 若符号未绑定，返回 #<undefined>。
+
+
+;; 内建符号 + 的值
+(check (symbol->value '+) => +)
+
+
+;; 内建符号 car 的值
+(check (symbol->value 'car) => car)
+
+
+;; 在指定 let 中查找符号
+(check (symbol->value 'a (inlet 'a 99)) => 99)
+
+
+;; 在当前环境中查找局部变量
+(check (let ((x 42)) (symbol->value 'x)) => 42)
+
+
+;; 未绑定的符号返回 #<undefined>
+(check (undefined? (symbol->value 'nonexistent-xyz)) => #t)
+
+
+;; 在指定 let 中查找字符串绑定
+(check (symbol->value 'name (inlet 'name "hello")) => "hello")
+
+
+(check-report)

--- a/tests/liii/base/unlet-test.scm
+++ b/tests/liii/base/unlet-test.scm
@@ -1,0 +1,50 @@
+(import (liii check))
+(import (liii base))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; unlet
+;; 返回一个 let，该 let 反映所有预定义（内建）函数的原始绑定。
+;;
+;; 语法
+;; ----
+;; (unlet)
+;;
+;; 参数
+;; ----
+;; 无参数。
+;;
+;; 返回值
+;; ------
+;; let?
+;; 包含所有内建函数原始绑定的 let。
+;;
+;; 说明
+;; ----
+;; unlet 返回的 let 用于访问被遮蔽的内建函数的原始版本。
+;; 典型用法是 (with-let (unlet) ...)：
+;; 在该 with-let 内部，即使某个内建函数已被全局 set! 遮蔽，
+;; 也能访问到其原始定义。
+
+
+;; unlet 返回一个 let
+(check (let? (unlet)) => #t)
+
+
+;; unlet 的 let 中包含内建函数 + 的原始绑定
+(check (symbol->value '+ (unlet)) => +)
+
+
+;; 在遮蔽内建函数后，通过 with-let (unlet) 可访问原始版本
+(check (let ()
+         (set! map (lambda args 'shadowed))
+         (with-let (unlet) (map (lambda (x) (* x 10)) (list 1 2 3)))
+       ) ;let
+  =>
+  (list 10 20 30)
+) ;check
+
+
+(check-report)

--- a/tests/liii/base/varlet-test.scm
+++ b/tests/liii/base/varlet-test.scm
@@ -1,0 +1,69 @@
+(import (liii check))
+(import (liii base))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; varlet
+;; 将若干绑定添加到 target-let，并返回 target-let 自身。
+;;
+;; 语法
+;; ----
+;; (varlet target-let symbol value)
+;; (varlet target-let (symbol . value))
+;; (varlet target-let other-let)
+;;
+;; 参数
+;; ----
+;; target-let : let?
+;; 要添加绑定的目标 let。
+;;
+;; symbol : symbol?
+;; 绑定名。
+;;
+;; value : any
+;; 绑定值。
+;;
+;; other-let : let?
+;; 另一个 let，其所有绑定会被合并到 target-let。
+;;
+;; 返回值
+;; ------
+;; let?
+;; 返回 target-let（已被就地修改）。
+;;
+;; 说明
+;; ----
+;; varlet 就地修改 target-let：把新绑定直接合并进去，
+;; 返回的就是 target-let 本身（eq? 为 #t）。
+;; 这与 sublet 不同：sublet 创建新 let，不改父。
+
+
+;; varlet 把绑定添加到 target-let，并返回同一对象
+(check (let ((e (inlet 'a 1))) (eq? (varlet e 'b 2) e)) => #t)
+
+
+;; varlet 添加的绑定可通过 let-ref 访问
+(check (let ((e (inlet 'a 1))) (varlet e 'b 99) (let-ref e 'b)) => 99)
+
+
+;; varlet 保留原有绑定
+(check (let ((e (inlet 'a 1))) (varlet e 'b 2) (let-ref e 'a)) => 1)
+
+
+;; varlet 合并另一个 let 的所有绑定
+(check (let ((target (inlet 'a 1)) (source (inlet 'b 2 'c 3)))
+         (varlet target source)
+         (length target)
+       ) ;let
+  =>
+  3
+) ;check
+
+
+;; varlet 接受点对形式 (symbol . value)
+(check (let ((e (inlet))) (varlet e (cons 'x 99)) (let-ref e 'x)) => 99)
+
+
+(check-report)


### PR DESCRIPTION
## Summary
- 在 `(liii base)` 正式 export 20 个 let 相关函数，使其成为公开 API 并可被 `gf doc` 索引
  - 谓词：`let?` `openlet?` `funclet?`
  - 环境获取：`curlet` `outlet` `rootlet` `owlet` `funclet`
  - 环境构造/操作：`inlet` `sublet` `varlet` `cutlet` `openlet` `coverlet` `unlet`
  - 绑定访问：`let-ref` `let-set!` `let->list`
  - 符号查找：`symbol->value` `symbol->dynamic-value`
- 为这 20 个函数各写一个文档化测试（`tests/liii/base/*-test.scm`，文件名遵循 `gf doc` 的特殊字符映射规则），共 111 个 check
- 新增 `devel/0092.md` 记录任务背景与后续 C 拆分计划

## Why
这些函数此前通过 `(scheme base)` 在 `(liii base)` 中可见，但未正式 export，`gf doc` 无法识别为 `(liii base)` 的公开 API。正式 export 后 `gf doc funclet` 等命令才能工作，函数也才成为稳定公开接口。

## Test plan
- [x] `bin/gf doc --build-json` 重建索引
- [x] `bin/gf doc funclet` / `bin/gf doc let-set!` / `bin/gf doc symbol->value` 均正确显示 `(liii base)` 下的文档
- [x] 20 个新测试文件全部通过（111 check）
- [x] `bin/gf test --all` 共 1492 项全部通过，无回归

## 后续
拆分 `src/s7.c` 出 `s7_scheme_let.c` 作为下一个子任务（详见 `devel/0092.md`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)