### PR TITLE
[0092] 从 s7.c 拆出 s7_scheme_let.c / s7_scheme_let.h

### DIFF
--- a/devel/0092.md
+++ b/devel/0092.md
@@ -1,9 +1,10 @@
 # [0092] 拆分 s7_scheme_let.c 并在 (liii base) 导出 let 相关函数
 
 ## 任务相关的代码文件
-- src/s7.c （后续子任务：拆出 s7_scheme_let.c）
-- src/s7_scheme_let.c （后续子任务：新增）
-- src/s7_scheme_let.h （后续子任务：新增）
+- src/s7.c （已修改：迁出 let 相关函数，约 34+5 个函数去 static）
+- src/s7_scheme_let.c （已新增）
+- src/s7_scheme_let.h （已新增）
+- src/s7_internal.h （已修改：追加迁移所需的宏/枚举/声明）
 - goldfish/liii/base.scm （已修改：新增 20 个 let 相关函数的 export）
 - tests/liii/base/*-test.scm （已新增 20 个测试文件）
 - devel/0092.md
@@ -26,6 +27,46 @@ done
 # 完整测试套件
 bin/gf test --all
 ```
+
+## 2026-07-30 第二个子任务：从 s7.c 拆出 s7_scheme_let.c / s7_scheme_let.h
+
+### What
+1. 新增 `src/s7_scheme_let.c`（约 1350 行）与 `src/s7_scheme_let.h`（44 个函数声明），
+   从 `src/s7.c` 迁出 63 个代码区段：`g_unlet` 到 `g_is_defined` 的密集块，
+   外加 `g_funclet` 与 `g_owlet`，涵盖 unlet / openlet / coverlet / varlet /
+   cutlet / sublet / inlet / let->list / let-ref / let-set! / rootlet / curlet /
+   outlet / symbol->value / symbol->dynamic-value / defined? / funclet / owlet
+   及其私有辅助函数。`s7.c` 从 88327 行缩减到 87161 行。
+2. `src/s7_internal.h` 追加约 260 行：迁移代码所需的宏（含 S7_DEBUGGING /
+   WITH_GCC / REPORT_ROOTLET_REDEF 多分支变体）、`starlet_t` 枚举、
+   外部全局变量与函数声明。
+3. `s7.c` 中约 34 个 static 函数去 `static`（其中
+   `add_slot_at_end`/`add_slot_checked_with_id`/`add_slot_unchecked`/
+   `checked_slot_set_value`/`is_constant_symbol` 用 `extern inline` 保持内联），
+   另去 `static` 5 个仅 S7_DEBUGGING 下编译的调试函数
+   （`check_let_set_slots`/`set_opt2_1`/`set_opt3_1`/`gc_protect_2`/`unstack_1`）。
+4. `xmake.lua` 注册 `src/s7_scheme_let.c`；release 与 debug（-DS7_DEBUGGING）
+   两种模式均编译链接通过；`bin/gf test --all` 1492 项全部通过，
+   20 个 let 测试文件单独运行也全部通过。
+
+### Why
+`s7.c` 是 88k 行的单体文件，按既定路线（0074 起陆续拆出 symbol/inexact/
+continuation 等模块）继续拆分，let 相关函数是文档中规划好的下一块。
+
+### How
+- **边界判定靠引用计数**：用脚本统计每个候选函数被 s7.c 其余部分引用的次数，
+  求值热路径函数（lookup、position_of、is_proper_quote、starlet 等，被引用
+  数十到数百次）留在 s7.c，只迁出 20 个公开 let API 及其私有辅助。
+- **`extern inline` 模式**：热函数在 s7.c 保留 `extern inline` 定义、
+  在 s7_internal.h 放 `extern inline` 声明，TU 内仍内联、TU 间有外部符号。
+- **H_/Q_ 宏留在 s7.c**：文档/签名宏虽定义在函数体内但作用于文件，
+  s7.c 尾部的 defun 注册点仍在使用，迁移时只加注释标明函数已迁出。
+- **`symbol_set_id` 的双形态**：release 下是宏、debug 下是函数，头文件需
+  用 `#if S7_DEBUGGING` 镜像该结构，否则 release 链接报 undefined reference。
+- **`make_integer`/`make_real` 例外**：s7.c 的快路径宏依赖 static 的
+  `small_ints` 数组，s7_scheme_let.c 中直接
+  `#define make_integer(Sc, N) s7_make_integer(Sc, N)`（函数内部有同样的
+  小整数快路径），避免把 small_ints 暴露出去。
 
 ## 2026-07-29 第一个子任务：在 (liii base) 导出 20 个 let 相关函数并补齐文档与测试
 
@@ -66,10 +107,7 @@ bin/gf test --all
     `(with-let (unlet) ...)` 以访问被遮蔽的原始版本
 
 ## 后续子任务（待做）
-- 从 `src/s7.c` 拆出 `s7_scheme_let.c` / `s7_scheme_let.h`
-- 拆分边界：`g_unlet`（9606）到 `g_is_defined`（11471）的密集块，
-  外加 `g_funclet`（34666）和 `g_owlet`（40690）
-- 关键约束：`g_simple_inlet` / `g_sublet_curlet` / `g_cdr_let_ref` /
-  `g_rootlet_ref` / `g_unlet_ref` / `g_cdr_let_set` / `g_unlet_set` /
-  `g_starlet_set` 被 s7.c 内部通过 `fn_proc() ==` 比较 和 `sc->xxx` 缓存
-  槽位引用，外迁时需去 `static` 通过头文件暴露符号
+- （暂无；拆分已完成。遗留约束备查：`g_simple_inlet` / `g_sublet_curlet` /
+  `g_cdr_let_ref` / `g_rootlet_ref` / `g_unlet_ref` / `g_cdr_let_set` /
+  `g_unlet_set` / `g_starlet_set` 被 s7.c 内部通过 `fn_proc() ==` 比较和
+  `sc->xxx` 缓存槽位引用，已通过 s7_scheme_let.h 暴露符号）

--- a/src/s7.c
+++ b/src/s7.c
@@ -175,8 +175,6 @@
 /* ---------------- scheme choices ---------------- */
 
 
-
-
 #ifndef WITH_PURE_S7
   #define WITH_PURE_S7 0
 #endif
@@ -413,6 +411,7 @@
 #include "s7_liii_vector.h"
 #include "s7_module.h"
 #include "s7_dtoa.h"
+#include "s7_scheme_let.h"
 #include "s7_op_names.h"
 #include "s7_ctables.h"
 
@@ -797,7 +796,6 @@ struct opt_info {
 };
 
 #define q_temp(o) o->v[num_vunions - 1]
-
 
 
 typedef intptr_t opcode_t;
@@ -3753,7 +3751,6 @@ void begin_temp_1(s7_scheme *sc, s7_pointer p, s7_pointer val, const char *func,
 #endif
 
 
-
 #if S7_DEBUGGING
 const char *display(s7_pointer obj);
 const char *display(s7_pointer obj)
@@ -4127,7 +4124,7 @@ static char *pos_int_to_str_direct_1(s7_scheme *sc, s7_int num)
   #define lookup_unexamined(Sc, Sym) s7_symbol_value(Sc, Sym)  /* changed 3-Nov-22 -- we're using lookup_unexamined below to avoid the unbound_variable check */
   #define lookup_checked(Sc, Sym) lookup(Sc, Sym)
 #endif
-static s7_pointer symbol_to_local_slot(s7_scheme *sc, s7_pointer symbol, s7_pointer let);
+s7_pointer symbol_to_local_slot(s7_scheme *sc, s7_pointer symbol, s7_pointer let);
 
 
 /* ---------------- evaluator ops ---------------- */
@@ -4944,7 +4941,7 @@ static s7_pointer check_ref_one(s7_pointer p, uint8_t expected_type, const char 
   return(p);
 }
 
-static void check_let_set_slots(s7_scheme *sc, s7_pointer let, s7_pointer slot, const char *func, int32_t line)
+void check_let_set_slots(s7_scheme *sc, s7_pointer let, s7_pointer slot, const char *func, int32_t line)
 {
   if ((!in_heap(let)) && (slot) && (in_heap(slot))) fprintf(stderr, "%s[%d]: let+slot mismatch\n", func, line);
   if ((let == sc->rootlet) && (slot != slot_end))
@@ -5429,7 +5426,7 @@ static void base_opt2(s7_pointer p, s7_uint role)
   set_opt2_is_set(p);
 }
 
-static void set_opt2_1(s7_scheme *sc, s7_pointer p, s7_pointer x, s7_uint role, const char *func, int32_t line)
+void set_opt2_1(s7_scheme *sc, s7_pointer p, s7_pointer x, s7_uint role, const char *func, int32_t line)
 {
   if ((role == OPT2_FX) &&
       (x == NULL) &&
@@ -5516,7 +5513,7 @@ static void base_opt3(s7_pointer p, s7_uint role)
   set_opt3_is_set(p);
 }
 
-static void set_opt3_1(s7_pointer p, s7_pointer x, s7_uint role)
+void set_opt3_1(s7_pointer p, s7_pointer x, s7_uint role)
 {
   clear_type_bit(p, T_LOCATION);
   p->object.cons.o3.opt3 = x;
@@ -5724,7 +5721,7 @@ s7_pointer set_elist_2(s7_scheme *sc, s7_pointer x1, s7_pointer x2)
   return(sc->elist_2);
 }
 
-static s7_pointer set_elist_3(s7_scheme *sc, s7_pointer x1, s7_pointer x2, s7_pointer x3)
+s7_pointer set_elist_3(s7_scheme *sc, s7_pointer x1, s7_pointer x2, s7_pointer x3)
 {
   s7_pointer p = sc->elist_3;
   set_car(p, x1); p = cdr(p);
@@ -5733,7 +5730,7 @@ static s7_pointer set_elist_3(s7_scheme *sc, s7_pointer x1, s7_pointer x2, s7_po
   return(sc->elist_3);
 }
 
-static s7_pointer set_elist_4(s7_scheme *sc, s7_pointer x1, s7_pointer x2, s7_pointer x3, s7_pointer x4)
+s7_pointer set_elist_4(s7_scheme *sc, s7_pointer x1, s7_pointer x2, s7_pointer x3, s7_pointer x4)
 {
   s7_pointer p = sc->elist_4;
   set_car(p, x1); p = cdr(p);
@@ -5743,7 +5740,7 @@ static s7_pointer set_elist_4(s7_scheme *sc, s7_pointer x1, s7_pointer x2, s7_po
   return(sc->elist_4);
 }
 
-static s7_pointer set_elist_5(s7_scheme *sc, s7_pointer x1, s7_pointer x2, s7_pointer x3, s7_pointer x4, s7_pointer x5)
+s7_pointer set_elist_5(s7_scheme *sc, s7_pointer x1, s7_pointer x2, s7_pointer x3, s7_pointer x4, s7_pointer x5)
 {
   set_car(sc->elist_5, x1);
   set_elist_4(sc, x2, x3, x4, x5);
@@ -5783,13 +5780,13 @@ static s7_pointer set_wlist_4(s7_pointer lst, s7_pointer x1, s7_pointer x2, s7_p
   return(lst);
 }
 
-static s7_pointer set_mlist_1(s7_scheme *sc, s7_pointer x1)
+s7_pointer set_mlist_1(s7_scheme *sc, s7_pointer x1)
 {
   set_car(sc->mlist_1, x1);
   return(sc->mlist_1);
 }
 
-static s7_pointer set_mlist_2(s7_scheme *sc, s7_pointer x1, s7_pointer x2) /* mlist_3 saves 3 in tmock -- see ~/old/s7-mlist_3.c */
+s7_pointer set_mlist_2(s7_scheme *sc, s7_pointer x1, s7_pointer x2) /* mlist_3 saves 3 in tmock -- see ~/old/s7-mlist_3.c */
 {
   set_car(sc->mlist_2, x1);
   set_cadr(sc->mlist_2, x2);
@@ -5802,14 +5799,14 @@ s7_pointer set_plist_1(s7_scheme *sc, s7_pointer x1)
   return(sc->plist_1);
 }
 
-static s7_pointer set_plist_2(s7_scheme *sc, s7_pointer x1, s7_pointer x2)
+s7_pointer set_plist_2(s7_scheme *sc, s7_pointer x1, s7_pointer x2)
 {
   set_car(sc->plist_2, x1);
   set_car(sc->plist_2_2, x2);
   return(sc->plist_2);
 }
 
-static s7_pointer set_plist_3(s7_scheme *sc, s7_pointer x1, s7_pointer x2, s7_pointer x3)
+s7_pointer set_plist_3(s7_scheme *sc, s7_pointer x1, s7_pointer x2, s7_pointer x3)
 {
   return(set_wlist_3(sc->plist_3, x1, x2, x3));
 }
@@ -5819,14 +5816,14 @@ static s7_pointer set_plist_4(s7_scheme *sc, s7_pointer x1, s7_pointer x2, s7_po
   return(set_wlist_4(sc->plist_4, x1, x2, x3, x4));
 }
 
-static s7_pointer set_qlist_2(s7_scheme *sc, s7_pointer x1, s7_pointer x2) /* let_ref_fallback */
+s7_pointer set_qlist_2(s7_scheme *sc, s7_pointer x1, s7_pointer x2) /* let_ref_fallback */
 {
   set_car(sc->qlist_2, x1);
   set_cadr(sc->qlist_2, x2);
   return(sc->qlist_2);
 }
 
-static s7_pointer set_qlist_3(s7_scheme *sc, s7_pointer x1, s7_pointer x2, s7_pointer x3) /* let_set_fallback */
+s7_pointer set_qlist_3(s7_scheme *sc, s7_pointer x1, s7_pointer x2, s7_pointer x3) /* let_set_fallback */
 {
   return(set_wlist_3(sc->qlist_3, x1, x2, x3));
 }
@@ -5850,7 +5847,7 @@ static s7_pointer set_dlist_1(s7_scheme *sc, s7_pointer x1) /* another like clis
   return(sc->dlist_1);
 }
 
-static s7_pointer set_ulist_1(s7_scheme *sc, s7_pointer x1, s7_pointer x2)
+s7_pointer set_ulist_1(s7_scheme *sc, s7_pointer x1, s7_pointer x2)
 {
   set_car(sc->u1_1, x1);
   set_cdr_unchecked(sc->u1_1, x2);
@@ -5940,7 +5937,7 @@ static const char *type_name_from_type(int32_t typ, article_t article)
   return(NULL);
 }
 
-static s7_pointer find_let(s7_scheme *sc, s7_pointer obj)
+s7_pointer find_let(s7_scheme *sc, s7_pointer obj)
 {
   if ((S7_DEBUGGING) && (is_let(obj))) {fprintf(stderr, "let passed to find_let: %s\n", display(obj)); if (sc->stop_at_error) abort();}
   if (has_closure_let(obj)) return(closure_let(obj)); /* some of these are immutable -- they hold the parameter names */
@@ -5962,7 +5959,7 @@ s7_pointer s7_function_let(s7_scheme *sc, s7_pointer obj) {return(c_function_let
 
 static inline s7_pointer lookup_slot_from(s7_pointer symbol, s7_pointer let);
 
-static s7_pointer find_method(s7_scheme *sc, s7_pointer let, s7_pointer symbol)
+s7_pointer find_method(s7_scheme *sc, s7_pointer let, s7_pointer symbol)
 {
   s7_pointer slot;
   if (is_global(symbol)) /* this means the symbol has never been bound locally, so how can it be a method? */
@@ -6017,7 +6014,7 @@ static const char *type_name(s7_scheme *sc, s7_pointer arg, article_t article)
   return("messed up object");
 }
 
-static s7_pointer object_type_name(s7_scheme *sc, s7_pointer obj) /* used only by the error handlers */
+s7_pointer object_type_name(s7_scheme *sc, s7_pointer obj) /* used only by the error handlers */
 {
   uint8_t typ;
   if (has_active_methods(sc, obj))
@@ -6054,7 +6051,7 @@ void sole_arg_wrong_type_error_nr(s7_scheme *sc, s7_pointer caller, s7_pointer a
   error_nr(sc, sc->wrong_type_arg_symbol, sc->sole_arg_wrong_type_info);
 }
 
-static /* Inline */ no_return void wrong_type_error_nr(s7_scheme *sc, s7_pointer caller, s7_int arg_num, s7_pointer arg, s7_pointer typ)
+/* Inline */ no_return void wrong_type_error_nr(s7_scheme *sc, s7_pointer caller, s7_int arg_num, s7_pointer arg, s7_pointer typ)
 {
   s7_pointer p = cdr(sc->wrong_type_arg_info);  /* info list is '(format_string caller arg_n arg type_name descr) */
   set_car(p, caller);                    p = cdr(p);
@@ -6139,7 +6136,7 @@ static no_return void syntax_error_with_caller2_nr(s7_scheme *sc, const char *er
   error_nr(sc, sc->syntax_error_symbol, set_elist_4(sc, wrap_string(sc, errmsg, len), caller, name, obj));
 }
 
-static s7_pointer make_symbol(s7_scheme *sc, const char *name, s7_int len); /* calls new_symbol */
+s7_pointer make_symbol(s7_scheme *sc, const char *name, s7_int len); /* calls new_symbol */
 #define make_symbol_with_strlen(Sc, Name) make_symbol(Sc, Name, safe_strlen(Name))
 
 static s7_pointer missing_method_class_name(s7_scheme *sc, s7_pointer obj)
@@ -6227,7 +6224,7 @@ static s7_pointer find_and_apply_method(s7_scheme *sc, s7_pointer obj, s7_pointe
   return(s7_apply_function(sc, func, args));
 }
 
-static s7_pointer method_or_bust(s7_scheme *sc, s7_pointer obj, s7_pointer method, s7_pointer args, s7_pointer typ, int32_t num)
+s7_pointer method_or_bust(s7_scheme *sc, s7_pointer obj, s7_pointer method, s7_pointer args, s7_pointer typ, int32_t num)
 {
   if (!has_active_methods(sc, obj)) wrong_type_error_nr(sc, method, num, obj, typ);
   return(find_and_apply_method(sc, obj, method, args));
@@ -6384,7 +6381,7 @@ bool s7_is_boolean(s7_pointer x) {return(type(x) == T_BOOLEAN);}
 
 
 /* -------------------------------- constant? -------------------------------- */
-static inline bool is_constant_symbol(s7_scheme *sc, s7_pointer sym) /* inline: 7 in cb, 5 in tgen */
+extern inline bool is_constant_symbol(s7_scheme *sc, s7_pointer sym) /* inline: 7 in cb, 5 in tgen */
 {
   if (is_immutable_symbol(sym))    /* for keywords */
     return(true);
@@ -6408,7 +6405,7 @@ static s7_pointer is_constant_p_p(s7_scheme *sc, s7_pointer p) {return(make_bool
 
 /* -------------------------------- immutable? -------------------------------- */
 
-static no_return void find_let_error_nr(s7_scheme *sc, s7_pointer caller, s7_pointer let, s7_pointer new_let, s7_int arg_num, s7_pointer args)
+no_return void find_let_error_nr(s7_scheme *sc, s7_pointer caller, s7_pointer let, s7_pointer new_let, s7_int arg_num, s7_pointer args)
 {
   if (new_let == sc->rootlet)
     {
@@ -6528,7 +6525,7 @@ static s7_pointer g_immutable(s7_scheme *sc, s7_pointer args)
  */
 
 #if S7_DEBUGGING
-static s7_int gc_protect_2(s7_scheme *sc, s7_pointer x, int32_t line)
+s7_int gc_protect_2(s7_scheme *sc, s7_pointer x, int32_t line)
 {
   static bool already_warned = false;
   s7_int loc = s7_gc_protect(sc, x);
@@ -6878,7 +6875,6 @@ static void add_gensym(s7_scheme *sc, s7_pointer p)
 #define add_weak_ref(sc, p)          add_to_gc_list(sc, sc->weak_refs, p)
 #define add_weak_hash_iterator(sc, p) add_to_gc_list(sc, sc->weak_hash_iterators, p)
 #define add_opt1_func(sc, p) do {if (!opt1_func_listed(p)) add_to_gc_list(sc, sc->opt1_funcs, p); set_opt1_func_listed(p);} while (0) /* called by set_opt1_lambda_add */
-
 
 
 static void init_gc_caches(s7_scheme *sc)
@@ -8223,7 +8219,7 @@ void push_stack_1(s7_scheme *sc, opcode_t op, s7_pointer args, s7_pointer code, 
 
 #if S7_DEBUGGING
 #define unstack_with(Sc, Op) unstack_1(Sc, Op, __func__, __LINE__)
-static void unstack_1(s7_scheme *sc, opcode_t op, const char *func, int32_t line)
+void unstack_1(s7_scheme *sc, opcode_t op, const char *func, int32_t line)
 {
   sc->stack_end -= 4;
   if ((opcode_t)T_Op(stack_end_op(sc)) != op)
@@ -8573,7 +8569,7 @@ static Inline s7_pointer inline_make_symbol(s7_scheme *sc, const char *name, s7_
   return(new_symbol(sc, name, len, hash, location));
 }
 
-static s7_pointer make_symbol(s7_scheme *sc, const char *name, s7_int len) {return(inline_make_symbol(sc, name, len));}
+s7_pointer make_symbol(s7_scheme *sc, const char *name, s7_int len) {return(inline_make_symbol(sc, name, len));}
 
 s7_pointer s7_make_symbol(s7_scheme *sc, const char *name) {return(inline_make_symbol(sc, name, safe_strlen(name)));}
 
@@ -8855,7 +8851,7 @@ static Inline s7_pointer inline_make_string_with_length(s7_scheme *sc, const cha
   return(new_string);
 }
 
-static s7_pointer make_string_with_length(s7_scheme *sc, const char *str, s7_int len)
+s7_pointer make_string_with_length(s7_scheme *sc, const char *str, s7_int len)
 {
   return(inline_make_string_with_length(sc, str, len)); /* packaged to avoid inlining everywhere */
 }
@@ -8967,7 +8963,7 @@ static s7_pointer g_symbol_set_initial_value(s7_scheme *sc, s7_pointer args)
 
 s7_pointer s7_symbol_initial_value(s7_pointer symbol) {return(initial_value(symbol));}
 
-static bool is_eq_initial_value(s7_pointer symbol, s7_pointer other)
+bool is_eq_initial_value(s7_pointer symbol, s7_pointer other)
 {
   const s7_pointer init = initial_value(symbol);
   if (init == other) return(true);
@@ -9176,7 +9172,7 @@ static s7_pointer make_let_with_two_slots(s7_scheme *sc, s7_pointer old_let, s7_
 }
 
 /* in all these functions, symbol_set_local_slot should follow slot_set_value so that we can evaluate the slot's value in its old state */
-static inline void add_slot_unchecked(s7_scheme *sc, s7_pointer let, s7_pointer symbol, s7_pointer value, s7_uint id)
+extern inline void add_slot_unchecked(s7_scheme *sc, s7_pointer let, s7_pointer symbol, s7_pointer value, s7_uint id)
 {
   s7_pointer slot;
   new_cell_unchecked(sc, slot, T_SLOT);
@@ -9211,7 +9207,7 @@ static inline s7_pointer add_slot_checked(s7_scheme *sc, s7_pointer let, s7_poin
   return(slot);
 }
 
-static inline s7_pointer add_slot_checked_with_id(s7_scheme *sc, s7_pointer let, s7_pointer symbol, s7_pointer value)
+extern inline s7_pointer add_slot_checked_with_id(s7_scheme *sc, s7_pointer let, s7_pointer symbol, s7_pointer value)
 {
   s7_pointer slot;
   new_cell(sc, slot, T_SLOT);
@@ -9247,7 +9243,7 @@ static s7_pointer add_slot_unchecked_with_id(s7_scheme *sc, s7_pointer let, s7_p
   return(slot);
 }
 
-static inline s7_pointer add_slot_at_end(s7_scheme *sc, s7_uint id, s7_pointer last_slot, s7_pointer symbol, s7_pointer value)
+extern inline s7_pointer add_slot_at_end(s7_scheme *sc, s7_uint id, s7_pointer last_slot, s7_pointer symbol, s7_pointer value)
 {
   s7_pointer slot;
   new_cell_unchecked(sc, slot, T_SLOT);
@@ -9258,7 +9254,7 @@ static inline s7_pointer add_slot_at_end(s7_scheme *sc, s7_uint id, s7_pointer l
   return(slot);
 }
 
-static s7_pointer add_slot_checked_at_end(s7_scheme *sc, s7_uint id, s7_pointer last_slot, s7_pointer symbol, s7_pointer value)
+s7_pointer add_slot_checked_at_end(s7_scheme *sc, s7_uint id, s7_pointer last_slot, s7_pointer symbol, s7_pointer value)
 { /* same as above but new_cell is checked */
   s7_pointer slot;
   new_cell(sc, slot, T_SLOT);
@@ -9378,9 +9374,9 @@ static s7_pointer make_semipermanent_let(s7_scheme *sc, s7_pointer vars)
   return(let);
 }
 
-static s7_pointer call_setter(s7_scheme *sc, s7_pointer slot, s7_pointer old_value);
+s7_pointer call_setter(s7_scheme *sc, s7_pointer slot, s7_pointer old_value);
 
-static inline s7_pointer checked_slot_set_value(s7_scheme *sc, s7_pointer slot, s7_pointer value)
+extern inline s7_pointer checked_slot_set_value(s7_scheme *sc, s7_pointer slot, s7_pointer value)
 {
   if (slot_has_setter(slot))
     slot_set_value(slot, call_setter(sc, slot, value));
@@ -9438,7 +9434,7 @@ static s7_int let_length(s7_scheme *sc, s7_pointer let)
   }
 }
 
-static void slot_set_setter(s7_pointer slot, s7_pointer val)
+void slot_set_setter(s7_pointer slot, s7_pointer val)
 {
   if ((type(val) == T_C_FUNCTION) &&
       (c_function_has_bool_setter(val)))
@@ -9446,7 +9442,7 @@ static void slot_set_setter(s7_pointer slot, s7_pointer val)
   else slot_set_setter_1(slot, val);
 }
 
-static void slot_set_value_with_hook_1(s7_scheme *sc, s7_pointer slot, s7_pointer value)
+void slot_set_value_with_hook_1(s7_scheme *sc, s7_pointer slot, s7_pointer value)
 {
   /* (set! (hook-functions *rootlet-redefinition-hook*) (list (lambda (hook) (format *stderr* "~A ~A~%" (hook 'name) (hook 'value))))) */
   s7_pointer symbol = slot_symbol(slot);
@@ -9603,32 +9599,13 @@ bool s7_is_let(s7_pointer let) {return(is_let(let));}
 
 
 /* -------------------------------- unlet -------------------------------- */
-static s7_pointer g_unlet(s7_scheme *sc, s7_pointer unused_args)
-{
-  /* add sc->unlet bindings to the current environment */
+/* g_unlet moved to s7_scheme_let.c */
   #define H_unlet "(unlet) returns a let that establishes the original bindings of all the predefined functions"
   #define Q_unlet s7_make_signature(sc, 1, sc->is_let_symbol)
 
-  const s7_pointer result = make_let(sc, sc->curlet);
-  begin_temp(sc->y, result);
-  set_is_unlet(result);
-  if (global_value(sc->else_symbol) != sc->else_symbol)
-    add_slot_checked_with_id(sc, result, sc->else_symbol, initial_value(sc->else_symbol));
-  for (unlet_entry_t *p = sc->unlet_entries; p; p = p->next)
-    {
-      s7_pointer sym = p->symbol;
-      if ((!is_eq_initial_value(sym, global_value(sym))) ||  /* it has been changed globally */
-	  ((!is_global(sym)) &&        /* it might be shadowed locally */
-	   (s7_symbol_local_value(sc, sym, sc->curlet) != global_value(sym))))
-	add_slot_checked_with_id(sc, result, sym, initial_value(sym));
-    }
-  end_temp(sc->y);
-  return(result);
-}
-
 
 /* -------------------------------- openlet? -------------------------------- */
-bool s7_is_openlet(s7_pointer let) {return(has_methods(let));}
+/* s7_is_openlet moved to s7_scheme_let.c */
 
 /* g_is_openlet is now defined in s7_scheme_predicate.c */
   #define H_is_openlet "(openlet? obj) returns #t if 'obj' has methods."
@@ -9636,130 +9613,26 @@ bool s7_is_openlet(s7_pointer let) {return(has_methods(let));}
 
 
 /* -------------------------------- openlet -------------------------------- */
-s7_pointer s7_openlet(s7_scheme *sc, s7_pointer let)
-{
-  /* if e is not a let, the openlet bit is still set on it (c-pointer etc) */
-  set_has_methods(let);
-  return(let);
-}
+/* s7_openlet moved to s7_scheme_let.c */
 
-static s7_pointer g_openlet(s7_scheme *sc, s7_pointer args)
-{
+/* g_openlet moved to s7_scheme_let.c */
   #define H_openlet "(openlet e) tells the built-in functions that the let e might have an over-riding method. e is returned."
   #define Q_openlet s7_make_signature(sc, 2, has_let_signature(sc), has_let_signature(sc))
 
-  const s7_pointer let = car(args);
-  s7_pointer new_let, func;
-  if (!is_let(let))
-    {
-      new_let = find_let(sc, let);
-      if ((!is_let(new_let)) || (new_let == sc->rootlet))
-	find_let_error_nr(sc, sc->openlet_symbol, let, new_let, 1, args);
-    }
-  else new_let = let;
-  if ((new_let == sc->rootlet) || (new_let == sc->starlet))
-    error_nr(sc, sc->out_of_range_symbol, set_elist_2(sc, wrap_string(sc, "can't openlet ~S", 17), let));
-  if (is_unlet(new_let)) /* protect against infinite loop: (let () (define + -) (with-let (unlet) (+ (openlet (unlet)) 2))) */
-    error_nr(sc, sc->out_of_range_symbol, set_elist_1(sc, wrap_string(sc, "can't openlet unlet", 19)));
-  if ((has_active_methods(sc, let)) &&
-      ((func = find_method(sc, new_let, sc->openlet_symbol)) != sc->undefined))
-    return(s7_apply_function(sc, func, args));
-  set_has_methods(let);
-  return(let); /* openlet and coverlet return their argument */
-}
-
 /* -------------------------------- coverlet -------------------------------- */
-static s7_pointer g_coverlet(s7_scheme *sc, s7_pointer args)
-{
+/* g_coverlet moved to s7_scheme_let.c */
   #define H_coverlet "(coverlet e) undoes an earlier openlet.  e is returned."
   #define Q_coverlet s7_make_signature(sc, 2, has_let_signature(sc), has_let_signature(sc))
 
-  const s7_pointer let = car(args);
-  s7_pointer new_let, func;
-  if (!is_let(let))
-    {
-      new_let = find_let(sc, let);
-      if ((!is_let(new_let))  || (new_let == sc->rootlet))
-	find_let_error_nr(sc, sc->coverlet_symbol, let, new_let, 1, args);
-    }
-  else new_let = let;
-  if ((new_let == sc->rootlet) || (new_let == sc->starlet))
-    error_nr(sc, sc->out_of_range_symbol, set_elist_2(sc, wrap_string(sc, "can't coverlet ~S", 17), let));
-  if (is_unlet(new_let))
-    error_nr(sc, sc->out_of_range_symbol, set_elist_1(sc, wrap_string(sc, "can't coverlet unlet", 20)));
-  if ((has_active_methods(sc, let)) &&
-      ((func = find_method(sc, new_let, sc->coverlet_symbol)) != sc->undefined))
-    return(s7_apply_function(sc, func, args));
-  clear_has_methods(let);
-  return(let); /* mimic openlet in everything */
-}
-
 
 /* -------------------------------- varlet -------------------------------- */
-static void check_let_fallback(s7_scheme *sc, const s7_pointer symbol, s7_pointer let)
-{
-  if (symbol == sc->let_ref_fallback_symbol)
-    set_has_let_ref_fallback(let);
-  else
-    if (symbol == sc->let_set_fallback_symbol)
-      set_has_let_set_fallback(let);
-}
+/* check_let_fallback moved to s7_scheme_let.c */
 
-static void append_let(s7_scheme *sc, s7_pointer new_let, s7_pointer old_let)
-{
-  if (new_let == sc->rootlet)
-    for (s7_pointer slot = let_slots(old_let); is_not_slot_end(slot); slot = next_slot(slot))
-      {
-	s7_pointer sym = slot_symbol(slot), val = slot_value(slot);
-	if (is_slot(global_slot(sym)))
-	  set_global_value(sym, val);
-	else s7_make_slot(sc, sc->rootlet, sym, val);
-      }
-  else
-    if (old_let == sc->starlet)
-      {
-	const s7_pointer iter = s7_make_iterator(sc, sc->starlet);
-	const s7_int gc_loc = gc_protect_1(sc, iter);
-	iterator_carrier(iter) = cons_unchecked(sc, sc->F, sc->F);
-	set_has_carrier(iter); /* so carrier is GC protected by mark_iterator */
-	while (true)
-	  {
-	    s7_pointer field = s7_iterate(sc, iter);
-	    if (iterator_is_at_end(iter)) break;
-	    add_slot_checked_with_id(sc, new_let, car(field), cdr(field));
-	  }
-	s7_gc_unprotect_at(sc, gc_loc);
-      }
-    else
-      for (s7_pointer slot = let_slots(old_let); is_not_slot_end(slot); slot = next_slot(slot))
-	add_slot_checked_with_id(sc, new_let, slot_symbol(slot), slot_value(slot)); /* not add_slot here because it might run off the free heap end */
-}
+/* append_let moved to s7_scheme_let.c */
 
-s7_pointer s7_varlet(s7_scheme *sc, s7_pointer let, s7_pointer symbol, s7_pointer value)
-{
-  if (!is_let(let))
-    wrong_type_error_nr(sc, sc->varlet_symbol, 1, let, a_let_string);
-  if (!is_symbol(symbol))
-    wrong_type_error_nr(sc, sc->varlet_symbol, 2, symbol, a_symbol_string);
-  if ((is_slot(global_slot(symbol))) &&
-      (is_syntax(global_value(symbol))))
-    wrong_type_error_nr(sc, sc->varlet_symbol, 2, symbol, wrap_string(sc, "a non-syntactic symbol", 22));
+/* s7_varlet moved to s7_scheme_let.c */
 
-  if (let == sc->rootlet)
-    {
-      if (is_slot(global_slot(symbol)))
-	set_global_value(symbol, value);
-      else s7_make_slot(sc, sc->rootlet, symbol, value);
-    }
-  else
-    {
-      add_slot_checked_with_id(sc, let, symbol, value);
-      check_let_fallback(sc, symbol, let);
-    }
-  return(value);
-}
-
-static int32_t position_of(const s7_pointer p, s7_pointer args)
+int32_t position_of(const s7_pointer p, s7_pointer args)
 {
   int32_t i;
   for (i = 1; p != args; i++, args = cdr(args));
@@ -9771,648 +9644,98 @@ s7_int s7i_position_of(const s7_pointer p, s7_pointer args)
   return((s7_int)position_of(p, args));
 }
 
-static s7_pointer g_varlet(s7_scheme *sc, s7_pointer args)   /* varlet = with-let + define */
-{
+/* g_varlet moved to s7_scheme_let.c */
   #define H_varlet "(varlet target-let ...) adds its arguments (a let, a cons: (symbol . value), or two arguments, the symbol and its value) \
 to the let target-let, and returns target-let.  (varlet (curlet) 'a 1) adds 'a to the current environment with the value 1."
   #define Q_varlet s7_make_circular_signature(sc, 2, 4, sc->is_let_symbol, has_let_signature(sc), \
                      s7_make_signature(sc, 3, sc->is_pair_symbol, sc->is_symbol_symbol, sc->is_let_symbol), sc->T)
-  s7_pointer let = car(args);
-  if (!is_let(let))
-    {
-      s7_pointer new_let = find_let(sc, let);
-      if ((!is_let(new_let)) || (new_let == sc->rootlet))
-	find_let_error_nr(sc, sc->varlet_symbol, let, new_let, 1, args);
-      let = new_let;
-    }
-  if ((is_immutable_let(let)) || (let == sc->starlet))
-    immutable_object_error_nr(sc, set_elist_3(sc, wrap_string(sc, "can't (varlet ~{~S~^ ~}), ~S is immutable", 41), args, let));
-
-  for (s7_pointer arglist = cdr(args); is_pair(arglist); arglist = cdr(arglist))
-    {
-      s7_pointer sym, val;
-      const s7_pointer arg = car(arglist);
-      if (is_symbol(arg))
-	{
-	  sym = (is_keyword(arg)) ? keyword_symbol(arg) : arg;
-	  if (!is_pair(cdr(arglist)))
-	    error_nr(sc, sc->syntax_error_symbol, set_elist_3(sc, wrap_string(sc, "varlet: symbol ~S, but no value: ~S", 35), arg, args));
-	  if (is_constant_symbol(sc, sym))
-	    wrong_type_error_nr(sc, sc->varlet_symbol, position_of(arglist, args), sym, a_non_constant_symbol_string);
-	  arglist = cdr(arglist);
-	  val = car(arglist);
-	}
-      else
-	if (is_let(arg))
-	  {
-	    if ((arg != sc->rootlet) && (let != sc->starlet))   /* (varlet (inlet 'a 1) (rootlet)) is trouble */
-	      {
-		append_let(sc, let, arg);
-		if (has_let_set_fallback(arg)) set_has_let_set_fallback(let);
-		if (has_let_ref_fallback(arg)) set_has_let_ref_fallback(let);
-	      }
-	    continue;
-	  }
-	else
-	  if (is_pair(arg))
-	    {
-	      sym = car(arg);
-	      if (!is_symbol(sym))
-		wrong_type_error_nr(sc, sc->varlet_symbol, position_of(arglist, args), arg, a_symbol_string);
-	      if (is_constant_symbol(sc, sym))
-		wrong_type_error_nr(sc, sc->varlet_symbol, position_of(arglist, args), sym, a_non_constant_symbol_string);
-	      val = cdr(arg);
-	    }
-	  else wrong_type_error_nr(sc, sc->varlet_symbol, position_of(arglist, args), arg, wrap_string(sc, "a symbol, let, or cons", 22));
-
-      if (let == sc->rootlet)
-	{
-	  s7_pointer gslot = global_slot(sym);
-	  if (is_slot(gslot))
-	    {
-	      if (is_immutable(gslot)) /* (immutable! 'abs) (varlet (rootlet) 'abs 1) */
-		immutable_object_error_nr(sc, set_elist_5(sc, wrap_string(sc, "~S is immutable in (varlet ~S '~S ~S)", 37), sym, car(args), arg, val));
-	      slot_set_value_with_hook(global_slot(sym), val);
-	    }
-	  else s7_make_slot(sc, sc->rootlet, sym, val);
-	}
-      else
-	{
-	  check_let_fallback(sc, sym, let);
-	  add_slot_checked_with_id(sc, let, sym, val);
-	  /* this used to check for sym already defined, and set its value, but that greatly slows down
-	   *   the most common use (adding a slot), and makes it hard to shadow explicitly.  Don't use
-	   *   varlet as a substitute for set!/let-set!.
-	   */
-	}}
-  return(let);
-}
 
 
 /* -------------------------------- cutlet -------------------------------- */
-static s7_pointer g_cutlet(s7_scheme *sc, s7_pointer args)
-{
+/* g_cutlet moved to s7_scheme_let.c */
   #define H_cutlet "(cutlet e symbol ...) removes symbols from the let e."
   #define Q_cutlet s7_make_circular_signature(sc, 2, 3, sc->is_let_symbol, has_let_signature(sc), sc->is_symbol_symbol)
 
-  s7_pointer let = car(args);
-  s7_int the_un_id;
-  if (let != sc->rootlet)
-    {
-      if_method_exists_return_value(sc, let, sc->cutlet_symbol, args);
-      if (!is_let(let))
-	{
-	  s7_pointer new_let = find_let(sc, let);
-	  if ((!is_let(new_let)) || (new_let == sc->rootlet))
-	    find_let_error_nr(sc, sc->cutlet_symbol, let, new_let, 1, args);
-	  let = new_let;
-	}}
-  if ((is_immutable_let(let)) || (let == sc->starlet))
-    immutable_object_error_nr(sc, set_elist_3(sc, immutable_error_string, sc->cutlet_symbol, let));
-
-  /* besides removing the slot we have to make sure the symbol_id does not match, else
-   *   let-ref and others will use the old slot!  So use the next (unused) id.
-   *   (let ((b 1)) (let ((b 2)) (cutlet (curlet) 'b)) b)
-   */
-  the_un_id = ++sc->let_number;
-
-  for (s7_pointer syms = cdr(args); is_pair(syms); syms = cdr(syms))
-    {
-      s7_pointer sym = car(syms);
-      if (!is_symbol(sym))
-	wrong_type_error_nr(sc, sc->cutlet_symbol, position_of(syms, args), sym, a_symbol_string);
-      if (is_keyword(sym))
-	sym = keyword_symbol(sym);
-
-      if (let == sc->rootlet)
-	{
-	  if (!is_slot(global_slot(sym)))
-	    error_nr(sc, sc->out_of_range_symbol, set_elist_2(sc, wrap_string(sc, "cutlet can't remove ~S", 22), sym));
-	  if (is_immutable(global_slot(sym)))
-	    immutable_object_error_nr(sc, set_elist_3(sc, immutable_error_string, sc->cutlet_symbol, sym));
-	  symbol_set_id(sym, the_un_id);
-	  set_global_value(sym, sc->undefined);
-	  /* here we need to at least clear bits: syntactic binder clean-symbol(?) etc, maybe also locally */
-	}
-      else
-	{
-	  s7_pointer slot;
-	  if ((has_let_fallback(let)) &&
-	      ((sym == sc->let_ref_fallback_symbol) || (sym == sc->let_set_fallback_symbol)))
-	    error_nr(sc, sc->out_of_range_symbol, set_elist_2(sc, wrap_string(sc, "cutlet can't remove ~S", 22), sym));
-	  slot = let_slots(let);
-	  if (is_not_slot_end(slot))
-	    {
-	      if (slot_symbol(slot) == sym)
-		{
-		  if (is_immutable_slot(slot))
-		    immutable_object_error_nr(sc, set_elist_3(sc, immutable_error_string, sc->cutlet_symbol, sym));
-		  let_set_slots(let, next_slot(let_slots(let)));
-		  symbol_set_id(sym, the_un_id);
-		}
-	      else
-		{
-		  s7_pointer last_slot = slot;
-		  for (slot = next_slot(let_slots(let)); is_not_slot_end(slot); last_slot = slot, slot = next_slot(slot))
-		    if (slot_symbol(slot) == sym)
-		      {
-			if (is_immutable_slot(slot))
-			  immutable_object_error_nr(sc, set_elist_3(sc, immutable_error_string, sc->cutlet_symbol, sym));
-			symbol_set_id(sym, the_un_id);
-			slot_set_next(last_slot, next_slot(slot));
-			break;
-		      }}}}}
-  return(let);
-}
-
 
 /* -------------------------------- sublet -------------------------------- */
-static s7_pointer sublet_1(s7_scheme *sc, s7_pointer let, s7_pointer bindings, s7_pointer caller)
-{
-  const s7_pointer new_let = make_let(sc, let);
-  set_all_methods(new_let, let);
+/* sublet_1 moved to s7_scheme_let.c */
 
-  if (!is_null(bindings))
-    {
-      sc->temp3 = new_let;
-      for (s7_pointer slot = NULL, entries = bindings; is_pair(entries); entries = cdr(entries))
-	{
-	  s7_pointer entry = car(entries), sym, val;
+/* s7_sublet moved to s7_scheme_let.c */
 
-	  switch (type(entry))
-	    {
-	    case T_SYMBOL:
-	      sym = (is_keyword(entry)) ? keyword_symbol(entry) : entry;
-	      if (!is_pair(cdr(entries)))
-		error_nr(sc, sc->syntax_error_symbol,
-			 set_elist_4(sc, wrap_string(sc, "~A: entry ~S, but no value: ~S", 30), caller, entry, bindings));
-	      entries = cdr(entries);
-	      val = car(entries);
-	      break;
-
-	    case T_PAIR:  /* (cons sym val) */
-	      sym = car(entry);
-	      if (!is_symbol(sym))
-		wrong_type_error_nr(sc, caller, 1 + position_of(entries, bindings), entry, a_symbol_string);
-	      if (is_keyword(sym))
-		sym = keyword_symbol(sym);
-	      val = cdr(entry);
-	      break;
-
-	    case T_LET:
-	      if ((entry == sc->rootlet) || (new_let == sc->starlet)) continue;
-	      append_let(sc, new_let, entry);
-	      if (is_not_slot_end(let_slots(new_let))) /* make sure the end slot (slot) is correct */
-		for (slot = let_slots(new_let); is_not_slot_end(next_slot(slot)); slot = next_slot(slot)); /* slot can't be local -- see below */
-	      continue;
-
-	    default:
-	      wrong_type_error_nr(sc, caller, 1 + position_of(entries, bindings), entry, a_symbol_string);
-	    }
-	  if (is_constant_symbol(sc, sym))
-	    wrong_type_error_nr(sc, caller, 1 + position_of(entries, bindings), sym, a_non_constant_symbol_string);
-#if 0
-	  if ((is_slot(global_slot(sym))) &&
-	      (is_syntax_or_qq(global_value(sym))))
-	    wrong_type_error_nr(sc, caller, 2, sym, wrap_string(sc, "a non-syntactic symbol", 22));
-	  /* this is a local redefinition which we accept elsewhere: (let ((if 3)) if) -> 3 */
-	  /*   so s7_inlet (which calls sublet) differs from g_inlet? which is correct? */
-	  /*   (define (f1) (with-let (sublet (curlet)) (inlet 'quasiquote 1))) (f1) */
-
-#endif
-	  /* here we know new_let is a let and is not rootlet */
-	  if (!slot)
-	    slot = add_slot_checked_with_id(sc, new_let, sym, val);
-	  else
-	    {
-	      /* if (sc->free_heap_top <= sc->free_heap_trigger) try_to_call_gc(sc);*/ /* or maybe add add_slot_at_end_checked? */
-	      slot = add_slot_checked_at_end(sc, let_id(new_let), slot, sym, val);
-	      set_local(sym); /* ? */
-	    }
-	  check_let_fallback(sc, sym, new_let);
-	}
-      if ((S7_DEBUGGING) && (sc->temp3 != new_let)) fprintf(stderr, "%s[%d]: temp3: %s\n", __func__, __LINE__, display(sc->temp3));
-      sc->temp3 = sc->unused;
-    }
-  return(new_let);
-}
-
-s7_pointer s7_sublet(s7_scheme *sc, s7_pointer let, s7_pointer bindings) {return(sublet_1(sc, let, bindings, sc->sublet_symbol));}
-
-static s7_pointer g_sublet(s7_scheme *sc, s7_pointer args)
-{
+/* g_sublet moved to s7_scheme_let.c */
   #define H_sublet "(sublet lt ...) makes a new let (an environment) within the environment 'lt', initializing it with the bindings"
   #define Q_sublet Q_varlet
 
-  s7_pointer let = car(args);
-  if (!is_let(let))
-    {
-      s7_pointer new_let = find_let(sc, let);
-      if ((!is_let(new_let)) || (new_let == sc->rootlet))
-	find_let_error_nr(sc, sc->sublet_symbol, let, new_let, 1, args);
-      let = new_let;
-    }
-  return(sublet_1(sc, let, cdr(args), sc->sublet_symbol));
-}
+/* g_sublet_curlet moved to s7_scheme_let.c */
 
-static s7_pointer g_sublet_curlet(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer sym = cadr(args), new_let;
-  if_let_method_exists_return_value(sc, sc->curlet, sc->sublet_symbol, args); /* curlet is a let so... */
-  new_let = inline_make_let_with_slot(sc, sc->curlet, sym, caddr(args));
-  set_all_methods(new_let, sc->curlet);
-  check_let_fallback(sc, sym, new_let);
-  return(new_let);
-}
-
-static s7_pointer sublet_chooser(s7_scheme *sc, s7_pointer func, int32_t num_args, s7_pointer expr)
-{
-  if (num_args == 3)
-    {
-      s7_pointer args = cdr(expr);
-      if ((is_pair(car(args))) && (caar(args) == sc->curlet_symbol) && (is_null(cdar(args))) &&
-	  (is_quoted_symbol(sc, cadr(args))))
-	return(sc->sublet_curlet);
-    }
-  return(func);
-}
+/* sublet_chooser moved to s7_scheme_let.c */
 
 
 /* -------------------------------- inlet -------------------------------- */
-s7_pointer s7_inlet(s7_scheme *sc, s7_pointer args)
-{
+/* s7_inlet moved to s7_scheme_let.c */
   #define H_inlet "(inlet ...) adds its arguments, each a let, a cons: '(symbol . value), or a symbol/value pair, \
 to a new let, and returns the new let. (inlet :a 1 :b 2) or (inlet 'a 1 'b 2)"
   #define Q_inlet s7_make_circular_signature(sc, 1, 2, sc->is_let_symbol, sc->T)
-  return(sublet_1(sc, sc->rootlet, args, sc->inlet_symbol));
-}
 
 #define g_inlet s7_inlet
 
-static s7_pointer g_simple_inlet(s7_scheme *sc, s7_pointer args)
-{
-  /* here all args are paired with normal symbol/value, no fallbacks, no immutable symbols, no syntax, etc */
-  const s7_pointer new_let = make_let(sc, sc->rootlet);
-  const s7_int id = let_id(new_let);
+/* g_simple_inlet moved to s7_scheme_let.c */
 
-  begin_temp(sc->temp6, new_let);
-  for (s7_pointer x = args, last_slot = NULL; is_pair(x); x = cddr(x))
-    {
-      s7_pointer symbol = car(x);
-      if (is_keyword(symbol))                 /* (inlet ':allow-other-keys 3) */
-	symbol = keyword_symbol(symbol);
-      if (is_constant_symbol(sc, symbol))     /* (inlet 'pi 1) */
-	{
-	  end_temp(sc->temp6);
-	  wrong_type_error_nr(sc, sc->inlet_symbol, 1, symbol, a_non_constant_symbol_string);
-	}
-      if (!last_slot)
-	{
-	  add_slot_unchecked(sc, new_let, symbol, cadr(x), id);
-	  last_slot = let_slots(new_let);
-	}
-      else last_slot = add_slot_checked_at_end(sc, id, last_slot, symbol, cadr(x));
-    }
-  end_temp(sc->temp6);
-  return(new_let);
-}
+/* inlet_p_pp moved to s7_scheme_let.c */
 
-static s7_pointer inlet_p_pp(s7_scheme *sc, s7_pointer symbol, s7_pointer value)
-{
-  if (!is_symbol(symbol))
-    return(sublet_1(sc, sc->rootlet, set_plist_2(sc, symbol, value), sc->inlet_symbol));
-  if (is_keyword(symbol))
-    symbol = keyword_symbol(symbol);
-  if (is_constant_symbol(sc, symbol))
-    wrong_type_error_nr(sc, sc->inlet_symbol, 1, symbol, a_non_constant_symbol_string);
-  if ((is_defined_global(symbol)) &&
-      (is_syntax_or_qq(global_value(symbol))))
-    wrong_type_error_nr(sc, sc->inlet_symbol, 1, symbol, wrap_string(sc, "a non-syntactic symbol", 22));
-  {
-    s7_pointer new_let;
-    new_cell(sc, new_let, T_LET | T_SAFE_PROCEDURE);
-    begin_temp(sc->x, new_let);
-    let_set_id(new_let, ++sc->let_number);
-    let_set_outlet(new_let, sc->rootlet);
-    let_set_slots(new_let, slot_end);
-    add_slot_unchecked(sc, new_let, symbol, value, let_id(new_let));
-    end_temp(sc->x);
-    return(new_let);
-  }
-}
+/* internal_inlet moved to s7_scheme_let.c */
 
-static s7_pointer internal_inlet(s7_scheme *sc, s7_int num_args, ...) /* used in *->let */
-{
-  va_list ap;
-  const s7_pointer new_let = make_let(sc, sc->rootlet);
-  const s7_int id = let_id(new_let);
-  s7_pointer last_slot = NULL;
-
-  begin_temp(sc->x, new_let);
-  va_start(ap, num_args);
-  for (s7_int i = 0; i < num_args; i += 2)
-    {
-      s7_pointer symbol = T_Sym(va_arg(ap, s7_pointer));
-      s7_pointer value = T_Ext(va_arg(ap, s7_pointer));
-      if (!last_slot)
-	{
-	  add_slot_unchecked(sc, new_let, symbol, value, id);
-	  last_slot = let_slots(new_let);
-	}
-      else last_slot = add_slot_at_end(sc, id, last_slot, symbol, value);
-    }
-  va_end(ap);
-  end_temp(sc->x);
-  return(new_let);
-}
-
-static bool is_proper_quote(s7_scheme *sc, s7_pointer p)
+bool is_proper_quote(s7_scheme *sc, s7_pointer p)
 {
   return((is_safe_quoted_pair(sc, p)) &&
 	 (is_pair(cdr(p))) &&
 	 (is_null(cddr(p))));
 }
 
-static s7_pointer inlet_chooser(s7_scheme *sc, s7_pointer func, int32_t args, s7_pointer expr)
-{
-  if ((args > 0) && ((args % 2) == 0))
-    {
-      for (s7_pointer p = cdr(expr); is_pair(p); p = cddr(p))
-	{
-	  s7_pointer sym;
-	  if (is_symbol_and_keyword(car(p)))                  /* (inlet :if ...) */
-	    sym = keyword_symbol(car(p));
-	  else
-	    {
-	      if (!is_proper_quote(sc, car(p))) return(func); /* (inlet abs ...) */
-	      sym = cadar(p);                                 /* looking for (inlet 'a ...) */
-	      if (!is_symbol(sym)) return(func);              /* (inlet '(a . 3) ...) */
-	      if (is_keyword(sym)) sym = keyword_symbol(sym); /* (inlet ':abs ...) */
-	    }
-	  if ((is_possibly_constant(sym)) ||                  /* (inlet 'define-constant ...) or (inlet 'pi ...) */
-	      (is_syntactic_symbol(sym))  ||                  /* (inlet 'if 3) */
-	      ((is_slot(global_slot(sym))) &&
-	       (is_syntax_or_qq(global_value(sym)))) ||       /* (inlet 'quasiquote 1) */
-	      (sym == sc->let_ref_fallback_symbol) ||
-	      (sym == sc->let_set_fallback_symbol))
-	    return(func);
-	}
-      return(sc->simple_inlet);
-    }
-  return(func);
-}
+/* inlet_chooser moved to s7_scheme_let.c */
 
 
 /* -------------------------------- let->list -------------------------------- */
-static s7_pointer proper_list_reverse_in_place(s7_scheme *sc, s7_pointer list);
+s7_pointer proper_list_reverse_in_place(s7_scheme *sc, s7_pointer list);
 
-static s7_pointer abbreviate_let(s7_scheme *sc, s7_pointer val)
-{
-  if (is_let(val))
-    return(make_symbol(sc, "<inlet...>", 11));
-  return(val);
-}
+/* abbreviate_let moved to s7_scheme_let.c */
 
-s7_pointer s7_let_to_list(s7_scheme *sc, s7_pointer let)
-{
-  if (let == sc->rootlet)
-    {
-      begin_temp(sc->temp6, sc->nil);
-      for (s7_pointer lib = global_value(sc->libraries_symbol); is_pair(lib); lib = cdr(lib))
-	sc->temp6 = cons(sc, caar(lib), sc->temp6);
-      sc->temp6 = cons(sc, cons(sc, sc->libraries_symbol, sc->temp6), sc->nil);
-      for (s7_pointer slot = sc->rootlet_slots; is_not_slot_end(slot); slot = next_slot(slot))
-	if (slot_symbol(slot) != sc->libraries_symbol)
-	  sc->temp6 = cons_unchecked(sc, cons(sc, slot_symbol(slot), abbreviate_let(sc, slot_value(slot))), sc->temp6);
-      {
-	s7_pointer result = proper_list_reverse_in_place(sc, sc->temp6);
-	end_temp(sc->temp6);
-	return(result);
-      }}
-  else
-    {
-      s7_pointer iter, func;
-      s7_int gc_loc = -1;
-      /* need to check make-iterator method before dropping into let->list */
-      sc->temp3 = sc->w;
-      sc->w = sc->nil;
+/* s7_let_to_list moved to s7_scheme_let.c */
 
-      if ((has_active_methods(sc, let)) &&
-	  ((func = find_method(sc, let, sc->make_iterator_symbol)) != sc->undefined))
-	iter = s7_apply_function(sc, func, set_plist_1(sc, let));
-      else
-	if (let == sc->starlet) /* (let->list *s7*) via starlet_make_iterator */
-	  {
-	    iter = s7_make_iterator(sc, let);
-	    gc_loc = gc_protect_1(sc, iter);
-	  }
-	else iter = sc->nil;
-
-      if (is_null(iter))
-	for (s7_pointer slot = let_slots(let); is_not_slot_end(slot); slot = next_slot(slot))
-	  sc->w = cons_unchecked(sc, cons(sc, slot_symbol(slot), slot_value(slot)), sc->w);
-      else
-	/* (begin (load "mockery.scm") (let ((lt ((*mock-pair* 'mock-pair) 1 2 3))) (format *stderr* "~{~A ~}" lt))) */
-	while (true)
-	  {
-	    s7_pointer val = s7_iterate(sc, iter);
-	    if (iterator_is_at_end(iter)) break;
-	    sc->w = cons(sc, val, sc->w);
-	  }
-      sc->w = proper_list_reverse_in_place(sc, sc->w);
-      if (gc_loc != -1)
-	s7_gc_unprotect_at(sc, gc_loc);
-      {
-	s7_pointer result = sc->w;
-	sc->w = sc->temp3;
-	sc->temp3 = sc->unused;
-	return(result);
-      }}
-}
-
-#if !WITH_PURE_S7
-static s7_pointer g_let_to_list(s7_scheme *sc, s7_pointer args)
-{
+/* g_let_to_list moved to s7_scheme_let.c */
   #define H_let_to_list "(let->list let) returns let's bindings as a list of cons's: '(symbol . value)."
   #define Q_let_to_list s7_make_signature(sc, 2, sc->is_pair_symbol, has_let_signature(sc))
 
-  s7_pointer let = car(args);
-  if_method_exists_return_value(sc, let, sc->let_to_list_symbol, args);
-  if (!is_let(let))
-    {
-      s7_pointer new_let = find_let(sc, let);
-      if ((!is_let(new_let)) || (new_let == sc->rootlet))
-	find_let_error_nr(sc, sc->let_to_list_symbol, let, new_let, 1, args);
-      /* this is not (let->list (rootlet)) but (say) (let->list func) which defaults in find_let to rootlet */
-      let = new_let;
-    }
-  return(s7_let_to_list(sc, let));
-}
-/* *s7* in gdb: p display(s7_let_to_list(sc, sc->starlet)) */
-#endif
-
 
 /* -------------------------------- let-ref -------------------------------- */
-static s7_pointer call_let_ref_fallback(s7_scheme *sc, s7_pointer let, s7_pointer symbol)
-{
-  s7_pointer result;
-  const s7_pointer val = find_method(sc, let, sc->let_ref_fallback_symbol);
-  /* (let ((x #f)) (let begin ((x 1234)) (begin 1) 2)) -> stack overflow eventually, but should we try to catch it? */
-  if (!is_applicable(val)) return(val);
-  push_stack_no_let(sc, OP_GC_PROTECT, sc->value, sc->code);
-  result = s7_apply_function(sc, val, set_qlist_2(sc, let, symbol));
-  unstack_gc_protect(sc);
-  sc->code = T_Pos(stack_end_code(sc)); /* can be #<unused> */
-  sc->value = T_Ext(stack_end_args(sc));
-  return(result);
-}
+/* call_let_ref_fallback moved to s7_scheme_let.c */
 
-static s7_pointer call_let_set_fallback(s7_scheme *sc, s7_pointer let, s7_pointer symbol, s7_pointer value)
-{
-  s7_pointer result;
-  push_stack_no_let(sc, OP_GC_PROTECT, sc->value, sc->code);
-  result = s7_apply_function(sc, find_method(sc, let, sc->let_set_fallback_symbol), set_qlist_3(sc, let, symbol, value));
-  unstack_gc_protect(sc);
-  sc->code = T_Pos(stack_end_code(sc));
-  sc->value = T_Ext(stack_end_args(sc));
-  return(result);
-}
+/* call_let_set_fallback moved to s7_scheme_let.c */
 
 /* g_unlet_disabled is now defined in s7_scheme_predicate.c */
 /* we need a self-id here for let_ref, but it needs to be a real s7_cell, not g_unlet_disabled itself, hence sc->unlet_disabled */
 
-static /* inline */ s7_pointer let_ref(s7_scheme *sc, s7_pointer let, s7_pointer symbol)
-{
-  /* (let ((a 1)) ((curlet) 'a)) or ((rootlet) 'abs) */
-  if (!is_let(let))
-    {
-      s7_pointer new_let;
-      if (let == sc->unlet_disabled) return(initial_value(symbol));
-      new_let = find_let(sc, let);
-      if ((!is_let(new_let)) || (new_let == sc->rootlet))
-	find_let_error_nr(sc, sc->let_ref_symbol, let, new_let, 1, set_mlist_2(sc, let, symbol));
-      let = new_let;
-    }
-  if (!is_symbol(symbol))
-    {
-      if ((let != sc->rootlet) && (has_let_ref_fallback(let))) /* let-ref|set-fallback refer to (explicit) let-ref in various forms, not the method lookup process */
-	return(call_let_ref_fallback(sc, let, symbol));
-      wrong_type_error_nr(sc, sc->let_ref_symbol, 2, symbol, a_symbol_string);
-    }
-  /* a let-ref method is almost impossible to write without creating an infinite loop:
-   *   any reference to the let will probably call let-ref somewhere, calling us again, and looping.
-   *   This is not a problem in c-objects and funclets because c-object-ref and funclet-ref don't exist.
-   *   After much wasted debugging, I decided to make let-ref and let-set! immutable.
-   *   What about other let-as-first-arg funcs?
-   */
+/* let_ref moved to s7_scheme_let.c */
 
-  if (let_id(let) == symbol_id(symbol))
-    return(local_value(symbol)); /* this has to follow the rootlet check(?) */
+/* s7_let_ref moved to s7_scheme_let.c */
 
-  if (is_keyword(symbol))
-    symbol = keyword_symbol(symbol);
-  if (let == sc->rootlet)
-    return((is_slot(global_slot(symbol))) ? global_value(symbol) : sc->undefined);
-
-  for (s7_pointer e = let; e; e = let_outlet(e))
-    for (s7_pointer slot = let_slots(e); is_not_slot_end(slot); slot = next_slot(slot))
-      if (slot_symbol(slot) == symbol)
-	return(slot_value(slot));
-
-  if (is_openlet(let))
-    {
-      /* If a let is a mock-hash-table (for example), implicit indexing of the hash-table collides with the same thing for the let (field names
-       *   versus keys), and we can't just try again here because that makes it too easy to get into infinite recursion.  So, 'let-ref-fallback...
-       */
-      if (has_let_ref_fallback(let))
-	return(call_let_ref_fallback(sc, let, symbol));
-    }
-  return((is_slot(global_slot(symbol))) ? global_value(symbol) : sc->undefined); /* (let () ((curlet) 'pi)) */
-}
-
-s7_pointer s7_let_ref(s7_scheme *sc, s7_pointer let, s7_pointer symbol) {return(let_ref(sc, let, symbol));}
-
-static s7_pointer g_let_ref(s7_scheme *sc, s7_pointer args)
-{
+/* g_let_ref moved to s7_scheme_let.c */
   #define H_let_ref "(let-ref let sym) returns the value of the symbol sym in the let"
   #define Q_let_ref s7_make_signature(sc, 3, sc->T, has_let_signature(sc), sc->is_symbol_symbol)
-  if (!is_pair(cdr(args)))
-    error_nr(sc, sc->syntax_error_symbol,
-	     set_elist_2(sc, wrap_string(sc, "let-ref: symbol missing: ~S", 27), set_ulist_1(sc, sc->let_ref_symbol, args)));
-  return(let_ref(sc, car(args), cadr(args)));
-}
 
-static s7_pointer slot_in_let(s7_scheme *sc, s7_pointer let, const s7_pointer sym)
-{
-  for (s7_pointer slot = let_slots(let); is_not_slot_end(slot); slot = next_slot(slot))
-    if (slot_symbol(slot) == sym)
-      return(slot);
-  return(sc->undefined);
-}
+/* slot_in_let moved to s7_scheme_let.c */
 
-static s7_pointer let_ref_p_pp(s7_scheme *sc, s7_pointer let, s7_pointer sym)
-{
-  if (let_id(let) == symbol_id(sym))
-    return(local_value(sym)); /* see add in tlet! */
-  if (let == sc->rootlet) /* op_implicit_let_ref_c can pass rootlet */
-    return((is_slot(global_slot(sym))) ? global_value(sym) : sc->undefined);
-  for (s7_pointer e = let; e; e = let_outlet(e))
-    for (s7_pointer slot = let_slots(e); is_not_slot_end(slot); slot = next_slot(slot))
-      if (slot_symbol(slot) == sym)
-	return(slot_value(slot));
-  if (has_let_ref_fallback(let))
-    return(call_let_ref_fallback(sc, let, sym));
-  return((is_slot(global_slot(sym))) ? global_value(sym) : sc->undefined);
-}
+/* let_ref_p_pp moved to s7_scheme_let.c */
 
-static inline s7_pointer g_cdr_let_ref(s7_scheme *sc, s7_pointer args)
-{
-  const s7_pointer let = car(args), sym = cadr(args);
-  if (!is_let(let))
-    wrong_type_error_nr(sc, sc->let_ref_symbol, 1, let, a_let_string);
-  if (let_id(let) == symbol_id(sym))
-    return(local_value(sym));
-  if (let == sc->rootlet)
-    return((is_slot(global_slot(sym))) ? global_value(sym) : sc->undefined);
-  for (s7_pointer slot = let_slots(let); is_not_slot_end(slot); slot = next_slot(slot))
-    if (slot_symbol(slot) == sym)
-      return(slot_value(slot));
-  return(let_ref_p_pp(sc, let_outlet(let), sym));
-}
+/* g_cdr_let_ref moved to s7_scheme_let.c */
 
-static s7_pointer starlet(s7_scheme *sc, s7_int choice);
-s7_pointer g_starlet_ref(s7_scheme *sc, s7_pointer args) {return(starlet(sc, starlet_symbol_id(cadr(args))));}
+s7_pointer starlet(s7_scheme *sc, s7_int choice);
+/* g_starlet_ref moved to s7_scheme_let.c */
 
 
-static s7_pointer g_rootlet_ref(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer sym = cadr(args);
-  return((is_slot(global_slot(sym))) ? global_value(sym) : sc->undefined);
-}
+/* g_rootlet_ref moved to s7_scheme_let.c */
 
-static s7_pointer let_ref_chooser(s7_scheme *sc, s7_pointer func, int32_t unused_args, s7_pointer expr)
-{
-  const s7_pointer arg1 = cadr(expr), arg2 = caddr(expr);
-  if ((is_quoted_symbol(sc, arg2)) && (!is_keyword(cadr(arg2))))
-    {
-      if (is_pair(arg1))
-	{
-	  if ((optimize_op(expr) == HOP_SAFE_C_opSq_C) && (car(arg1) == sc->cdr_symbol))
-	    {
-	      set_opt3_sym(cdr(expr), cadr(arg2));
-	      return(sc->cdr_let_ref);
-	    }
-	  if (car(arg1) == sc->rootlet_symbol) return(sc->rootlet_ref);
-	  if (car(arg1) == sc->curlet_symbol) return(sc->curlet_ref);
-	  if (car(arg1) == sc->unlet_symbol)
-	    {
-	      set_fn_direct(arg1, g_unlet_disabled);
-	      return(sc->unlet_ref);
-	    }}
-      if (arg1 == sc->starlet_symbol) return(sc->starlet_ref); /* should *curlet* be added? */
-    }
-  return(func);
-}
+/* let_ref_chooser moved to s7_scheme_let.c */
 
 static bool op_implicit_let_ref_c(s7_scheme *sc)
 {
@@ -10443,224 +9766,32 @@ static s7_pointer fx_implicit_let_ref_c(s7_scheme *sc, s7_pointer arg)
 
 
 /* -------------------------------- let-set! -------------------------------- */
-static s7_pointer let_set_1(s7_scheme *sc, s7_pointer let, s7_pointer symbol, s7_pointer value)
-{
-  if (is_keyword(symbol))
-    symbol = keyword_symbol(symbol);
+/* let_set_1 moved to s7_scheme_let.c */
 
-  if (let == sc->rootlet)
-    {
-      s7_pointer slot;
-      if (is_constant_symbol(sc, symbol))  /* (let-set! (rootlet) 'pi #f) */
-	wrong_type_error_nr(sc, sc->let_set_symbol, 2, symbol, a_non_constant_symbol_string);
-      /* it would be nice if safety>0 to add an error check for bad arity if a built-in method is set (set! (lt 'write) hash-table-set!),
-       *   built_in being (initial_value_is_defined(sc, sym)), but this function is called a ton, and this error can't easily be
-       *   checked by the optimizer (we see the names, but not the values, so bad arity check requires assumptions about those values).
-       */
-      slot = global_slot(symbol);
-      if (!is_slot(slot))
-	error_nr(sc, sc->wrong_type_arg_symbol,
-		 set_elist_3(sc, wrap_string(sc, "let-set!: ~A is not defined in ~A", 33), symbol, let));
-      if (is_syntax(slot_value(slot)))
-	wrong_type_error_nr(sc, sc->let_set_symbol, 2, symbol, wrap_string(sc, "a non-syntactic symbol", 22));
-      if (is_immutable(slot))
-	immutable_object_error_nr(sc, set_elist_2(sc, wrap_string(sc, "~S is immutable in (rootlet)", 28), symbol)); /* also (set! (with-let...)...) */
-      symbol_increment_ctr(symbol);
-      slot_set_value(slot, (slot_has_setter(slot)) ? call_setter(sc, slot, value) : value);
-      return(slot_value(slot));
-    }
-  if (is_unlet(let))
-    immutable_object_error_nr(sc, set_elist_2(sc, wrap_string(sc, "~S is immutable in (unlet)", 26), symbol));
-  if (let_id(let) == symbol_id(symbol))
-   {
-     s7_pointer slot = local_slot(symbol);
-     if (is_slot(slot))
-       {
-	 symbol_increment_ctr(symbol);
-	 return(checked_slot_set_value(sc, slot, value));
-       }}
-  for (s7_pointer e = let; e; e = let_outlet(e))
-    for (s7_pointer slot = let_slots(e); is_not_slot_end(slot); slot = next_slot(slot))
-      if (slot_symbol(slot) == symbol)
-	{
-	  symbol_increment_ctr(symbol);
-	  return(checked_slot_set_value(sc, slot, value));
-	}
-  if (!has_let_set_fallback(let))
-    error_nr(sc, sc->wrong_type_arg_symbol,
-	     set_elist_3(sc, wrap_string(sc, "let-set!: ~A is not defined in ~A", 33), symbol, let));
-  /* not sure about this -- what's the most useful choice? */
-  return(call_let_set_fallback(sc, let, symbol, value));
-}
+/* let_set_2 moved to s7_scheme_let.c */
 
-static s7_pointer let_set_2(s7_scheme *sc, s7_pointer let, s7_pointer symbol, s7_pointer value)
-{
-  if (!is_let(let))
-    {
-      s7_pointer new_let = find_let(sc, let);
-      if (!is_let(new_let))
-	find_let_error_nr(sc, sc->let_set_symbol, let, new_let, 1, set_plist_3(sc, let, symbol, value));
-      let = new_let;
-    }
-  if (!is_symbol(symbol))
-    {
-      if ((let != sc->rootlet) && (has_let_set_fallback(let)))
-	return(call_let_set_fallback(sc, let, symbol, value));
-      wrong_type_error_nr(sc, sc->let_set_symbol, 2, symbol, a_symbol_string);
-    }
-  /* currently let-set! is immutable, so we don't have to check for a let-set! method (so let_set! is always global) */
-  return(let_set_1(sc, let, symbol, value));
-}
+/* s7_let_set moved to s7_scheme_let.c */
 
-s7_pointer s7_let_set(s7_scheme *sc, s7_pointer let, s7_pointer symbol, s7_pointer value) {return(let_set_2(sc, let, symbol, value));}
-
-static s7_pointer g_let_set(s7_scheme *sc, s7_pointer args)
-{
-  /* (let ((a 1)) (set! ((curlet) 'a) 32) a) */
+/* g_let_set moved to s7_scheme_let.c */
   #define H_let_set "(let-set! let sym val) sets the symbol sym's value in the let to val"
   #define Q_let_set s7_make_signature(sc, 4, sc->T, has_let_signature(sc), sc->is_symbol_symbol, sc->T)
 
-  if (!is_pair(cdr(args))) /* (let ((a 123.0)) (define (f) (set! (let-ref) a)) (catch #t f (lambda args #f)) (f)) */
-    error_nr(sc, sc->wrong_number_of_args_symbol,
-	     set_elist_3(sc, wrap_string(sc, "~S: not enough arguments: ~S", 28), sc->let_set_symbol, sc->code));
+/* let_set_p_ppp_2 moved to s7_scheme_let.c */
 
-  return(let_set_2(sc, car(args), cadr(args), caddr(args)));
-}
-
-static s7_pointer let_set_p_ppp_2(s7_scheme *sc, s7_pointer let, s7_pointer sym, s7_pointer val)
-{
-  if (!is_symbol(sym))
-    wrong_type_error_nr(sc, sc->let_set_symbol, 2, sym, a_symbol_string);
-  return(let_set_1(sc, let, sym, val));
-}
-
-static s7_pointer g_cdr_let_set(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer let = car(args);
-  const s7_pointer sym = cadr(args), val = caddr(args);
-  if (!is_let(let))
-    {
-      s7_pointer new_let = find_let(sc, let);
-      if (!is_let(new_let))
-	find_let_error_nr(sc, sc->let_set_symbol, let, new_let, 1, args);
-      let = new_let;
-    }
-  if (let != sc->rootlet)
-    {
-      for (s7_pointer e = let; e; e = let_outlet(e))
-	for (s7_pointer slot = let_slots(e); is_not_slot_end(slot); slot = next_slot(slot))
-	  if (slot_symbol(slot) == sym)
-	    {
-	      slot_set_value(slot, (slot_has_setter(slot)) ? call_setter(sc, slot, val) : val);
-	      return(slot_value(slot));
-	    }
-      if ((let != sc->rootlet) && (has_let_set_fallback(let)))
-	return(call_let_set_fallback(sc, let, sym, val));
-    }
-  {
-    s7_pointer slot = global_slot(sym);
-    if (!is_slot(slot))
-      error_nr(sc, sc->wrong_type_arg_symbol, set_elist_3(sc, wrap_string(sc, "let-set!: ~A is not defined in ~A", 33), sym, let));
-    slot_set_value(slot, (slot_has_setter(slot)) ? call_setter(sc, slot, val) : val);
-    return(slot_value(slot));
-  }
-}
+/* g_cdr_let_set moved to s7_scheme_let.c */
 
 s7_pointer starlet_set_1(s7_scheme *sc, s7_pointer sym, s7_pointer val);
 
-static s7_pointer g_starlet_set(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer sym = cadr(args);
-  if (!is_symbol(sym)) /* (let () (define (func) (let-set! *s7* '(1 . 2) (hash-table))) (func) (func)) */
-    error_nr(sc, sc->wrong_type_arg_symbol,
-	     set_elist_3(sc, wrap_string(sc, "(let-set! *s7* ~A ...) second argument is ~A but should be a symbol", 67),
-			 sym, object_type_name(sc, sym)));
-  if (is_keyword(sym))
-    sym = keyword_symbol(sym);
-  if (starlet_symbol_id(sym) == sl_no_field)
-    error_nr(sc, sc->out_of_range_symbol, set_elist_2(sc, wrap_string(sc, "can't set (*s7* '~S); no such field in *s7*", 43), sym));
-  return(starlet_set_1(sc, sym, caddr(args)));
-}
+/* g_starlet_set moved to s7_scheme_let.c */
 
-static s7_pointer g_unlet_set(s7_scheme *sc, s7_pointer args)
-{
-  immutable_object_error_nr(sc, set_elist_2(sc, wrap_string(sc, "~S is immutable in (unlet)", 26), cadr(args)));
-  return(sc->F);
-}
+/* g_unlet_set moved to s7_scheme_let.c */
 
-static s7_pointer let_set_chooser(s7_scheme *sc, s7_pointer func, int32_t unused_args, s7_pointer expr)
-{
-  const s7_pointer arg1 = cadr(expr);
-  if (optimize_op(expr) == HOP_SAFE_C_opSq_CS)
-    {
-      const s7_pointer arg2 = caddr(expr), arg3 = cadddr(expr);
-      if ((car(arg1) == sc->cdr_symbol) &&
-	  (is_quoted_symbol(sc, arg2)) &&
-	  (!is_possibly_constant(cadr(arg2))) && /* assumes T_Sym */
-	  (!is_possibly_constant(arg3)))
-	return(sc->cdr_let_set);
-      if (car(arg1) == sc->unlet_symbol)
-	{
-	  set_fn_direct(arg1, g_unlet_disabled);
-	  return(sc->unlet_set);
-	}}
-  if (arg1 == sc->starlet_symbol) return(sc->starlet_set);
-  return(func);
-}
+/* let_set_chooser moved to s7_scheme_let.c */
 
 
-static s7_pointer reverse_slots(s7_pointer let_slots)
-{
-  s7_pointer slot = let_slots, result = slot_end;
-  while (is_not_slot_end(slot))
-    {
-      s7_pointer nextslot = next_slot(slot);
-      slot_set_next(slot, result);
-      result = slot;
-      slot = nextslot;
-    }
-  return(result);
-}
+/* reverse_slots moved to s7_scheme_let.c */
 
-static s7_pointer let_copy(s7_scheme *sc, s7_pointer let)
-{
-  s7_pointer new_let;
-  if (T_Let(let) == sc->rootlet)   /* (copy (rootlet)) or (copy (funclet abs)) etc */
-    return(sc->rootlet);
-  /* we can't make copy handle lets-as-objects specially because the make-object function in define-class uses copy to make a new object!
-   *   So if it is present, we get it here, and then there's almost surely trouble.
-   */
-  new_let = make_let(sc, let_outlet(let));
-  set_all_methods(new_let, let);
-  begin_temp(sc->x, new_let);
-  if (is_not_slot_end(let_slots(let)))
-    {
-      const s7_int id = let_id(new_let);
-      for (s7_pointer last_slot = NULL, slot = let_slots(let); is_not_slot_end(slot); slot = next_slot(slot))
-	{
-	  s7_pointer new_slot;
-	  new_cell(sc, new_slot, T_SLOT);
-	  slot_set_symbol_and_value(new_slot, slot_symbol(slot), slot_value(slot));
-	  if (symbol_id(slot_symbol(new_slot)) != id) /* keep shadowing intact */
-	    symbol_set_local_slot(slot_symbol(slot), id, new_slot);
-	  if (slot_has_setter(slot))
-	    {
-	      slot_set_setter(new_slot, slot_setter(slot));
-	      slot_set_has_setter(new_slot);
-	    }
-	  if (last_slot)
-	    slot_set_next(last_slot, new_slot);
-	  else let_set_slots(new_let, new_slot);
-	  slot_set_next(new_slot, slot_end);        /* in case GC runs during this loop */
-	  last_slot = new_slot;
-	}}
-  /* We can't do a (normal) loop here then reverse the slots later because the symbol's local_slot has to
-   *    match the unshadowed slot, not the last in the list:
-   *    (let ((e1 (inlet 'a 1 'a 2))) (let ((e2 (copy e1))) (list (equal? e1 e2) (equal? (e1 'a) (e2 'a)))))
-   */
-  end_temp(sc->x);
-  return(new_let);
-}
+/* let_copy moved to s7_scheme_let.c */
 
 
 /* -------------------------------- rootlet -------------------------------- */
@@ -10668,124 +9799,43 @@ static s7_pointer let_copy(s7_scheme *sc, s7_pointer let)
   #define H_rootlet "(rootlet) returns the current top-level definitions (symbol bindings)."
   #define Q_rootlet s7_make_signature(sc, 1, sc->is_let_symbol)
 
-s7_pointer s7_rootlet(s7_scheme *sc) {return(sc->rootlet);}
+/* s7_rootlet moved to s7_scheme_let.c */
 
 /* shadow_rootlet is a convenience for foreign function writers -- the C code can act as if it were loading everything into rootlet,
  *   but when actually loaded, everything can be shunted into a separate namespace (*motif* for example).
  */
-s7_pointer s7_shadow_rootlet(s7_scheme *sc) {return(sc->shadow_rootlet);}
+/* s7_shadow_rootlet moved to s7_scheme_let.c */
 
-s7_pointer s7_set_shadow_rootlet(s7_scheme *sc, s7_pointer let)
-{
-  s7_pointer old_let = sc->shadow_rootlet;
-  sc->shadow_rootlet = let;
-  return(old_let); /* like s7_set_curlet below */
-}
+/* s7_set_shadow_rootlet moved to s7_scheme_let.c */
 
 
 /* -------------------------------- curlet -------------------------------- */
-s7_pointer s7_curlet(s7_scheme *sc) /* see also fx_curlet */
-{
-  sc->capture_let_counter++;
-  return(sc->curlet);
-}
+/* s7_curlet moved to s7_scheme_let.c */
 
 /* g_curlet is now defined in s7_scheme_predicate.c */
 #define H_curlet "(curlet) returns the current definitions (symbol bindings)"
 #define Q_curlet s7_make_signature(sc, 1, sc->is_let_symbol)
 
-static void update_symbol_ids(s7_scheme *sc, s7_pointer let)
-{
-  for (s7_pointer slot = let_slots(let); is_not_slot_end(slot); slot = next_slot(slot))
-    {
-      s7_pointer sym = slot_symbol(slot);
-      if (symbol_id(sym) != sc->let_number)
-	symbol_set_local_slot_unincremented(sym, sc->let_number, slot);
-    }
-}
+/* update_symbol_ids moved to s7_scheme_let.c */
 
-s7_pointer s7_set_curlet(s7_scheme *sc, s7_pointer let)
-{
-  const s7_pointer old_let = sc->curlet;
-  if (is_let(let))
-    {
-      set_curlet(sc, let);
-      if (let_id(let) > 0)
-	{
-	  let_set_id(let, ++sc->let_number);
-	  update_symbol_ids(sc, let);
-	}}
-  return(old_let);
-}
+/* s7_set_curlet moved to s7_scheme_let.c */
 
 
 /* -------------------------------- outlet -------------------------------- */
-s7_pointer s7_outlet(s7_scheme *sc, s7_pointer let) {return(let_outlet(let));}
+/* s7_outlet moved to s7_scheme_let.c */
 
-static s7_pointer outlet_p_p(s7_scheme *sc, s7_pointer let)
-{
-  if (!is_let(let))
-    {
-      s7_pointer new_let = find_let(sc, let);
-      if (!is_let(new_let))
-	find_let_error_nr(sc, sc->outlet_symbol, let, new_let, 1, set_mlist_1(sc, let));
-      let = new_let;
-    }
-  return((let == sc->rootlet) ? sc->rootlet : let_outlet(let)); /* rootlet check is needed(!) */
-}
+/* outlet_p_p moved to s7_scheme_let.c */
 
 /* g_outlet_unlet migrated to s7_scheme_predicate.c */
 
-s7_pointer s7i_outlet_p_p(s7_scheme *sc, s7_pointer let) {return(outlet_p_p(sc, let));}
+/* s7i_outlet_p_p moved to s7_scheme_let.c */
 
 #define H_outlet "(outlet let) is the environment that contains let."
 #define Q_outlet s7_make_signature(sc, 2, sc->is_let_symbol, has_let_signature(sc))
 
-static s7_pointer outlet_chooser(s7_scheme *sc, s7_pointer func, int32_t num_args, s7_pointer expr)
-{
-  if ((num_args == 1) && (is_pair(cadr(expr))) && (caadr(expr) == sc->unlet_symbol))
-    {
-      set_fn_direct(cadr(expr), g_unlet_disabled);
-      return(sc->outlet_unlet);
-    }
-  return(func);
-}
+/* outlet_chooser moved to s7_scheme_let.c */
 
-static s7_pointer g_set_outlet(s7_scheme *sc, s7_pointer args)
-{
-  /* (let ((a 1)) (let ((b 2)) (set! (outlet (curlet)) (rootlet)) ((curlet) 'a))) */
-  s7_pointer let = car(args), new_outer;
-
-  if (!is_let(let))
-    {
-      s7_pointer new_let = find_let(sc, let);
-      if (!is_let(new_let))
-	find_let_error_nr(sc, wrap_string(sc, "set! outlet", 11), let, new_let, 1, args);
-      let = new_let;
-    }
-  if (let == sc->starlet)
-    error_nr(sc, sc->out_of_range_symbol, set_elist_1(sc, wrap_string(sc, "can't set! (outlet *s7*)", 24)));
-  if (is_immutable_let(let))
-    immutable_object_error_nr(sc, set_elist_4(sc, wrap_string(sc, "can't (set! (outlet ~S) ~S), ~S is immutable", 44), let, cadr(args), let));
-  new_outer = cadr(args);
-  if (!is_let(new_outer))
-    {
-      s7_pointer new_let = find_let(sc, new_outer);
-      if (!is_let(new_let))
-	find_let_error_nr(sc, wrap_string(sc, "set! outlet", 11), new_outer, new_let, 2, args);
-      new_outer = new_let;
-    }
-  if (let != sc->rootlet)
-    {
-      /* here it's possible to get cyclic let chains; maybe do this check only if safety>0 */
-      for (s7_pointer new_let = new_outer; new_let; new_let = let_outlet(new_let))
-	if (let == new_let)
-	  error_nr(sc, make_symbol(sc, "cyclic-let", 10),
-		   set_elist_2(sc, wrap_string(sc, "set! (outlet ~A) creates a cyclic let chain", 43), let));
-      let_set_outlet(let, new_outer);
-    }
-  return(new_outer);
-}
+/* g_set_outlet moved to s7_scheme_let.c */
 
 /* -------------------------------- symbol lookup -------------------------------- */
 static Inline s7_pointer inline_lookup_from(s7_scheme *sc, const s7_pointer symbol, s7_pointer let)
@@ -10851,7 +9901,7 @@ s7_pointer s7_slot_set_value(s7_scheme *sc, s7_pointer slot, s7_pointer value) {
 
 void s7_slot_set_real_value(s7_scheme *sc, s7_pointer slot, s7_double value) {set_real(slot_value(slot), value);}
 
-static s7_pointer symbol_to_local_slot(s7_scheme *sc, s7_pointer symbol, s7_pointer let) /* assumes e is a let */
+s7_pointer symbol_to_local_slot(s7_scheme *sc, s7_pointer symbol, s7_pointer let) /* assumes e is a let */
 {
   if (T_Let(let) == sc->rootlet)
     return(global_slot(symbol));
@@ -10895,39 +9945,10 @@ s7_pointer s7_symbol_local_value(s7_scheme *sc, s7_pointer sym, s7_pointer let)
 /* -------------------------------- symbol->value -------------------------------- */
 #define lookup_global(Sc, Sym) ((is_defined_global(Sym)) ? global_value(Sym) : lookup_checked(Sc, Sym))
 
-static s7_pointer g_symbol_to_value(s7_scheme *sc, s7_pointer args)
-{
+/* g_symbol_to_value moved to s7_scheme_let.c */
   #define H_symbol_to_value "(symbol->value sym (let (curlet))) returns the binding of (the value associated with) the \
 symbol sym in the given let: (let ((x 32)) (symbol->value 'x)) -> 32"
   #define Q_symbol_to_value s7_make_signature(sc, 3, sc->T, sc->is_symbol_symbol, has_let_signature(sc))
-
-  const s7_pointer sym = car(args);
-  if (!is_symbol(sym))
-    return(method_or_bust(sc, sym, sc->symbol_to_value_symbol, args, sc->type_names[T_SYMBOL], 1));
-  if (is_keyword(sym))
-    {
-      if ((is_pair(cdr(args))) && (!is_let(cadr(args))) && (!is_let(find_let(sc, cadr(args)))))
-	wrong_type_error_nr(sc, sc->symbol_to_value_symbol, 2, cadr(args), sc->type_names[T_LET]);
-      return(sym);
-    }
-  if (is_pair(cdr(args)))
-    {
-      s7_pointer local_let = cadr(args);
-      if (!is_let(local_let))
-	{
-	  local_let = find_let(sc, local_let);
-	  if (!is_let(local_let))
-	    return(method_or_bust(sc, cadr(args), sc->symbol_to_value_symbol, args, a_let_string, 2)); /* not local_let */
-	}
-      if (local_let == sc->rootlet) return((is_slot(global_slot(sym))) ? global_value(sym) : sc->undefined);
-      if (is_unlet(local_let)) return(initial_value(sym));
-      if (local_let == sc->starlet) return(starlet(sc, starlet_symbol_id(sym)));
-      return(s7_symbol_local_value(sc, sym, local_let));
-    }
-  if (is_defined_global(sym))
-    return(global_value(sym));
-  return(s7_symbol_value(sc, sym));
-}
 
 s7_pointer s7_symbol_set_value(s7_scheme *sc, s7_pointer sym, s7_pointer val)
 {
@@ -10938,72 +9959,15 @@ s7_pointer s7_symbol_set_value(s7_scheme *sc, s7_pointer sym, s7_pointer val)
 }
 
 
-
-static s7_pointer symbol_to_value_chooser(s7_scheme *sc, s7_pointer func, int32_t unused_args, s7_pointer expr)
-{
-  s7_pointer arg1 = cadr(expr), arg2 = (is_pair(cddr(expr))) ? caddr(expr) : sc->F;
-  if ((is_quoted_symbol(sc, arg1)) && (!is_keyword(cadr(arg1))) && (is_pair(arg2)) && (car(arg2) == sc->unlet_symbol)) /* old-style (obsolete) unlet as third arg(!) */
-    {
-      set_fn_direct(arg2, g_unlet_disabled);
-      return(sc->sv_unlet_ref);
-    }
-  return(func);
-}
+/* symbol_to_value_chooser moved to s7_scheme_let.c */
 
 
 /* -------------------------------- symbol->dynamic-value -------------------------------- */
-static s7_pointer find_dynamic_value(s7_scheme *sc, s7_pointer let, s7_pointer sym, s7_int *id)
-{
-  for (; let_id(let) > symbol_id(sym); let = let_outlet(let));
-  if (let_id(let) == symbol_id(sym))
-    {
-      (*id) = let_id(let);
-      return(local_value(sym));
-    }
-  for (; (let) && (let_id(let) > (*id)); let = let_outlet(let))
-    for (s7_pointer slot = let_slots(let); is_not_slot_end(slot); slot = next_slot(slot))
-      if (slot_symbol(slot) == sym)
-	{
-	  (*id) = let_id(let);
-	  return(slot_value(slot));
-	}
-  return(sc->unused);
-}
+/* find_dynamic_value moved to s7_scheme_let.c */
 
-static s7_pointer g_symbol_to_dynamic_value(s7_scheme *sc, s7_pointer args)
-{
+/* g_symbol_to_dynamic_value moved to s7_scheme_let.c */
   #define H_symbol_to_dynamic_value "(symbol->dynamic-value sym) returns the dynamic binding of the symbol sym"
   #define Q_symbol_to_dynamic_value s7_make_signature(sc, 2, sc->T, sc->is_symbol_symbol)
-
-  const s7_pointer sym = car(args);
-  s7_pointer val;
-  s7_int top_id = -1;
-
-  if (!is_symbol(sym))
-    return(method_or_bust(sc, sym, sc->symbol_to_dynamic_value_symbol, args, sc->type_names[T_SYMBOL], 1));
-
-  if (is_defined_global(sym))
-    return(global_value(sym));
-
-  if (let_id(sc->curlet) == symbol_id(sym))
-    return(local_value(sym));
-
-  val = find_dynamic_value(sc, sc->curlet, sym, &top_id);
-  if (top_id == symbol_id(sym))
-    return(val);
-
-  for (s7_int op_loc = stack_top(sc) - 1; op_loc > 0; op_loc -= 4)
-    if (is_let_unchecked(stack_let(sc->stack, op_loc))) /* OP_GC_PROTECT let slot can be anything (even free) */
-      {
-	s7_pointer cur_val = find_dynamic_value(sc, stack_let(sc->stack, op_loc), sym, &top_id);
-	if (cur_val != sc->unused)
-	  val = cur_val;
-	if (top_id == symbol_id(sym))
-	  return(val);
-      }
-  /* what about call/cc stacks? */
-  return((val == sc->unused) ? s7_symbol_value(sc, sym) : val);
-}
 
 static bool direct_memq(const s7_pointer symbol, s7_pointer symbols)
 {
@@ -11468,57 +10432,10 @@ static s7_pointer copy_closure(s7_scheme *sc, s7_pointer fnc)
 
 
 /* -------------------------------- defined? -------------------------------- */
-static s7_pointer g_is_defined(s7_scheme *sc, s7_pointer args)
-{
+/* g_is_defined moved to s7_scheme_let.c */
   #define H_is_defined "(defined? symbol (let (curlet)) ignore-globals) returns #t if symbol has a binding (a value) in the let. \
 Only the let is searched if ignore-globals is #t."
   #define Q_is_defined s7_make_signature(sc, 4, sc->is_boolean_symbol, sc->is_symbol_symbol, has_let_signature(sc), sc->is_boolean_symbol)
-  /* if the symbol has a global slot and e is unset or rootlet, this returns #t */
-
-  s7_pointer sym = car(args);
-  if (!is_symbol(sym))
-    return(method_or_bust(sc, sym, sc->is_defined_symbol, args, sc->type_names[T_SYMBOL], 1));
-
-  if (is_pair(cdr(args)))
-    {
-      s7_pointer let = cadr(args);
-      const s7_pointer ignore_globals = (is_pair(cddr(args))) ? caddr(args) : sc->F;
-      if (!is_let(let))
-	{
-	  const s7_pointer new_let = find_let(sc, let);  /* returns () if none */
-	  if (!is_let(new_let))
-	    find_let_error_nr(sc, sc->is_defined_symbol, let, new_let, 2, args);
-	  if ((new_let == sc->rootlet) && (is_pair(cddr(args))) && (ignore_globals != sc->F))
-	    {
-	      if (ignore_globals != sc->T) /* signature claims this should be a boolean */
-		return(method_or_bust(sc, ignore_globals, sc->is_defined_symbol, args, a_boolean_string, 3));
-	      return(sc->F);
-	    }
-	  let = new_let;
-	}
-      /* if (is_unlet(let)) return(make_boolean(sc, initial_value_is_defined(sc, sym))); */
-      /* this ^ is wrong: (with-let (unlet) (define xx 1) (list (defined? 'xx) (defined? 'xx (curlet)))) should be (#t #t) */
-
-      if (is_keyword(sym))                       /* if no "let", is global -> #t */
-	{                                        /* we're treating :x as 'x outside rootlet, but consider all keywords defined (as themselves) in rootlet? */
-	  if (let == sc->rootlet) return(sc->T); /* (defined? x (rootlet)) where x value is a keyword */
-	  sym = keyword_symbol(sym);             /* (defined? :print-length *s7*) */
-	}
-      if (let == sc->starlet)
-	return(make_boolean(sc, starlet_symbol_id(sym) != sl_no_field));
-      if (!is_boolean(ignore_globals))
-	return(method_or_bust(sc, ignore_globals, sc->is_defined_symbol, args, a_boolean_string, 3));
-      if (let == sc->rootlet) /* we checked (let? let) above */
-	{
-	  if (ignore_globals == sc->F)
-	    return(make_boolean(sc, is_slot(global_slot(sym)))); /* new_symbol and gensym initialize global_slot to #<undefined> */
-	  return(sc->F);
-	}
-      if (is_slot(symbol_to_local_slot(sc, sym, T_Let(let)))) return(sc->T);
-      return((ignore_globals == sc->T) ? sc->F : make_boolean(sc, is_slot(global_slot(sym))));
-    }
-  return((is_defined_global(sym)) ? sc->T : make_boolean(sc, is_bound_symbol(sc, sym)));
-}
 
 static s7_pointer is_defined_chooser(s7_scheme *sc, s7_pointer func, int32_t args, s7_pointer expr)
 {
@@ -11832,7 +10749,6 @@ void symbol_to_port(s7_scheme *sc, s7_pointer obj, s7_pointer port, use_write_t 
 s7_pointer b_simple_setter(s7_scheme *sc, int32_t typer, s7_pointer args);
 
 #include "s7_continuation.h"
-
 
 
 /* -------------------------------- numbers -------------------------------- */
@@ -12452,7 +11368,6 @@ static inline double dpow(int32_t x, int32_t y)
     return(pow((double)x, (double)y));
   return(pepow[x][y + MAX_POW]);
 }
-
 
 
 /* dtoa (Grisu2 double-to-ASCII) is now in s7_dtoa.c */
@@ -13948,11 +12863,7 @@ the optional 'radix' argument is ignored: (string->number \"#x11\" 2) -> 17 not 
 /* g_string_to_number is now defined in s7_liii_string.c */
 
 
-
-
 /* (abs|magnitude -9223372036854775808) won't work here */
-
-
 
 
 /* -------------------------------- inexact helpers -------------------------------- */
@@ -13971,9 +12882,6 @@ static s7_pointer log_chooser(s7_scheme *sc, s7_pointer func, int32_t args, s7_p
     }
   return(func);
 }
-
-
-
 
 
 /* ---------------------------------------- add ---------------------------------------- */
@@ -17084,14 +15992,6 @@ static bool is_negative(s7_scheme *sc, s7_pointer x)
 /* ---------------------------------------- exact<->inexact exact? inexact? ---------------------------------------- */
 
 
-
-
-
-
-
-
-
-
 /* ---------------------------------------- integer-length ---------------------------------------- */
 static int32_t integer_length(s7_int a)
 {
@@ -19471,8 +18371,6 @@ static void function_write_string(s7_scheme *sc, const char *str, s7_int len, s7
 
 static void stdout_display(s7_scheme *sc, const char *str, s7_pointer port) {if (str) fputs(str, stdout);}
 static void stderr_display(s7_scheme *sc, const char *str, s7_pointer port) {if (str) fputs(str, stderr);}
-
-
 
 
 /* -------- skip to newline readers -------- */
@@ -25531,7 +24429,6 @@ static void number_to_port(s7_scheme *sc, s7_pointer num, s7_pointer port, use_w
 }
 
 
-
 static void syntax_to_port(s7_scheme *sc, s7_pointer obj, s7_pointer port, use_write_t unused_use_write, shared_info_t *unused_ci)
 {
   if (is_initial_value(obj))
@@ -30651,7 +29548,7 @@ static s7_pointer reverse_in_place_unchecked(s7_scheme *sc, s7_pointer term, s7_
   return(result);
 }
 
-static s7_pointer proper_list_reverse_in_place(s7_scheme *sc, s7_pointer list)
+s7_pointer proper_list_reverse_in_place(s7_scheme *sc, s7_pointer list)
 {
   return(reverse_in_place_unchecked(sc, sc->nil, list));
 }
@@ -32963,7 +31860,6 @@ static hash_entry_t *hash_char(s7_scheme *sc, s7_pointer table, s7_pointer key)
 }
 
 
-
 /* ---------------- hash strings ---------------- */
 static s7_uint hash_map_string(s7_scheme *sc, s7_pointer table, s7_pointer key)
 {
@@ -34553,7 +33449,7 @@ static s7_pointer procedure_type_to_symbol(s7_scheme *sc, int32_t type)
   return(sc->lambda_symbol);
 }
 
-static s7_pointer g_procedure_source(s7_scheme *sc, s7_pointer args)
+s7_pointer g_procedure_source(s7_scheme *sc, s7_pointer args)
 {
   #define H_procedure_source "(procedure-source func) tries to return the definition of func"
   #define Q_procedure_source s7_make_signature(sc, 2, sc->is_list_symbol, s7_make_signature(sc, 2, sc->is_procedure_symbol, sc->is_macro_symbol))
@@ -34663,23 +33559,10 @@ and 'arglist. (define (func x y) (*function* (curlet) 'arglist)) (func 1 2): '(x
 /* -------------------------------- funclet -------------------------------- */
 s7_pointer s7_funclet(s7_scheme *sc, s7_pointer func) {return((has_closure_let(func)) ? closure_let(func) : sc->rootlet);} /* c_function_let(func)?? */
 
-static s7_pointer g_funclet(s7_scheme *sc, s7_pointer args)
-{
+/* g_funclet moved to s7_scheme_let.c */
   #define H_funclet "(funclet func) tries to return a function's definition environment"
   #define Q_funclet s7_make_signature(sc, 2, s7_make_signature(sc, 2, sc->is_let_symbol, sc->is_null_symbol), \
 				      s7_make_signature(sc, 3, sc->is_procedure_symbol, sc->is_macro_symbol, sc->is_symbol_symbol))
-  s7_pointer func = car(args);
-  if (is_symbol(func))
-    {
-      if ((func = s7_symbol_value(sc, func)) == sc->undefined)
-	error_nr(sc, sc->wrong_type_arg_symbol,
-		 set_elist_2(sc, wrap_string(sc, "funclet argument, '~S, is unbound", 33), car(args))); /* not func here */
-    }
-  if_method_exists_return_value(sc, func, sc->funclet_symbol, args);
-  if (!((is_any_procedure(func)) || (is_c_object(func))))
-    sole_arg_wrong_type_error_nr(sc, sc->funclet_symbol, func, a_procedure_or_a_macro_string);
-  return(find_let(sc, func));
-}
 
 
 /* -------------------------------- s7_define_function and friends --------------------------------
@@ -36313,7 +35196,7 @@ static s7_pointer call_c_function_setter(s7_scheme *sc, s7_pointer func, s7_poin
   return(c_function_call(func)(sc, with_list_t2(sc, symbol, new_value)));
 }
 
-static s7_pointer call_setter(s7_scheme *sc, s7_pointer slot, s7_pointer new_value) /* see also op_set1 */
+s7_pointer call_setter(s7_scheme *sc, s7_pointer slot, s7_pointer new_value) /* see also op_set1 */
 {
   const s7_pointer func = slot_setter(slot);
   if (is_c_function(func))
@@ -39167,7 +38050,6 @@ s7_pointer s7_append(s7_scheme *sc, s7_pointer a, s7_pointer b)
 }
 
 
-
 static s7_pointer append_chooser(s7_scheme *sc, s7_pointer func, int32_t args, s7_pointer unused_expr)
 {
   if (args == 2) return(sc->append_2);
@@ -40666,7 +39548,7 @@ static s7_pointer init_owlet(s7_scheme *sc)
 }
 
 #if WITH_HISTORY
-static s7_pointer sanitize_history(s7_scheme *sc, s7_pointer code)
+s7_pointer sanitize_history(s7_scheme *sc, s7_pointer code)
 {
   begin_small_symbol_set(sc); /* make a list of words banned from the history */
   add_symbol_to_small_symbol_set(sc, sc->starlet_symbol);
@@ -40687,8 +39569,7 @@ static s7_pointer sanitize_history(s7_scheme *sc, s7_pointer code)
 }
 #endif
 
-static s7_pointer g_owlet(s7_scheme *sc, s7_pointer args)
-{
+/* g_owlet moved to s7_scheme_let.c */
 #if WITH_HISTORY
   #define H_owlet "(owlet) returns the environment at the point of the last error. \
 It has the additional local variables: error-type, error-data, error-code, error-line, error-file, and error-history."
@@ -40697,49 +39578,6 @@ It has the additional local variables: error-type, error-data, error-code, error
 It has the additional local variables: error-type, error-data, error-code, error-line, and error-file."
 #endif
   #define Q_owlet s7_make_signature(sc, 1, sc->is_let_symbol)
-  /* if owlet is not copied, (define e (owlet)), e changes as owlet does! */
-
-  s7_pointer let;
-  const bool old_gc = sc->gc_off;
-  if (is_pair(args))
-    error_nr(sc, sc->wrong_number_of_args_symbol, set_elist_3(sc, too_many_arguments_string, sc->owlet_symbol, args));
-#if WITH_HISTORY
-  slot_set_value(sc->error_history, sanitize_history(sc, slot_value(sc->error_history)));
-#endif
-  let = let_copy(sc, sc->owlet);
-  gc_protect_via_stack(sc, let);
-
-  /* make sure the pairs/reals/strings/integers are copied: should be error-data, error-code, and error-history */
-  sc->gc_off = true;
-  for (s7_pointer slot = let_slots(let); is_not_slot_end(slot); slot = next_slot(slot))
-    if (is_pair(slot_value(slot)))
-      {
-	const s7_pointer new_list = copy_any_list(sc, slot_value(slot));
-	slot_set_value(slot, new_list);
-	for (s7_pointer p = new_list, sp = p; is_pair(p); p = cdr(p), sp = cdr(sp))
-	  {
-	    s7_pointer val = car(p);
-	    if (is_t_real(val))
-	      set_car(p, make_real(sc, real(val)));
-	    else
-	      if (is_string(val))
-		set_car(p, make_string_with_length(sc, string_value(val), string_length(val)));
-	      else
-		if (is_t_integer(val))
-		  set_car(p, make_integer(sc, integer(val)));
-	    p = cdr(p);
-	    if ((!is_pair(p)) || (p == sp)) break;
-	    val = car(p);
-	    if (is_t_real(val))
-	      set_car(p, make_real(sc, real(val)));
-	    else
-	      if (is_string(val))
-		set_car(p, make_string_with_length(sc, string_value(val), string_length(val)));
-	  }}
-  sc->gc_off = old_gc;
-  unstack_gc_protect(sc);
-  return(let);
-}
 
 
 /* -------- catch handlers -------- (don't free the catcher) */
@@ -84327,7 +83165,7 @@ static s7_pointer sl_gc_protected_objects_to_list(s7_scheme *sc)
   return(nv);
 }
 
-static s7_pointer starlet(s7_scheme *sc, s7_int choice)
+s7_pointer starlet(s7_scheme *sc, s7_int choice)
 {
   switch (choice)
     {
@@ -85792,7 +84630,6 @@ static void init_opt_functions(s7_scheme *sc)
   s7_set_p_p_function(sc, global_value(sc->object_to_let_symbol), object_to_let_p_p);
   s7_set_p_p_function(sc, global_value(sc->outlet_symbol), outlet_p_p);
   s7_set_p_p_function(sc, global_value(sc->make_iterator_symbol), s7_make_iterator);
-
 
 
   s7_set_b_i_function(sc, global_value(sc->is_even_symbol), even_i);
@@ -88210,8 +87047,6 @@ int main(int argc, char **argv)
  *   tree_set_memq et al with #_*? also begin_set* [search is done by hand -- can c_funcs have a tag? what about big_symbol tag]
  *     there's room for int32_t in cell func
  */
-
-
 
 
 /* ========================================== format bridge functions ========================================== */

--- a/src/s7_internal.h
+++ b/src/s7_internal.h
@@ -2248,4 +2248,297 @@ enum {OP_UNOPT, OP_GC_PROTECT, /* must be an even number of ops here, op_gc_prot
 #define is_safe_closure_star_op(op) ((op >= OP_SAFE_CLOSURE_STAR_A) && (op < OP_C_SS))
 #define is_unknown_op(op)           ((op >= OP_UNKNOWN) && (op <= OP_UNKNOWN_NP))
 
+/* ---- macros copied from s7.c for s7_scheme_let.c (keep in sync!) ---- */
+#define caadr(p)                       car(car(cdr(p)))
+#define cadar(p)                       car(cdr(car(p)))
+#define cadddr(p)                      car(cdr(cdr(cdr(p))))
+#define cdar(p)                        cdr(car(p))
+#define clear_has_methods(p)           clear_mid_type_bit(T_Met(p), T_MID_HAS_METHODS)
+#if S7_DEBUGGING
+#define gc_protect_1(Sc, X) gc_protect_2(Sc, X, __LINE__)
+#else
+#define gc_protect_1(Sc, X) s7_gc_protect(Sc, X)
+#endif
+#define gc_protect_via_stack(Sc, Obj) push_stack_no_code(Sc, OP_GC_PROTECT, Obj)
+#define global_slot(p)                 T_Sld((T_Sym(p))->object.sym.global_slot)
+#define global_value(p)                slot_value(global_slot(T_Sym(p)))
+#define has_active_methods(Sc, p)      ((has_mid_type_bit(T_Ext(p), T_MID_HAS_METHODS)) && (Sc->has_openlets)) /* g_char #<eof> */
+#define has_let_fallback(p)            has_mid_type_bit(T_Let(p), (T_MID_HAS_LET_REF_FALLBACK | T_MID_HAS_LET_SET_FALLBACK))
+#define has_let_ref_fallback(p)        ((mid_type(T_Let(p)) & (T_MID_HAS_LET_REF_FALLBACK | T_MID_HAS_METHODS)) == (T_MID_HAS_LET_REF_FALLBACK | T_MID_HAS_METHODS))
+#define has_let_set_fallback(p)        ((mid_type(T_Let(p)) & (T_MID_HAS_LET_SET_FALLBACK | T_MID_HAS_METHODS)) == (T_MID_HAS_LET_SET_FALLBACK | T_MID_HAS_METHODS))
+#define has_methods(p)                 has_mid_type_bit(T_Exs(p), T_MID_HAS_METHODS) /* display slot hits T_Ext here */
+#define if_let_method_exists_return_value(Sc, Let, Method, Args)	\
+  {							\
+    s7_pointer _Func_;					\
+    if ((has_active_methods(Sc, T_Let(Let))) &&				\
+	((_Func_ = find_method(Sc, Let, Method)) != Sc->undefined)) \
+      return(s7_apply_function(Sc, _Func_, Args)); \
+  }
+#define initial_value(p)               symbol_info(p)->ex.ex_ptr
+#define integer(p)                     (T_Int(p))->object.number.integer_value
+#define is_any_procedure(P)            (type(P) >= T_CLOSURE)
+#define is_applicable(P)               (t_applicable_p[type(P)])
+#define is_boolean(p)                  (type(p) == T_BOOLEAN)
+#define is_bound_symbol(Sc, p)         (is_slot(s7_slot(Sc, p))) /* (s7_slot(Sc, p) != Sc->undefined) is the same speed apparently */
+#define is_c_object(p)                 (type(p) == T_C_OBJECT)
+#define is_defined_global(p)           ((is_slot(global_slot(p))) && (symbol_id(p) == 0))
+#define is_global(p)                   (symbol_id(p) == 0)
+#define is_immutable_let(p)            has_mid_type_bit(T_Let(p), T_MID_IMMUTABLE)
+#define is_immutable_slot(p)           has_mid_type_bit(T_Slt(p), T_MID_IMMUTABLE)
+#define is_keyword(p)                  has_high_type_bit(T_Sym(p), T_SHORT_KEYWORD)
+#define is_let(p)                      (type(p) == T_LET)
+#define is_let_unchecked(p)            (type_unchecked(p) == T_LET)
+#if S7_DEBUGGING
+  #define is_not_slot_end(p)           ((p) && (T_Slt(p)))
+#else
+  #define is_not_slot_end(p)           (p) /* used for loop through let slots which end in null, not for general slot recognition */
+#endif
+#define is_openlet(p)                  has_mid_type_bit(T_Let(p), T_MID_HAS_METHODS)
+#define is_possibly_constant(p)        has_high_type_bit(T_Sym(p), T_SYMCONS)
+#define is_quoted_symbol(Sc, p)        ((is_quoted_pair(Sc, p)) && (is_pair(cdr(p))) && (is_symbol(cadr(p))))
+#define is_safe_quoted_pair(Sc, p)     ((is_pair(p)) && (is_safe_quote(Sc, car(p))))
+#define is_quoted_pair(Sc, p)          ((is_pair(p)) && (is_quote(Sc, car(p))))
+#define is_slot(p)                     (type(p) == T_SLOT)
+#define is_string(p)                   (type(p) == T_STRING)
+#define is_symbol_and_keyword(p)       ((is_symbol(p)) && (is_keyword(p)))
+#define is_syntactic_symbol(p)         has_low_type_bit(T_Sym(p), T_SYNTACTIC)
+#define is_syntax(p)                   (type(p) == T_SYNTAX)
+#define is_syntax_or_qq(p)	       ((is_syntax(p)) || ((p) == sc->quasiquote_function)) /* qq is from s7_define_macro -> T_C_MACRO */
+#define is_t_integer(p)                (type(p) == T_INTEGER)
+#define is_t_real(p)                   (type(p) == T_REAL)
+#define is_unlet(p)                    has_high_type_bit(T_Let(p), T_UNLET)
+#define iterator_carrier(p)            (T_Itr(p))->object.iter.cur
+#define iterator_is_at_end(p)          (!iter_ok(p))                /* ((full_type(T_Itr(p)) & T_ITER_OK) == 0) */
+#define keyword_symbol(p)              symbol_info(T_Key(p))->nx.ksym        /* keyword only, so does not collide with documentation */
+#define let_id(p)                      (T_Let(p))->object.let.id
+#if S7_DEBUGGING
+  #define let_set_id(p, Id)            do {(T_Let(p))->object.let.id = Id; if ((p == sc->rootlet) && (Id != -1)) {fprintf(stderr, "%s[%d]: rootlet id: %" ld64 "\n", __func__, __LINE__, (s7_int)Id); if (sc->stop_at_error) abort();}} while (0)
+#else
+  #define let_set_id(p, Id)            (T_Let(p))->object.let.id = Id
+#endif
+#define let_set_outlet(p, ol)          (T_Let(p))->object.let.nxt = T_Out(ol)
+#if S7_DEBUGGING
+  #define let_set_slots(p, Slot)       check_let_set_slots(sc, p, Slot, __func__, __LINE__)
+#else
+  #define let_set_slots(p, Slot)       (T_Let(p))->object.let.slots = T_Sln(Slot)
+#endif
+#define let_slots(p)                   T_Sln((T_Let(p))->object.let.slots)
+#define local_slot(p)                  T_Slt((T_Sym(p))->object.sym.local_slot)        /* was T_Sld 1-Aug-25 */
+#define local_value(p)                 slot_value(local_slot(T_Sym(p)))
+  #define make_boolean(Sc, Val)        ((Val) ? Sc->T : Sc->F)
+/* make_integer/make_real fast paths depend on s7.c's static small_ints array;
+ * s7_scheme_let.c defines them as s7_make_integer/s7_make_real wrappers. */
+#define next_slot(p)                   T_Sln((T_Slt(p))->object.slt.nxt)
+#define optimize_op(P)                 (T_Ext(P))->tf.bits.opt_bits
+#if S7_DEBUGGING
+#define push_stack_no_let(Sc, Op, Args, Code)   push_stack(Sc, Op, Args, Code)
+#else
+#define push_stack_no_let(Sc, Op, Args, Code) \
+  do { \
+      stack_end_code(Sc) = Code; \
+      stack_end_args(Sc) = Args; \
+      stack_end_op(Sc) = (s7_pointer)(opcode_t)(Op); \
+      Sc->stack_end += 4; \
+  } while (0)
+#endif
+#if S7_DEBUGGING
+#define push_stack_no_code(Sc, Op, Args)        push_stack(Sc, Op, Args, Sc->unused)
+#else
+#define push_stack_no_code(Sc, Op, Args) \
+  do { \
+      stack_end_let(Sc) = Sc->curlet; \
+      stack_end_args(Sc) = Args; \
+      stack_end_op(Sc) = (s7_pointer)(opcode_t)(Op); \
+      Sc->stack_end += 4; \
+  } while (0)
+#endif
+#define real(p)                        (T_Rel(p))->object.number.real_value
+#define set_all_methods(p, Let)        mid_type(T_Let(p)) |= (mid_type(Let) & (T_MID_HAS_METHODS | T_MID_HAS_LET_REF_FALLBACK | T_MID_HAS_LET_SET_FALLBACK))
+#define set_car(p, Val)                car(p) = Val                   /* can be a slot or #<unused> or #<catch> etc */
+#define set_fn_direct(f, X)            do {set_opt2(f, (s7_pointer)(X), OPT2_FN); set_has_fn(f);} while (0)
+#define set_global_value(p, Val)       slot_set_value(global_slot(T_Sym(p)), Val) /* slot_set_value checks T_Ext */
+#if S7_DEBUGGING
+  #define set_has_carrier(p)           do {set_mid_type_bit(T_Itr(p), T_MARK_SEQ); p->carrier_line = __LINE__;} while (0)
+#else
+  #define set_has_carrier(p)           set_mid_type_bit(T_Itr(p), T_MARK_SEQ)
+#endif
+#define set_has_let_ref_fallback(p)    set_mid_type_bit(T_Let(p), T_MID_HAS_LET_REF_FALLBACK)
+#define set_has_let_set_fallback(p)    set_mid_type_bit(T_Let(p), T_MID_HAS_LET_SET_FALLBACK)
+#define set_has_methods(p)             set_mid_type_bit(T_Met(p), T_MID_HAS_METHODS)
+#define set_is_unlet(p)                set_high_type_bit(T_Let(p), T_UNLET)
+#if REPORT_ROOTLET_REDEF
+  #define set_local(Symbol)            set_local_1(sc, T_Sym(Symbol), __func__, __LINE__)
+#else
+  #define set_local(p)                 full_type(T_Sym(p)) &= ~(T_DONT_EVAL_ARGS | T_SYNTACTIC)
+#endif
+#if !S7_DEBUGGING
+#define set_opt2(p, x, r)              (p)->object.cons.o2.opt2 = (s7_pointer)(x)
+#else
+#define set_opt2(p, x, Role)           set_opt2_1(sc, T_Pair(p), (s7_pointer)(x), Role, __func__, __LINE__)
+#endif
+#if !S7_DEBUGGING
+#define set_opt3(p, x, r)              do {(p)->object.cons.o3.opt3 = x; clear_type_bit(p, T_LOCATION);} while (0)
+#else
+#define set_opt3(p, x, Role)           set_opt3_1(T_Pair(p), x, Role)
+#endif
+#define set_opt3_sym(P, X)             set_opt3(P, T_Sym(X),        OPT3_SYM)
+#define slot_end                       NULL
+#define slot_has_setter(p)             has_mid_type_bit(T_Slt(p), T_HAS_SETTER)
+#define slot_set_has_setter(p)         set_mid_type_bit(T_Slt(p), T_HAS_SETTER)
+#define slot_set_next(p, Val)          (T_Slt(p))->object.slt.nxt = T_Sln(Val)
+#define slot_set_symbol_and_value(Slot, Symbol, Value) do {slot_set_symbol(Slot, Symbol); slot_set_value(Slot, Value);} while (0)
+#define slot_setter(p)                 T_Prc((T_Slt(p)->object.slt.pending_value))
+#if S7_DEBUGGING
+#define slot_set_value(slot, value) \
+  do { \
+       if (is_immutable_slot(slot)) fprintf(stderr, "%s[%d]: setting immutable slot %s\n", __func__, __LINE__, symbol_name(slot_symbol(slot))); \
+       (T_Slt(slot))->object.slt.val = T_Nmv(value); \
+     } while (0)
+#else
+#define slot_set_value(p, Val)         (T_Slt(p))->object.slt.val = T_Nmv(Val)
+#endif
+#define slot_set_value_with_hook(Slot, Value) \
+  do {if (hook_has_functions(sc->rootlet_redefinition_hook)) slot_set_value_with_hook_1(sc, T_Slt(Slot), T_Nmv(Value)); else slot_set_value(T_Slt(Slot), T_Nmv(Value));} while (0)
+#define slot_symbol(p)                 T_Sym((T_Slt(p))->object.slt.sym)
+#define slot_value(p)                  T_Nmv((T_Slt(p))->object.slt.val)
+#define starlet_symbol_id(p)           ((uint8_t)((block_size(symbol_info(p)) >> 8) & 0xff))  /* *s7* id -- can be gensym, eval unopt section */
+#define string_length(p)               (T_Str(p))->object.string.length
+#define symbol_id(p)                   (T_Sym(p))->object.sym.id
+#define symbol_increment_ctr(p)        (T_Sym(p))->object.sym.ctr++          /* despite this expense, ctr does save a lot overall */
+#define symbol_set_local_slot(Symbol, Id, Slot) \
+  do {set_local_slot(Symbol, Slot); symbol_set_id(Symbol, Id); symbol_increment_ctr(Symbol);} while (0)
+#define symbol_set_local_slot_unincremented(Symbol, Id, Slot) \
+  do {set_local_slot(Symbol, Slot); symbol_set_id(Symbol, Id);} while (0)
+#if S7_DEBUGGING
+#define unstack_gc_protect(Sc) unstack_with(Sc, OP_GC_PROTECT)
+#else
+#define unstack_gc_protect(Sc) Sc->stack_end -= 4
+#endif
+#if S7_DEBUGGING
+#define unstack_with(Sc, Op) unstack_1(Sc, Op, __func__, __LINE__)
+#else
+#define unstack_with(Sc, op) Sc->stack_end -= 4
+#endif
+#define is_any_macro(P)                t_any_macro_p[type(P)]
+#define has_closure_let(P)             t_has_closure_let[type(P)]
+#define closure_let(p)                 T_Let((T_Clo(p))->object.func.let)
+#define funclet_function(p)            T_Sym((C_Let(p, L_FUNC))->object.let.edat.efnc.function)
+#define has_let_file(p)                has_high_type_bit(T_Let(p), T_HAS_LET_FILE)
+#define let_line(p)                    (C_Let(p, L_FUNC))->object.let.edat.efnc.line
+#define let_file(p)                    (C_Let(p, L_FUNC))->object.let.edat.efnc.file
+#define mid_type(p)                    (p)->tf.bits.mid_bits
+#define symbol_info(p)                 (symbol_name_cell(p))->object.string.block
+#define is_quote(Sc, p)                (((p) == Sc->quote_symbol) || ((p) == Sc->quote_function)) /* order here apparently does not matter */
+#define is_safe_quote(Sc, p)           ((((p) == Sc->quote_symbol) && (is_global(Sc->quote_symbol))) || ((p) == Sc->quote_function))
+#define set_has_fn(p)                  set_high_type_bit(T_Pair(p), T_HAS_FN)
+#if S7_DEBUGGING
+  #define C_Let(p, role)               check_let_ref(p, role, __func__, __LINE__)
+#else
+  #define C_Let(p, role)               p
+#endif
+#define iter_ok(p)                     has_mid_type_bit(T_Itr(p), T_MID_ITER_OK)
+#define T_SAFE_PROCEDURE               (1 << (16 + 5))
+#define T_UNLET                        T_SYMCONS
+#define T_MID_HAS_LET_REF_FALLBACK     T_MID_MUTABLE
+#define T_MID_HAS_LET_SET_FALLBACK     T_MID_SAFE_STEPPER
+#define T_HAS_SETTER                   T_MID_LOCATION
+#define T_MARK_SEQ                     T_MID_MUTABLE
+#define T_SYMCONS                      (1 << 0)
+#define T_SHORT_KEYWORD                (1 << 7)
+#define T_HAS_LET_FILE                 (1 << 1)
+#define OPT2_FN                        (1 << 19)  /* fn (s7_function) func (sc, arglist) */
+#define OPT3_SYM                       (1 << 23)  /* expression symbol access */
+#define L_FUNC                         (1LL << 41)
+#define T_HAS_FN                       (1 << 13)
+
+/* ---- extern globals from s7.c for s7_scheme_let.c ---- */
+extern bool t_any_macro_p[NUM_TYPES], t_any_closure_p[NUM_TYPES], t_has_closure_let[NUM_TYPES], t_applicable_p[NUM_TYPES];
+extern s7_pointer too_many_arguments_string, a_boolean_string, a_let_string, a_non_constant_symbol_string,
+  a_procedure_or_a_macro_string, a_symbol_string, immutable_error_string;
+
+/* sl_no_field and friends (starlet field ids), copied from s7.c */
+typedef enum {sl_no_field=0, sl_accept_all_keyword_arguments, sl_autoloading, sl_catches, sl_cpu_time, sl_c_types,
+	      sl_debug, sl_default_hash_table_length, sl_default_random_state, sl_default_rationalize_error, sl_equivalent_float_epsilon,
+	      sl_expansions, sl_filenames, sl_file_names, sl_float_format_precision, sl_free_heap_size, sl_gc_freed, sl_gc_info,
+	      sl_gc_protected_objects, sl_gc_resize_heap_by_4_fraction, sl_gc_resize_heap_fraction, sl_gc_stats, sl_gc_temps_size,
+	      sl_gc_total_freed, sl_hash_table_float_epsilon, sl_hash_table_missing_key_value, sl_heap_size, sl_history, sl_history_enabled,
+	      sl_history_size, sl_initial_string_port_length, sl_iterator_at_end_value, sl_major_version, sl_max_heap_size, sl_max_list_length,
+	      sl_max_stack_size, sl_max_string_length, sl_max_string_port_length, sl_max_vector_dimensions, sl_max_vector_length,
+	      sl_memory_usage, sl_minor_version, sl_most_negative_fixnum, sl_most_positive_fixnum, sl_muffle_warnings,
+	      sl_number_separator, sl_openlets, sl_output_file_port_length, sl_print_length, sl_profile, sl_profile_info,
+	      sl_profile_prefix, sl_rootlet_size, sl_safety, sl_scheme_version, sl_stack, sl_stacktrace_defaults, sl_stack_size, sl_stack_top,
+	      sl_symbol_quote, sl_symbol_printer, sl_undefined_constant_warnings, sl_undefined_identifier_warnings, sl_version,
+	      sl_num_fields} starlet_t;
+
+/* ---- function declarations (defined in s7.c) for s7_scheme_let.c ---- */
+s7_pointer add_slot_at_end(s7_scheme *sc, s7_uint id, s7_pointer last_slot, s7_pointer symbol, s7_pointer value);
+s7_pointer add_slot_checked_at_end(s7_scheme *sc, s7_uint id, s7_pointer last_slot, s7_pointer symbol, s7_pointer value);
+s7_pointer add_slot_checked_with_id(s7_scheme *sc, s7_pointer let, s7_pointer symbol, s7_pointer value);
+void add_slot_unchecked(s7_scheme *sc, s7_pointer let, s7_pointer symbol, s7_pointer value, s7_uint id);
+s7_pointer call_setter(s7_scheme *sc, s7_pointer slot, s7_pointer old_value);
+s7_pointer checked_slot_set_value(s7_scheme *sc, s7_pointer slot, s7_pointer value);
+s7_pointer find_let(s7_scheme *sc, s7_pointer obj);
+no_return void find_let_error_nr(s7_scheme *sc, s7_pointer caller, s7_pointer let, s7_pointer new_let, int32_t arg_num, s7_pointer args);
+s7_pointer find_method(s7_scheme *sc, s7_pointer let, s7_pointer symbol);
+bool is_constant_symbol(s7_scheme *sc, s7_pointer sym);
+bool is_eq_initial_value(s7_pointer symbol, s7_pointer other);
+bool is_proper_quote(s7_scheme *sc, s7_pointer p);
+s7_pointer make_string_with_length(s7_scheme *sc, const char *str, s7_int len);
+s7_pointer make_symbol(s7_scheme *sc, const char *name, s7_int len);
+s7_pointer method_or_bust(s7_scheme *sc, s7_pointer obj, s7_pointer method, s7_pointer args, s7_pointer typ, int32_t position);
+s7_pointer object_type_name(s7_scheme *sc, s7_pointer obj);
+int32_t position_of(const s7_pointer p, s7_pointer args);
+s7_pointer proper_list_reverse_in_place(s7_scheme *sc, s7_pointer list);
+s7_pointer set_elist_3(s7_scheme *sc, s7_pointer x1, s7_pointer x2, s7_pointer x3);
+s7_pointer set_elist_4(s7_scheme *sc, s7_pointer x1, s7_pointer x2, s7_pointer x3, s7_pointer x4);
+s7_pointer set_elist_5(s7_scheme *sc, s7_pointer x1, s7_pointer x2, s7_pointer x3, s7_pointer x4, s7_pointer x5);
+s7_pointer set_mlist_1(s7_scheme *sc, s7_pointer x1);
+s7_pointer set_mlist_2(s7_scheme *sc, s7_pointer x1, s7_pointer x2);
+s7_pointer set_plist_2(s7_scheme *sc, s7_pointer x1, s7_pointer x2);
+s7_pointer set_plist_3(s7_scheme *sc, s7_pointer x1, s7_pointer x2, s7_pointer x3);
+s7_pointer set_qlist_2(s7_scheme *sc, s7_pointer x1, s7_pointer x2);
+s7_pointer set_qlist_3(s7_scheme *sc, s7_pointer x1, s7_pointer x2, s7_pointer x3);
+s7_pointer set_ulist_1(s7_scheme *sc, s7_pointer x1, s7_pointer x2);
+void slot_set_setter(s7_pointer slot, s7_pointer val);
+s7_pointer starlet(s7_scheme *sc, s7_int choice);
+s7_pointer starlet_set_1(s7_scheme *sc, s7_pointer sym, s7_pointer val);
+s7_pointer symbol_to_local_slot(s7_scheme *sc, s7_pointer symbol, s7_pointer let);
+s7_pointer copy_any_list(s7_scheme *sc, s7_pointer a);
+s7_pointer g_procedure_source(s7_scheme *sc, s7_pointer args);
+#if WITH_HISTORY
+s7_pointer sanitize_history(s7_scheme *sc, s7_pointer code);
+#endif
+
+#define clear_mid_type_bit(p, b)       (p)->tf.bits.mid_bits &= (~(b))
+#define hook_has_functions(p)          (is_pair(s7_hook_functions(sc, T_Clo(p))))
+#define set_integer(p, x)              integer(p) = x
+#define set_local_slot(p, Val)         (T_Sym(p))->object.sym.local_slot = T_Slt(Val)
+#define slot_set_symbol(p, Sym)        (T_Slt(p))->object.slt.sym = T_Sym(Sym)
+#define symbol_name_cell(p)            T_Str((T_Sym(p))->object.sym.name)
+#define symbol_name(p)                 string_value(symbol_name_cell(p))
+#if S7_DEBUGGING
+void check_let_set_slots(s7_scheme *sc, s7_pointer let, s7_pointer slot, const char *func, int32_t line);
+void set_opt2_1(s7_scheme *sc, s7_pointer p, s7_pointer x, s7_uint role, const char *func, int32_t line);
+void set_opt3_1(s7_pointer p, s7_pointer x, s7_uint role);
+s7_int gc_protect_2(s7_scheme *sc, s7_pointer x, int32_t line);
+void unstack_1(s7_scheme *sc, opcode_t op, const char *func, int32_t line);
+#endif
+#define set_real(p, x)                 real(p) = x
+#define T_MID_LOCATION                 (1 << 2)
+#define T_MID_MUTABLE                  (1 << 10)
+#define T_MID_SAFE_STEPPER             (1 << 11)
+#define T_MID_ITER_OK                  (1 << 15)
+#define T_DONT_EVAL_ARGS               (1 << (8 + 5))
+#define T_LOCATION                     (1 << (16 + 2))
+
+/* more decls for s7_scheme_let.c */
+#if S7_DEBUGGING
+void symbol_set_id(s7_pointer sym, s7_int id);
+#else
+#define symbol_set_id(p, X)            (T_Sym(p))->object.sym.id = X
+#endif
+void slot_set_value_with_hook_1(s7_scheme *sc, s7_pointer slot, s7_pointer value);
+no_return void wrong_type_error_nr(s7_scheme *sc, s7_pointer caller, s7_int arg_num, s7_pointer arg, s7_pointer typ);
+void immutable_object_error_nr(s7_scheme *sc, s7_pointer info);
+
 #endif /* S7_INTERNAL_H */

--- a/src/s7_scheme_let.c
+++ b/src/s7_scheme_let.c
@@ -1,0 +1,1354 @@
+/* s7_scheme_let.c - let (environment) function implementations for s7 Scheme interpreter
+ *
+ * derived from s7, a Scheme interpreter
+ * SPDX-License-Identifier: 0BSD
+ */
+
+#include "s7_internal.h"
+#include "s7_scheme_let.h"
+#include "s7_scheme_base.h"
+
+/* s7.c's make_integer/make_real fast-path macros depend on the static small_ints array;
+ * the s7_make_* functions contain the same fast path internally. */
+#define make_integer(Sc, N) s7_make_integer(Sc, N)
+#define make_real(Sc, X)    s7_make_real(Sc, X)
+
+/* ---------------------------------------- unlet ---------------------------------------- */
+s7_pointer g_unlet(s7_scheme *sc, s7_pointer unused_args)
+{
+  /* add sc->unlet bindings to the current environment */
+
+  const s7_pointer result = make_let(sc, sc->curlet);
+  begin_temp(sc->y, result);
+  set_is_unlet(result);
+  if (global_value(sc->else_symbol) != sc->else_symbol)
+    add_slot_checked_with_id(sc, result, sc->else_symbol, initial_value(sc->else_symbol));
+  for (unlet_entry_t *p = sc->unlet_entries; p; p = p->next)
+    {
+      s7_pointer sym = p->symbol;
+      if ((!is_eq_initial_value(sym, global_value(sym))) ||  /* it has been changed globally */
+	  ((!is_global(sym)) &&        /* it might be shadowed locally */
+	   (s7_symbol_local_value(sc, sym, sc->curlet) != global_value(sym))))
+	add_slot_checked_with_id(sc, result, sym, initial_value(sym));
+    }
+  end_temp(sc->y);
+  return(result);
+}
+
+
+/* ---------------------------------------- openlet? ---------------------------------------- */
+bool s7_is_openlet(s7_pointer let) {return(has_methods(let));}
+
+
+/* ---------------------------------------- openlet ---------------------------------------- */
+s7_pointer s7_openlet(s7_scheme *sc, s7_pointer let)
+{
+  /* if e is not a let, the openlet bit is still set on it (c-pointer etc) */
+  set_has_methods(let);
+  return(let);
+}
+
+
+s7_pointer g_openlet(s7_scheme *sc, s7_pointer args)
+{
+
+  const s7_pointer let = car(args);
+  s7_pointer new_let, func;
+  if (!is_let(let))
+    {
+      new_let = find_let(sc, let);
+      if ((!is_let(new_let)) || (new_let == sc->rootlet))
+	find_let_error_nr(sc, sc->openlet_symbol, let, new_let, 1, args);
+    }
+  else new_let = let;
+  if ((new_let == sc->rootlet) || (new_let == sc->starlet))
+    error_nr(sc, sc->out_of_range_symbol, set_elist_2(sc, wrap_string(sc, "can't openlet ~S", 17), let));
+  if (is_unlet(new_let)) /* protect against infinite loop: (let () (define + -) (with-let (unlet) (+ (openlet (unlet)) 2))) */
+    error_nr(sc, sc->out_of_range_symbol, set_elist_1(sc, wrap_string(sc, "can't openlet unlet", 19)));
+  if ((has_active_methods(sc, let)) &&
+      ((func = find_method(sc, new_let, sc->openlet_symbol)) != sc->undefined))
+    return(s7_apply_function(sc, func, args));
+  set_has_methods(let);
+  return(let); /* openlet and coverlet return their argument */
+}
+
+
+/* ---------------------------------------- coverlet ---------------------------------------- */
+s7_pointer g_coverlet(s7_scheme *sc, s7_pointer args)
+{
+
+  const s7_pointer let = car(args);
+  s7_pointer new_let, func;
+  if (!is_let(let))
+    {
+      new_let = find_let(sc, let);
+      if ((!is_let(new_let))  || (new_let == sc->rootlet))
+	find_let_error_nr(sc, sc->coverlet_symbol, let, new_let, 1, args);
+    }
+  else new_let = let;
+  if ((new_let == sc->rootlet) || (new_let == sc->starlet))
+    error_nr(sc, sc->out_of_range_symbol, set_elist_2(sc, wrap_string(sc, "can't coverlet ~S", 17), let));
+  if (is_unlet(new_let))
+    error_nr(sc, sc->out_of_range_symbol, set_elist_1(sc, wrap_string(sc, "can't coverlet unlet", 20)));
+  if ((has_active_methods(sc, let)) &&
+      ((func = find_method(sc, new_let, sc->coverlet_symbol)) != sc->undefined))
+    return(s7_apply_function(sc, func, args));
+  clear_has_methods(let);
+  return(let); /* mimic openlet in everything */
+}
+
+
+/* ---------------------------------------- varlet ---------------------------------------- */
+static void check_let_fallback(s7_scheme *sc, const s7_pointer symbol, s7_pointer let)
+{
+  if (symbol == sc->let_ref_fallback_symbol)
+    set_has_let_ref_fallback(let);
+  else
+    if (symbol == sc->let_set_fallback_symbol)
+      set_has_let_set_fallback(let);
+}
+
+
+static void append_let(s7_scheme *sc, s7_pointer new_let, s7_pointer old_let)
+{
+  if (new_let == sc->rootlet)
+    for (s7_pointer slot = let_slots(old_let); is_not_slot_end(slot); slot = next_slot(slot))
+      {
+	s7_pointer sym = slot_symbol(slot), val = slot_value(slot);
+	if (is_slot(global_slot(sym)))
+	  set_global_value(sym, val);
+	else s7_make_slot(sc, sc->rootlet, sym, val);
+      }
+  else
+    if (old_let == sc->starlet)
+      {
+	const s7_pointer iter = s7_make_iterator(sc, sc->starlet);
+	const s7_int gc_loc = gc_protect_1(sc, iter);
+	iterator_carrier(iter) = cons_unchecked(sc, sc->F, sc->F);
+	set_has_carrier(iter); /* so carrier is GC protected by mark_iterator */
+	while (true)
+	  {
+	    s7_pointer field = s7_iterate(sc, iter);
+	    if (iterator_is_at_end(iter)) break;
+	    add_slot_checked_with_id(sc, new_let, car(field), cdr(field));
+	  }
+	s7_gc_unprotect_at(sc, gc_loc);
+      }
+    else
+      for (s7_pointer slot = let_slots(old_let); is_not_slot_end(slot); slot = next_slot(slot))
+	add_slot_checked_with_id(sc, new_let, slot_symbol(slot), slot_value(slot)); /* not add_slot here because it might run off the free heap end */
+}
+
+
+s7_pointer s7_varlet(s7_scheme *sc, s7_pointer let, s7_pointer symbol, s7_pointer value)
+{
+  if (!is_let(let))
+    wrong_type_error_nr(sc, sc->varlet_symbol, 1, let, a_let_string);
+  if (!is_symbol(symbol))
+    wrong_type_error_nr(sc, sc->varlet_symbol, 2, symbol, a_symbol_string);
+  if ((is_slot(global_slot(symbol))) &&
+      (is_syntax(global_value(symbol))))
+    wrong_type_error_nr(sc, sc->varlet_symbol, 2, symbol, wrap_string(sc, "a non-syntactic symbol", 22));
+
+  if (let == sc->rootlet)
+    {
+      if (is_slot(global_slot(symbol)))
+	set_global_value(symbol, value);
+      else s7_make_slot(sc, sc->rootlet, symbol, value);
+    }
+  else
+    {
+      add_slot_checked_with_id(sc, let, symbol, value);
+      check_let_fallback(sc, symbol, let);
+    }
+  return(value);
+}
+
+
+s7_pointer g_varlet(s7_scheme *sc, s7_pointer args)   /* varlet = with-let + define */
+{
+  s7_pointer let = car(args);
+  if (!is_let(let))
+    {
+      s7_pointer new_let = find_let(sc, let);
+      if ((!is_let(new_let)) || (new_let == sc->rootlet))
+	find_let_error_nr(sc, sc->varlet_symbol, let, new_let, 1, args);
+      let = new_let;
+    }
+  if ((is_immutable_let(let)) || (let == sc->starlet))
+    immutable_object_error_nr(sc, set_elist_3(sc, wrap_string(sc, "can't (varlet ~{~S~^ ~}), ~S is immutable", 41), args, let));
+
+  for (s7_pointer arglist = cdr(args); is_pair(arglist); arglist = cdr(arglist))
+    {
+      s7_pointer sym, val;
+      const s7_pointer arg = car(arglist);
+      if (is_symbol(arg))
+	{
+	  sym = (is_keyword(arg)) ? keyword_symbol(arg) : arg;
+	  if (!is_pair(cdr(arglist)))
+	    error_nr(sc, sc->syntax_error_symbol, set_elist_3(sc, wrap_string(sc, "varlet: symbol ~S, but no value: ~S", 35), arg, args));
+	  if (is_constant_symbol(sc, sym))
+	    wrong_type_error_nr(sc, sc->varlet_symbol, position_of(arglist, args), sym, a_non_constant_symbol_string);
+	  arglist = cdr(arglist);
+	  val = car(arglist);
+	}
+      else
+	if (is_let(arg))
+	  {
+	    if ((arg != sc->rootlet) && (let != sc->starlet))   /* (varlet (inlet 'a 1) (rootlet)) is trouble */
+	      {
+		append_let(sc, let, arg);
+		if (has_let_set_fallback(arg)) set_has_let_set_fallback(let);
+		if (has_let_ref_fallback(arg)) set_has_let_ref_fallback(let);
+	      }
+	    continue;
+	  }
+	else
+	  if (is_pair(arg))
+	    {
+	      sym = car(arg);
+	      if (!is_symbol(sym))
+		wrong_type_error_nr(sc, sc->varlet_symbol, position_of(arglist, args), arg, a_symbol_string);
+	      if (is_constant_symbol(sc, sym))
+		wrong_type_error_nr(sc, sc->varlet_symbol, position_of(arglist, args), sym, a_non_constant_symbol_string);
+	      val = cdr(arg);
+	    }
+	  else wrong_type_error_nr(sc, sc->varlet_symbol, position_of(arglist, args), arg, wrap_string(sc, "a symbol, let, or cons", 22));
+
+      if (let == sc->rootlet)
+	{
+	  s7_pointer gslot = global_slot(sym);
+	  if (is_slot(gslot))
+	    {
+	      if (is_immutable(gslot)) /* (immutable! 'abs) (varlet (rootlet) 'abs 1) */
+		immutable_object_error_nr(sc, set_elist_5(sc, wrap_string(sc, "~S is immutable in (varlet ~S '~S ~S)", 37), sym, car(args), arg, val));
+	      slot_set_value_with_hook(global_slot(sym), val);
+	    }
+	  else s7_make_slot(sc, sc->rootlet, sym, val);
+	}
+      else
+	{
+	  check_let_fallback(sc, sym, let);
+	  add_slot_checked_with_id(sc, let, sym, val);
+	  /* this used to check for sym already defined, and set its value, but that greatly slows down
+	   *   the most common use (adding a slot), and makes it hard to shadow explicitly.  Don't use
+	   *   varlet as a substitute for set!/let-set!.
+	   */
+	}}
+  return(let);
+}
+
+
+/* ---------------------------------------- cutlet ---------------------------------------- */
+s7_pointer g_cutlet(s7_scheme *sc, s7_pointer args)
+{
+
+  s7_pointer let = car(args);
+  s7_int the_un_id;
+  if (let != sc->rootlet)
+    {
+      if_method_exists_return_value(sc, let, sc->cutlet_symbol, args);
+      if (!is_let(let))
+	{
+	  s7_pointer new_let = find_let(sc, let);
+	  if ((!is_let(new_let)) || (new_let == sc->rootlet))
+	    find_let_error_nr(sc, sc->cutlet_symbol, let, new_let, 1, args);
+	  let = new_let;
+	}}
+  if ((is_immutable_let(let)) || (let == sc->starlet))
+    immutable_object_error_nr(sc, set_elist_3(sc, immutable_error_string, sc->cutlet_symbol, let));
+
+  /* besides removing the slot we have to make sure the symbol_id does not match, else
+   *   let-ref and others will use the old slot!  So use the next (unused) id.
+   *   (let ((b 1)) (let ((b 2)) (cutlet (curlet) 'b)) b)
+   */
+  the_un_id = ++sc->let_number;
+
+  for (s7_pointer syms = cdr(args); is_pair(syms); syms = cdr(syms))
+    {
+      s7_pointer sym = car(syms);
+      if (!is_symbol(sym))
+	wrong_type_error_nr(sc, sc->cutlet_symbol, position_of(syms, args), sym, a_symbol_string);
+      if (is_keyword(sym))
+	sym = keyword_symbol(sym);
+
+      if (let == sc->rootlet)
+	{
+	  if (!is_slot(global_slot(sym)))
+	    error_nr(sc, sc->out_of_range_symbol, set_elist_2(sc, wrap_string(sc, "cutlet can't remove ~S", 22), sym));
+	  if (is_immutable(global_slot(sym)))
+	    immutable_object_error_nr(sc, set_elist_3(sc, immutable_error_string, sc->cutlet_symbol, sym));
+	  symbol_set_id(sym, the_un_id);
+	  set_global_value(sym, sc->undefined);
+	  /* here we need to at least clear bits: syntactic binder clean-symbol(?) etc, maybe also locally */
+	}
+      else
+	{
+	  s7_pointer slot;
+	  if ((has_let_fallback(let)) &&
+	      ((sym == sc->let_ref_fallback_symbol) || (sym == sc->let_set_fallback_symbol)))
+	    error_nr(sc, sc->out_of_range_symbol, set_elist_2(sc, wrap_string(sc, "cutlet can't remove ~S", 22), sym));
+	  slot = let_slots(let);
+	  if (is_not_slot_end(slot))
+	    {
+	      if (slot_symbol(slot) == sym)
+		{
+		  if (is_immutable_slot(slot))
+		    immutable_object_error_nr(sc, set_elist_3(sc, immutable_error_string, sc->cutlet_symbol, sym));
+		  let_set_slots(let, next_slot(let_slots(let)));
+		  symbol_set_id(sym, the_un_id);
+		}
+	      else
+		{
+		  s7_pointer last_slot = slot;
+		  for (slot = next_slot(let_slots(let)); is_not_slot_end(slot); last_slot = slot, slot = next_slot(slot))
+		    if (slot_symbol(slot) == sym)
+		      {
+			if (is_immutable_slot(slot))
+			  immutable_object_error_nr(sc, set_elist_3(sc, immutable_error_string, sc->cutlet_symbol, sym));
+			symbol_set_id(sym, the_un_id);
+			slot_set_next(last_slot, next_slot(slot));
+			break;
+		      }}}}}
+  return(let);
+}
+
+
+/* ---------------------------------------- sublet ---------------------------------------- */
+static s7_pointer sublet_1(s7_scheme *sc, s7_pointer let, s7_pointer bindings, s7_pointer caller)
+{
+  const s7_pointer new_let = make_let(sc, let);
+  set_all_methods(new_let, let);
+
+  if (!is_null(bindings))
+    {
+      sc->temp3 = new_let;
+      for (s7_pointer slot = NULL, entries = bindings; is_pair(entries); entries = cdr(entries))
+	{
+	  s7_pointer entry = car(entries), sym, val;
+
+	  switch (type(entry))
+	    {
+	    case T_SYMBOL:
+	      sym = (is_keyword(entry)) ? keyword_symbol(entry) : entry;
+	      if (!is_pair(cdr(entries)))
+		error_nr(sc, sc->syntax_error_symbol,
+			 set_elist_4(sc, wrap_string(sc, "~A: entry ~S, but no value: ~S", 30), caller, entry, bindings));
+	      entries = cdr(entries);
+	      val = car(entries);
+	      break;
+
+	    case T_PAIR:  /* (cons sym val) */
+	      sym = car(entry);
+	      if (!is_symbol(sym))
+		wrong_type_error_nr(sc, caller, 1 + position_of(entries, bindings), entry, a_symbol_string);
+	      if (is_keyword(sym))
+		sym = keyword_symbol(sym);
+	      val = cdr(entry);
+	      break;
+
+	    case T_LET:
+	      if ((entry == sc->rootlet) || (new_let == sc->starlet)) continue;
+	      append_let(sc, new_let, entry);
+	      if (is_not_slot_end(let_slots(new_let))) /* make sure the end slot (slot) is correct */
+		for (slot = let_slots(new_let); is_not_slot_end(next_slot(slot)); slot = next_slot(slot)); /* slot can't be local -- see below */
+	      continue;
+
+	    default:
+	      wrong_type_error_nr(sc, caller, 1 + position_of(entries, bindings), entry, a_symbol_string);
+	    }
+	  if (is_constant_symbol(sc, sym))
+	    wrong_type_error_nr(sc, caller, 1 + position_of(entries, bindings), sym, a_non_constant_symbol_string);
+#if 0
+	  if ((is_slot(global_slot(sym))) &&
+	      (is_syntax_or_qq(global_value(sym))))
+	    wrong_type_error_nr(sc, caller, 2, sym, wrap_string(sc, "a non-syntactic symbol", 22));
+	  /* this is a local redefinition which we accept elsewhere: (let ((if 3)) if) -> 3 */
+	  /*   so s7_inlet (which calls sublet) differs from g_inlet? which is correct? */
+	  /*   (define (f1) (with-let (sublet (curlet)) (inlet 'quasiquote 1))) (f1) */
+
+#endif
+	  /* here we know new_let is a let and is not rootlet */
+	  if (!slot)
+	    slot = add_slot_checked_with_id(sc, new_let, sym, val);
+	  else
+	    {
+	      /* if (sc->free_heap_top <= sc->free_heap_trigger) try_to_call_gc(sc);*/ /* or maybe add add_slot_at_end_checked? */
+	      slot = add_slot_checked_at_end(sc, let_id(new_let), slot, sym, val);
+	      set_local(sym); /* ? */
+	    }
+	  check_let_fallback(sc, sym, new_let);
+	}
+      if ((S7_DEBUGGING) && (sc->temp3 != new_let)) fprintf(stderr, "%s[%d]: temp3: %s\n", __func__, __LINE__, display(sc->temp3));
+      sc->temp3 = sc->unused;
+    }
+  return(new_let);
+}
+
+
+s7_pointer s7_sublet(s7_scheme *sc, s7_pointer let, s7_pointer bindings) {return(sublet_1(sc, let, bindings, sc->sublet_symbol));}
+
+
+s7_pointer g_sublet(s7_scheme *sc, s7_pointer args)
+{
+
+  s7_pointer let = car(args);
+  if (!is_let(let))
+    {
+      s7_pointer new_let = find_let(sc, let);
+      if ((!is_let(new_let)) || (new_let == sc->rootlet))
+	find_let_error_nr(sc, sc->sublet_symbol, let, new_let, 1, args);
+      let = new_let;
+    }
+  return(sublet_1(sc, let, cdr(args), sc->sublet_symbol));
+}
+
+
+s7_pointer g_sublet_curlet(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer sym = cadr(args), new_let;
+  if_let_method_exists_return_value(sc, sc->curlet, sc->sublet_symbol, args); /* curlet is a let so... */
+  new_let = inline_make_let_with_slot(sc, sc->curlet, sym, caddr(args));
+  set_all_methods(new_let, sc->curlet);
+  check_let_fallback(sc, sym, new_let);
+  return(new_let);
+}
+
+
+s7_pointer sublet_chooser(s7_scheme *sc, s7_pointer func, int32_t num_args, s7_pointer expr)
+{
+  if (num_args == 3)
+    {
+      s7_pointer args = cdr(expr);
+      if ((is_pair(car(args))) && (caar(args) == sc->curlet_symbol) && (is_null(cdar(args))) &&
+	  (is_quoted_symbol(sc, cadr(args))))
+	return(sc->sublet_curlet);
+    }
+  return(func);
+}
+
+
+/* ---------------------------------------- inlet ---------------------------------------- */
+s7_pointer s7_inlet(s7_scheme *sc, s7_pointer args)
+{
+  return(sublet_1(sc, sc->rootlet, args, sc->inlet_symbol));
+}
+
+
+s7_pointer g_simple_inlet(s7_scheme *sc, s7_pointer args)
+{
+  /* here all args are paired with normal symbol/value, no fallbacks, no immutable symbols, no syntax, etc */
+  const s7_pointer new_let = make_let(sc, sc->rootlet);
+  const s7_int id = let_id(new_let);
+
+  begin_temp(sc->temp6, new_let);
+  for (s7_pointer x = args, last_slot = NULL; is_pair(x); x = cddr(x))
+    {
+      s7_pointer symbol = car(x);
+      if (is_keyword(symbol))                 /* (inlet ':allow-other-keys 3) */
+	symbol = keyword_symbol(symbol);
+      if (is_constant_symbol(sc, symbol))     /* (inlet 'pi 1) */
+	{
+	  end_temp(sc->temp6);
+	  wrong_type_error_nr(sc, sc->inlet_symbol, 1, symbol, a_non_constant_symbol_string);
+	}
+      if (!last_slot)
+	{
+	  add_slot_unchecked(sc, new_let, symbol, cadr(x), id);
+	  last_slot = let_slots(new_let);
+	}
+      else last_slot = add_slot_checked_at_end(sc, id, last_slot, symbol, cadr(x));
+    }
+  end_temp(sc->temp6);
+  return(new_let);
+}
+
+
+s7_pointer inlet_p_pp(s7_scheme *sc, s7_pointer symbol, s7_pointer value)
+{
+  if (!is_symbol(symbol))
+    return(sublet_1(sc, sc->rootlet, set_plist_2(sc, symbol, value), sc->inlet_symbol));
+  if (is_keyword(symbol))
+    symbol = keyword_symbol(symbol);
+  if (is_constant_symbol(sc, symbol))
+    wrong_type_error_nr(sc, sc->inlet_symbol, 1, symbol, a_non_constant_symbol_string);
+  if ((is_defined_global(symbol)) &&
+      (is_syntax_or_qq(global_value(symbol))))
+    wrong_type_error_nr(sc, sc->inlet_symbol, 1, symbol, wrap_string(sc, "a non-syntactic symbol", 22));
+  {
+    s7_pointer new_let;
+    new_cell(sc, new_let, T_LET | T_SAFE_PROCEDURE);
+    begin_temp(sc->x, new_let);
+    let_set_id(new_let, ++sc->let_number);
+    let_set_outlet(new_let, sc->rootlet);
+    let_set_slots(new_let, slot_end);
+    add_slot_unchecked(sc, new_let, symbol, value, let_id(new_let));
+    end_temp(sc->x);
+    return(new_let);
+  }
+}
+
+
+s7_pointer internal_inlet(s7_scheme *sc, s7_int num_args, ...) /* used in *->let */
+{
+  va_list ap;
+  const s7_pointer new_let = make_let(sc, sc->rootlet);
+  const s7_int id = let_id(new_let);
+  s7_pointer last_slot = NULL;
+
+  begin_temp(sc->x, new_let);
+  va_start(ap, num_args);
+  for (s7_int i = 0; i < num_args; i += 2)
+    {
+      s7_pointer symbol = T_Sym(va_arg(ap, s7_pointer));
+      s7_pointer value = T_Ext(va_arg(ap, s7_pointer));
+      if (!last_slot)
+	{
+	  add_slot_unchecked(sc, new_let, symbol, value, id);
+	  last_slot = let_slots(new_let);
+	}
+      else last_slot = add_slot_at_end(sc, id, last_slot, symbol, value);
+    }
+  va_end(ap);
+  end_temp(sc->x);
+  return(new_let);
+}
+
+
+s7_pointer inlet_chooser(s7_scheme *sc, s7_pointer func, int32_t args, s7_pointer expr)
+{
+  if ((args > 0) && ((args % 2) == 0))
+    {
+      for (s7_pointer p = cdr(expr); is_pair(p); p = cddr(p))
+	{
+	  s7_pointer sym;
+	  if (is_symbol_and_keyword(car(p)))                  /* (inlet :if ...) */
+	    sym = keyword_symbol(car(p));
+	  else
+	    {
+	      if (!is_proper_quote(sc, car(p))) return(func); /* (inlet abs ...) */
+	      sym = cadar(p);                                 /* looking for (inlet 'a ...) */
+	      if (!is_symbol(sym)) return(func);              /* (inlet '(a . 3) ...) */
+	      if (is_keyword(sym)) sym = keyword_symbol(sym); /* (inlet ':abs ...) */
+	    }
+	  if ((is_possibly_constant(sym)) ||                  /* (inlet 'define-constant ...) or (inlet 'pi ...) */
+	      (is_syntactic_symbol(sym))  ||                  /* (inlet 'if 3) */
+	      ((is_slot(global_slot(sym))) &&
+	       (is_syntax_or_qq(global_value(sym)))) ||       /* (inlet 'quasiquote 1) */
+	      (sym == sc->let_ref_fallback_symbol) ||
+	      (sym == sc->let_set_fallback_symbol))
+	    return(func);
+	}
+      return(sc->simple_inlet);
+    }
+  return(func);
+}
+
+
+/* ---------------------------------------- let->list ---------------------------------------- */
+static s7_pointer abbreviate_let(s7_scheme *sc, s7_pointer val)
+{
+  if (is_let(val))
+    return(make_symbol(sc, "<inlet...>", 11));
+  return(val);
+}
+
+
+s7_pointer s7_let_to_list(s7_scheme *sc, s7_pointer let)
+{
+  if (let == sc->rootlet)
+    {
+      begin_temp(sc->temp6, sc->nil);
+      for (s7_pointer lib = global_value(sc->libraries_symbol); is_pair(lib); lib = cdr(lib))
+	sc->temp6 = cons(sc, caar(lib), sc->temp6);
+      sc->temp6 = cons(sc, cons(sc, sc->libraries_symbol, sc->temp6), sc->nil);
+      for (s7_pointer slot = sc->rootlet_slots; is_not_slot_end(slot); slot = next_slot(slot))
+	if (slot_symbol(slot) != sc->libraries_symbol)
+	  sc->temp6 = cons_unchecked(sc, cons(sc, slot_symbol(slot), abbreviate_let(sc, slot_value(slot))), sc->temp6);
+      {
+	s7_pointer result = proper_list_reverse_in_place(sc, sc->temp6);
+	end_temp(sc->temp6);
+	return(result);
+      }}
+  else
+    {
+      s7_pointer iter, func;
+      s7_int gc_loc = -1;
+      /* need to check make-iterator method before dropping into let->list */
+      sc->temp3 = sc->w;
+      sc->w = sc->nil;
+
+      if ((has_active_methods(sc, let)) &&
+	  ((func = find_method(sc, let, sc->make_iterator_symbol)) != sc->undefined))
+	iter = s7_apply_function(sc, func, set_plist_1(sc, let));
+      else
+	if (let == sc->starlet) /* (let->list *s7*) via starlet_make_iterator */
+	  {
+	    iter = s7_make_iterator(sc, let);
+	    gc_loc = gc_protect_1(sc, iter);
+	  }
+	else iter = sc->nil;
+
+      if (is_null(iter))
+	for (s7_pointer slot = let_slots(let); is_not_slot_end(slot); slot = next_slot(slot))
+	  sc->w = cons_unchecked(sc, cons(sc, slot_symbol(slot), slot_value(slot)), sc->w);
+      else
+	/* (begin (load "mockery.scm") (let ((lt ((*mock-pair* 'mock-pair) 1 2 3))) (format *stderr* "~{~A ~}" lt))) */
+	while (true)
+	  {
+	    s7_pointer val = s7_iterate(sc, iter);
+	    if (iterator_is_at_end(iter)) break;
+	    sc->w = cons(sc, val, sc->w);
+	  }
+      sc->w = proper_list_reverse_in_place(sc, sc->w);
+      if (gc_loc != -1)
+	s7_gc_unprotect_at(sc, gc_loc);
+      {
+	s7_pointer result = sc->w;
+	sc->w = sc->temp3;
+	sc->temp3 = sc->unused;
+	return(result);
+      }}
+}
+
+
+#if !WITH_PURE_S7
+s7_pointer g_let_to_list(s7_scheme *sc, s7_pointer args)
+{
+
+  s7_pointer let = car(args);
+  if_method_exists_return_value(sc, let, sc->let_to_list_symbol, args);
+  if (!is_let(let))
+    {
+      s7_pointer new_let = find_let(sc, let);
+      if ((!is_let(new_let)) || (new_let == sc->rootlet))
+	find_let_error_nr(sc, sc->let_to_list_symbol, let, new_let, 1, args);
+      /* this is not (let->list (rootlet)) but (say) (let->list func) which defaults in find_let to rootlet */
+      let = new_let;
+    }
+  return(s7_let_to_list(sc, let));
+}
+/* *s7* in gdb: p display(s7_let_to_list(sc, sc->starlet)) */
+#endif
+
+
+/* ---------------------------------------- let-ref ---------------------------------------- */
+s7_pointer call_let_ref_fallback(s7_scheme *sc, s7_pointer let, s7_pointer symbol)
+{
+  s7_pointer result;
+  const s7_pointer val = find_method(sc, let, sc->let_ref_fallback_symbol);
+  /* (let ((x #f)) (let begin ((x 1234)) (begin 1) 2)) -> stack overflow eventually, but should we try to catch it? */
+  if (!is_applicable(val)) return(val);
+  push_stack_no_let(sc, OP_GC_PROTECT, sc->value, sc->code);
+  result = s7_apply_function(sc, val, set_qlist_2(sc, let, symbol));
+  unstack_gc_protect(sc);
+  sc->code = T_Pos(stack_end_code(sc)); /* can be #<unused> */
+  sc->value = T_Ext(stack_end_args(sc));
+  return(result);
+}
+
+
+s7_pointer call_let_set_fallback(s7_scheme *sc, s7_pointer let, s7_pointer symbol, s7_pointer value)
+{
+  s7_pointer result;
+  push_stack_no_let(sc, OP_GC_PROTECT, sc->value, sc->code);
+  result = s7_apply_function(sc, find_method(sc, let, sc->let_set_fallback_symbol), set_qlist_3(sc, let, symbol, value));
+  unstack_gc_protect(sc);
+  sc->code = T_Pos(stack_end_code(sc));
+  sc->value = T_Ext(stack_end_args(sc));
+  return(result);
+}
+
+
+s7_pointer let_ref(s7_scheme *sc, s7_pointer let, s7_pointer symbol)
+{
+  /* (let ((a 1)) ((curlet) 'a)) or ((rootlet) 'abs) */
+  if (!is_let(let))
+    {
+      s7_pointer new_let;
+      if (let == sc->unlet_disabled) return(initial_value(symbol));
+      new_let = find_let(sc, let);
+      if ((!is_let(new_let)) || (new_let == sc->rootlet))
+	find_let_error_nr(sc, sc->let_ref_symbol, let, new_let, 1, set_mlist_2(sc, let, symbol));
+      let = new_let;
+    }
+  if (!is_symbol(symbol))
+    {
+      if ((let != sc->rootlet) && (has_let_ref_fallback(let))) /* let-ref|set-fallback refer to (explicit) let-ref in various forms, not the method lookup process */
+	return(call_let_ref_fallback(sc, let, symbol));
+      wrong_type_error_nr(sc, sc->let_ref_symbol, 2, symbol, a_symbol_string);
+    }
+  /* a let-ref method is almost impossible to write without creating an infinite loop:
+   *   any reference to the let will probably call let-ref somewhere, calling us again, and looping.
+   *   This is not a problem in c-objects and funclets because c-object-ref and funclet-ref don't exist.
+   *   After much wasted debugging, I decided to make let-ref and let-set! immutable.
+   *   What about other let-as-first-arg funcs?
+   */
+
+  if (let_id(let) == symbol_id(symbol))
+    return(local_value(symbol)); /* this has to follow the rootlet check(?) */
+
+  if (is_keyword(symbol))
+    symbol = keyword_symbol(symbol);
+  if (let == sc->rootlet)
+    return((is_slot(global_slot(symbol))) ? global_value(symbol) : sc->undefined);
+
+  for (s7_pointer e = let; e; e = let_outlet(e))
+    for (s7_pointer slot = let_slots(e); is_not_slot_end(slot); slot = next_slot(slot))
+      if (slot_symbol(slot) == symbol)
+	return(slot_value(slot));
+
+  if (is_openlet(let))
+    {
+      /* If a let is a mock-hash-table (for example), implicit indexing of the hash-table collides with the same thing for the let (field names
+       *   versus keys), and we can't just try again here because that makes it too easy to get into infinite recursion.  So, 'let-ref-fallback...
+       */
+      if (has_let_ref_fallback(let))
+	return(call_let_ref_fallback(sc, let, symbol));
+    }
+  return((is_slot(global_slot(symbol))) ? global_value(symbol) : sc->undefined); /* (let () ((curlet) 'pi)) */
+}
+
+
+s7_pointer s7_let_ref(s7_scheme *sc, s7_pointer let, s7_pointer symbol) {return(let_ref(sc, let, symbol));}
+
+
+s7_pointer g_let_ref(s7_scheme *sc, s7_pointer args)
+{
+  if (!is_pair(cdr(args)))
+    error_nr(sc, sc->syntax_error_symbol,
+	     set_elist_2(sc, wrap_string(sc, "let-ref: symbol missing: ~S", 27), set_ulist_1(sc, sc->let_ref_symbol, args)));
+  return(let_ref(sc, car(args), cadr(args)));
+}
+
+
+s7_pointer slot_in_let(s7_scheme *sc, s7_pointer let, const s7_pointer sym)
+{
+  for (s7_pointer slot = let_slots(let); is_not_slot_end(slot); slot = next_slot(slot))
+    if (slot_symbol(slot) == sym)
+      return(slot);
+  return(sc->undefined);
+}
+
+
+s7_pointer let_ref_p_pp(s7_scheme *sc, s7_pointer let, s7_pointer sym)
+{
+  if (let_id(let) == symbol_id(sym))
+    return(local_value(sym)); /* see add in tlet! */
+  if (let == sc->rootlet) /* op_implicit_let_ref_c can pass rootlet */
+    return((is_slot(global_slot(sym))) ? global_value(sym) : sc->undefined);
+  for (s7_pointer e = let; e; e = let_outlet(e))
+    for (s7_pointer slot = let_slots(e); is_not_slot_end(slot); slot = next_slot(slot))
+      if (slot_symbol(slot) == sym)
+	return(slot_value(slot));
+  if (has_let_ref_fallback(let))
+    return(call_let_ref_fallback(sc, let, sym));
+  return((is_slot(global_slot(sym))) ? global_value(sym) : sc->undefined);
+}
+
+
+s7_pointer g_cdr_let_ref(s7_scheme *sc, s7_pointer args)
+{
+  const s7_pointer let = car(args), sym = cadr(args);
+  if (!is_let(let))
+    wrong_type_error_nr(sc, sc->let_ref_symbol, 1, let, a_let_string);
+  if (let_id(let) == symbol_id(sym))
+    return(local_value(sym));
+  if (let == sc->rootlet)
+    return((is_slot(global_slot(sym))) ? global_value(sym) : sc->undefined);
+  for (s7_pointer slot = let_slots(let); is_not_slot_end(slot); slot = next_slot(slot))
+    if (slot_symbol(slot) == sym)
+      return(slot_value(slot));
+  return(let_ref_p_pp(sc, let_outlet(let), sym));
+}
+
+
+s7_pointer g_starlet_ref(s7_scheme *sc, s7_pointer args) {return(starlet(sc, starlet_symbol_id(cadr(args))));}
+
+
+s7_pointer g_rootlet_ref(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer sym = cadr(args);
+  return((is_slot(global_slot(sym))) ? global_value(sym) : sc->undefined);
+}
+
+
+s7_pointer let_ref_chooser(s7_scheme *sc, s7_pointer func, int32_t unused_args, s7_pointer expr)
+{
+  const s7_pointer arg1 = cadr(expr), arg2 = caddr(expr);
+  if ((is_quoted_symbol(sc, arg2)) && (!is_keyword(cadr(arg2))))
+    {
+      if (is_pair(arg1))
+	{
+	  if ((optimize_op(expr) == HOP_SAFE_C_opSq_C) && (car(arg1) == sc->cdr_symbol))
+	    {
+	      set_opt3_sym(cdr(expr), cadr(arg2));
+	      return(sc->cdr_let_ref);
+	    }
+	  if (car(arg1) == sc->rootlet_symbol) return(sc->rootlet_ref);
+	  if (car(arg1) == sc->curlet_symbol) return(sc->curlet_ref);
+	  if (car(arg1) == sc->unlet_symbol)
+	    {
+	      set_fn_direct(arg1, g_unlet_disabled);
+	      return(sc->unlet_ref);
+	    }}
+      if (arg1 == sc->starlet_symbol) return(sc->starlet_ref); /* should *curlet* be added? */
+    }
+  return(func);
+}
+
+
+/* ---------------------------------------- let-set! ---------------------------------------- */
+s7_pointer let_set_1(s7_scheme *sc, s7_pointer let, s7_pointer symbol, s7_pointer value)
+{
+  if (is_keyword(symbol))
+    symbol = keyword_symbol(symbol);
+
+  if (let == sc->rootlet)
+    {
+      s7_pointer slot;
+      if (is_constant_symbol(sc, symbol))  /* (let-set! (rootlet) 'pi #f) */
+	wrong_type_error_nr(sc, sc->let_set_symbol, 2, symbol, a_non_constant_symbol_string);
+      /* it would be nice if safety>0 to add an error check for bad arity if a built-in method is set (set! (lt 'write) hash-table-set!),
+       *   built_in being (initial_value_is_defined(sc, sym)), but this function is called a ton, and this error can't easily be
+       *   checked by the optimizer (we see the names, but not the values, so bad arity check requires assumptions about those values).
+       */
+      slot = global_slot(symbol);
+      if (!is_slot(slot))
+	error_nr(sc, sc->wrong_type_arg_symbol,
+		 set_elist_3(sc, wrap_string(sc, "let-set!: ~A is not defined in ~A", 33), symbol, let));
+      if (is_syntax(slot_value(slot)))
+	wrong_type_error_nr(sc, sc->let_set_symbol, 2, symbol, wrap_string(sc, "a non-syntactic symbol", 22));
+      if (is_immutable(slot))
+	immutable_object_error_nr(sc, set_elist_2(sc, wrap_string(sc, "~S is immutable in (rootlet)", 28), symbol)); /* also (set! (with-let...)...) */
+      symbol_increment_ctr(symbol);
+      slot_set_value(slot, (slot_has_setter(slot)) ? call_setter(sc, slot, value) : value);
+      return(slot_value(slot));
+    }
+  if (is_unlet(let))
+    immutable_object_error_nr(sc, set_elist_2(sc, wrap_string(sc, "~S is immutable in (unlet)", 26), symbol));
+  if (let_id(let) == symbol_id(symbol))
+   {
+     s7_pointer slot = local_slot(symbol);
+     if (is_slot(slot))
+       {
+	 symbol_increment_ctr(symbol);
+	 return(checked_slot_set_value(sc, slot, value));
+       }}
+  for (s7_pointer e = let; e; e = let_outlet(e))
+    for (s7_pointer slot = let_slots(e); is_not_slot_end(slot); slot = next_slot(slot))
+      if (slot_symbol(slot) == symbol)
+	{
+	  symbol_increment_ctr(symbol);
+	  return(checked_slot_set_value(sc, slot, value));
+	}
+  if (!has_let_set_fallback(let))
+    error_nr(sc, sc->wrong_type_arg_symbol,
+	     set_elist_3(sc, wrap_string(sc, "let-set!: ~A is not defined in ~A", 33), symbol, let));
+  /* not sure about this -- what's the most useful choice? */
+  return(call_let_set_fallback(sc, let, symbol, value));
+}
+
+
+s7_pointer let_set_2(s7_scheme *sc, s7_pointer let, s7_pointer symbol, s7_pointer value)
+{
+  if (!is_let(let))
+    {
+      s7_pointer new_let = find_let(sc, let);
+      if (!is_let(new_let))
+	find_let_error_nr(sc, sc->let_set_symbol, let, new_let, 1, set_plist_3(sc, let, symbol, value));
+      let = new_let;
+    }
+  if (!is_symbol(symbol))
+    {
+      if ((let != sc->rootlet) && (has_let_set_fallback(let)))
+	return(call_let_set_fallback(sc, let, symbol, value));
+      wrong_type_error_nr(sc, sc->let_set_symbol, 2, symbol, a_symbol_string);
+    }
+  /* currently let-set! is immutable, so we don't have to check for a let-set! method (so let_set! is always global) */
+  return(let_set_1(sc, let, symbol, value));
+}
+
+
+s7_pointer s7_let_set(s7_scheme *sc, s7_pointer let, s7_pointer symbol, s7_pointer value) {return(let_set_2(sc, let, symbol, value));}
+
+
+s7_pointer g_let_set(s7_scheme *sc, s7_pointer args)
+{
+  /* (let ((a 1)) (set! ((curlet) 'a) 32) a) */
+
+  if (!is_pair(cdr(args))) /* (let ((a 123.0)) (define (f) (set! (let-ref) a)) (catch #t f (lambda args #f)) (f)) */
+    error_nr(sc, sc->wrong_number_of_args_symbol,
+	     set_elist_3(sc, wrap_string(sc, "~S: not enough arguments: ~S", 28), sc->let_set_symbol, sc->code));
+
+  return(let_set_2(sc, car(args), cadr(args), caddr(args)));
+}
+
+
+s7_pointer let_set_p_ppp_2(s7_scheme *sc, s7_pointer let, s7_pointer sym, s7_pointer val)
+{
+  if (!is_symbol(sym))
+    wrong_type_error_nr(sc, sc->let_set_symbol, 2, sym, a_symbol_string);
+  return(let_set_1(sc, let, sym, val));
+}
+
+
+s7_pointer g_cdr_let_set(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer let = car(args);
+  const s7_pointer sym = cadr(args), val = caddr(args);
+  if (!is_let(let))
+    {
+      s7_pointer new_let = find_let(sc, let);
+      if (!is_let(new_let))
+	find_let_error_nr(sc, sc->let_set_symbol, let, new_let, 1, args);
+      let = new_let;
+    }
+  if (let != sc->rootlet)
+    {
+      for (s7_pointer e = let; e; e = let_outlet(e))
+	for (s7_pointer slot = let_slots(e); is_not_slot_end(slot); slot = next_slot(slot))
+	  if (slot_symbol(slot) == sym)
+	    {
+	      slot_set_value(slot, (slot_has_setter(slot)) ? call_setter(sc, slot, val) : val);
+	      return(slot_value(slot));
+	    }
+      if ((let != sc->rootlet) && (has_let_set_fallback(let)))
+	return(call_let_set_fallback(sc, let, sym, val));
+    }
+  {
+    s7_pointer slot = global_slot(sym);
+    if (!is_slot(slot))
+      error_nr(sc, sc->wrong_type_arg_symbol, set_elist_3(sc, wrap_string(sc, "let-set!: ~A is not defined in ~A", 33), sym, let));
+    slot_set_value(slot, (slot_has_setter(slot)) ? call_setter(sc, slot, val) : val);
+    return(slot_value(slot));
+  }
+}
+
+
+s7_pointer g_starlet_set(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer sym = cadr(args);
+  if (!is_symbol(sym)) /* (let () (define (func) (let-set! *s7* '(1 . 2) (hash-table))) (func) (func)) */
+    error_nr(sc, sc->wrong_type_arg_symbol,
+	     set_elist_3(sc, wrap_string(sc, "(let-set! *s7* ~A ...) second argument is ~A but should be a symbol", 67),
+			 sym, object_type_name(sc, sym)));
+  if (is_keyword(sym))
+    sym = keyword_symbol(sym);
+  if (starlet_symbol_id(sym) == sl_no_field)
+    error_nr(sc, sc->out_of_range_symbol, set_elist_2(sc, wrap_string(sc, "can't set (*s7* '~S); no such field in *s7*", 43), sym));
+  return(starlet_set_1(sc, sym, caddr(args)));
+}
+
+
+s7_pointer g_unlet_set(s7_scheme *sc, s7_pointer args)
+{
+  immutable_object_error_nr(sc, set_elist_2(sc, wrap_string(sc, "~S is immutable in (unlet)", 26), cadr(args)));
+  return(sc->F);
+}
+
+
+s7_pointer let_set_chooser(s7_scheme *sc, s7_pointer func, int32_t unused_args, s7_pointer expr)
+{
+  const s7_pointer arg1 = cadr(expr);
+  if (optimize_op(expr) == HOP_SAFE_C_opSq_CS)
+    {
+      const s7_pointer arg2 = caddr(expr), arg3 = cadddr(expr);
+      if ((car(arg1) == sc->cdr_symbol) &&
+	  (is_quoted_symbol(sc, arg2)) &&
+	  (!is_possibly_constant(cadr(arg2))) && /* assumes T_Sym */
+	  (!is_possibly_constant(arg3)))
+	return(sc->cdr_let_set);
+      if (car(arg1) == sc->unlet_symbol)
+	{
+	  set_fn_direct(arg1, g_unlet_disabled);
+	  return(sc->unlet_set);
+	}}
+  if (arg1 == sc->starlet_symbol) return(sc->starlet_set);
+  return(func);
+}
+
+
+/* ---------------------------------------- let copy helpers ---------------------------------------- */
+s7_pointer reverse_slots(s7_pointer let_slots)
+{
+  s7_pointer slot = let_slots, result = slot_end;
+  while (is_not_slot_end(slot))
+    {
+      s7_pointer nextslot = next_slot(slot);
+      slot_set_next(slot, result);
+      result = slot;
+      slot = nextslot;
+    }
+  return(result);
+}
+
+
+s7_pointer let_copy(s7_scheme *sc, s7_pointer let)
+{
+  s7_pointer new_let;
+  if (T_Let(let) == sc->rootlet)   /* (copy (rootlet)) or (copy (funclet abs)) etc */
+    return(sc->rootlet);
+  /* we can't make copy handle lets-as-objects specially because the make-object function in define-class uses copy to make a new object!
+   *   So if it is present, we get it here, and then there's almost surely trouble.
+   */
+  new_let = make_let(sc, let_outlet(let));
+  set_all_methods(new_let, let);
+  begin_temp(sc->x, new_let);
+  if (is_not_slot_end(let_slots(let)))
+    {
+      const s7_int id = let_id(new_let);
+      for (s7_pointer last_slot = NULL, slot = let_slots(let); is_not_slot_end(slot); slot = next_slot(slot))
+	{
+	  s7_pointer new_slot;
+	  new_cell(sc, new_slot, T_SLOT);
+	  slot_set_symbol_and_value(new_slot, slot_symbol(slot), slot_value(slot));
+	  if (symbol_id(slot_symbol(new_slot)) != id) /* keep shadowing intact */
+	    symbol_set_local_slot(slot_symbol(slot), id, new_slot);
+	  if (slot_has_setter(slot))
+	    {
+	      slot_set_setter(new_slot, slot_setter(slot));
+	      slot_set_has_setter(new_slot);
+	    }
+	  if (last_slot)
+	    slot_set_next(last_slot, new_slot);
+	  else let_set_slots(new_let, new_slot);
+	  slot_set_next(new_slot, slot_end);        /* in case GC runs during this loop */
+	  last_slot = new_slot;
+	}}
+  /* We can't do a (normal) loop here then reverse the slots later because the symbol's local_slot has to
+   *    match the unshadowed slot, not the last in the list:
+   *    (let ((e1 (inlet 'a 1 'a 2))) (let ((e2 (copy e1))) (list (equal? e1 e2) (equal? (e1 'a) (e2 'a)))))
+   */
+  end_temp(sc->x);
+  return(new_let);
+}
+
+
+s7_pointer s7_rootlet(s7_scheme *sc) {return(sc->rootlet);}
+
+
+s7_pointer s7_shadow_rootlet(s7_scheme *sc) {return(sc->shadow_rootlet);}
+
+
+s7_pointer s7_set_shadow_rootlet(s7_scheme *sc, s7_pointer let)
+{
+  s7_pointer old_let = sc->shadow_rootlet;
+  sc->shadow_rootlet = let;
+  return(old_let); /* like s7_set_curlet below */
+}
+
+
+s7_pointer s7_curlet(s7_scheme *sc) /* see also fx_curlet */
+{
+  sc->capture_let_counter++;
+  return(sc->curlet);
+}
+
+
+void update_symbol_ids(s7_scheme *sc, s7_pointer let)
+{
+  for (s7_pointer slot = let_slots(let); is_not_slot_end(slot); slot = next_slot(slot))
+    {
+      s7_pointer sym = slot_symbol(slot);
+      if (symbol_id(sym) != sc->let_number)
+	symbol_set_local_slot_unincremented(sym, sc->let_number, slot);
+    }
+}
+
+
+s7_pointer s7_set_curlet(s7_scheme *sc, s7_pointer let)
+{
+  const s7_pointer old_let = sc->curlet;
+  if (is_let(let))
+    {
+      set_curlet(sc, let);
+      if (let_id(let) > 0)
+	{
+	  let_set_id(let, ++sc->let_number);
+	  update_symbol_ids(sc, let);
+	}}
+  return(old_let);
+}
+
+
+s7_pointer s7_outlet(s7_scheme *sc, s7_pointer let) {return(let_outlet(let));}
+
+
+s7_pointer outlet_p_p(s7_scheme *sc, s7_pointer let)
+{
+  if (!is_let(let))
+    {
+      s7_pointer new_let = find_let(sc, let);
+      if (!is_let(new_let))
+	find_let_error_nr(sc, sc->outlet_symbol, let, new_let, 1, set_mlist_1(sc, let));
+      let = new_let;
+    }
+  return((let == sc->rootlet) ? sc->rootlet : let_outlet(let)); /* rootlet check is needed(!) */
+}
+
+
+s7_pointer s7i_outlet_p_p(s7_scheme *sc, s7_pointer let) {return(outlet_p_p(sc, let));}
+
+
+s7_pointer outlet_chooser(s7_scheme *sc, s7_pointer func, int32_t num_args, s7_pointer expr)
+{
+  if ((num_args == 1) && (is_pair(cadr(expr))) && (caadr(expr) == sc->unlet_symbol))
+    {
+      set_fn_direct(cadr(expr), g_unlet_disabled);
+      return(sc->outlet_unlet);
+    }
+  return(func);
+}
+
+
+s7_pointer g_set_outlet(s7_scheme *sc, s7_pointer args)
+{
+  /* (let ((a 1)) (let ((b 2)) (set! (outlet (curlet)) (rootlet)) ((curlet) 'a))) */
+  s7_pointer let = car(args), new_outer;
+
+  if (!is_let(let))
+    {
+      s7_pointer new_let = find_let(sc, let);
+      if (!is_let(new_let))
+	find_let_error_nr(sc, wrap_string(sc, "set! outlet", 11), let, new_let, 1, args);
+      let = new_let;
+    }
+  if (let == sc->starlet)
+    error_nr(sc, sc->out_of_range_symbol, set_elist_1(sc, wrap_string(sc, "can't set! (outlet *s7*)", 24)));
+  if (is_immutable_let(let))
+    immutable_object_error_nr(sc, set_elist_4(sc, wrap_string(sc, "can't (set! (outlet ~S) ~S), ~S is immutable", 44), let, cadr(args), let));
+  new_outer = cadr(args);
+  if (!is_let(new_outer))
+    {
+      s7_pointer new_let = find_let(sc, new_outer);
+      if (!is_let(new_let))
+	find_let_error_nr(sc, wrap_string(sc, "set! outlet", 11), new_outer, new_let, 2, args);
+      new_outer = new_let;
+    }
+  if (let != sc->rootlet)
+    {
+      /* here it's possible to get cyclic let chains; maybe do this check only if safety>0 */
+      for (s7_pointer new_let = new_outer; new_let; new_let = let_outlet(new_let))
+	if (let == new_let)
+	  error_nr(sc, make_symbol(sc, "cyclic-let", 10),
+		   set_elist_2(sc, wrap_string(sc, "set! (outlet ~A) creates a cyclic let chain", 43), let));
+      let_set_outlet(let, new_outer);
+    }
+  return(new_outer);
+}
+
+
+/* ---------------------------------------- symbol->value ---------------------------------------- */
+s7_pointer g_symbol_to_value(s7_scheme *sc, s7_pointer args)
+{
+
+  const s7_pointer sym = car(args);
+  if (!is_symbol(sym))
+    return(method_or_bust(sc, sym, sc->symbol_to_value_symbol, args, sc->type_names[T_SYMBOL], 1));
+  if (is_keyword(sym))
+    {
+      if ((is_pair(cdr(args))) && (!is_let(cadr(args))) && (!is_let(find_let(sc, cadr(args)))))
+	wrong_type_error_nr(sc, sc->symbol_to_value_symbol, 2, cadr(args), sc->type_names[T_LET]);
+      return(sym);
+    }
+  if (is_pair(cdr(args)))
+    {
+      s7_pointer local_let = cadr(args);
+      if (!is_let(local_let))
+	{
+	  local_let = find_let(sc, local_let);
+	  if (!is_let(local_let))
+	    return(method_or_bust(sc, cadr(args), sc->symbol_to_value_symbol, args, a_let_string, 2)); /* not local_let */
+	}
+      if (local_let == sc->rootlet) return((is_slot(global_slot(sym))) ? global_value(sym) : sc->undefined);
+      if (is_unlet(local_let)) return(initial_value(sym));
+      if (local_let == sc->starlet) return(starlet(sc, starlet_symbol_id(sym)));
+      return(s7_symbol_local_value(sc, sym, local_let));
+    }
+  if (is_defined_global(sym))
+    return(global_value(sym));
+  return(s7_symbol_value(sc, sym));
+}
+
+
+s7_pointer symbol_to_value_chooser(s7_scheme *sc, s7_pointer func, int32_t unused_args, s7_pointer expr)
+{
+  s7_pointer arg1 = cadr(expr), arg2 = (is_pair(cddr(expr))) ? caddr(expr) : sc->F;
+  if ((is_quoted_symbol(sc, arg1)) && (!is_keyword(cadr(arg1))) && (is_pair(arg2)) && (car(arg2) == sc->unlet_symbol)) /* old-style (obsolete) unlet as third arg(!) */
+    {
+      set_fn_direct(arg2, g_unlet_disabled);
+      return(sc->sv_unlet_ref);
+    }
+  return(func);
+}
+
+
+/* ---------------------------------------- symbol->dynamic-value ---------------------------------------- */
+static s7_pointer find_dynamic_value(s7_scheme *sc, s7_pointer let, s7_pointer sym, s7_int *id)
+{
+  for (; let_id(let) > symbol_id(sym); let = let_outlet(let));
+  if (let_id(let) == symbol_id(sym))
+    {
+      (*id) = let_id(let);
+      return(local_value(sym));
+    }
+  for (; (let) && (let_id(let) > (*id)); let = let_outlet(let))
+    for (s7_pointer slot = let_slots(let); is_not_slot_end(slot); slot = next_slot(slot))
+      if (slot_symbol(slot) == sym)
+	{
+	  (*id) = let_id(let);
+	  return(slot_value(slot));
+	}
+  return(sc->unused);
+}
+
+
+s7_pointer g_symbol_to_dynamic_value(s7_scheme *sc, s7_pointer args)
+{
+
+  const s7_pointer sym = car(args);
+  s7_pointer val;
+  s7_int top_id = -1;
+
+  if (!is_symbol(sym))
+    return(method_or_bust(sc, sym, sc->symbol_to_dynamic_value_symbol, args, sc->type_names[T_SYMBOL], 1));
+
+  if (is_defined_global(sym))
+    return(global_value(sym));
+
+  if (let_id(sc->curlet) == symbol_id(sym))
+    return(local_value(sym));
+
+  val = find_dynamic_value(sc, sc->curlet, sym, &top_id);
+  if (top_id == symbol_id(sym))
+    return(val);
+
+  for (s7_int op_loc = stack_top(sc) - 1; op_loc > 0; op_loc -= 4)
+    if (is_let_unchecked(stack_let(sc->stack, op_loc))) /* OP_GC_PROTECT let slot can be anything (even free) */
+      {
+	s7_pointer cur_val = find_dynamic_value(sc, stack_let(sc->stack, op_loc), sym, &top_id);
+	if (cur_val != sc->unused)
+	  val = cur_val;
+	if (top_id == symbol_id(sym))
+	  return(val);
+      }
+  /* what about call/cc stacks? */
+  return((val == sc->unused) ? s7_symbol_value(sc, sym) : val);
+}
+
+
+/* ---------------------------------------- defined? ---------------------------------------- */
+s7_pointer g_is_defined(s7_scheme *sc, s7_pointer args)
+{
+  /* if the symbol has a global slot and e is unset or rootlet, this returns #t */
+
+  s7_pointer sym = car(args);
+  if (!is_symbol(sym))
+    return(method_or_bust(sc, sym, sc->is_defined_symbol, args, sc->type_names[T_SYMBOL], 1));
+
+  if (is_pair(cdr(args)))
+    {
+      s7_pointer let = cadr(args);
+      const s7_pointer ignore_globals = (is_pair(cddr(args))) ? caddr(args) : sc->F;
+      if (!is_let(let))
+	{
+	  const s7_pointer new_let = find_let(sc, let);  /* returns () if none */
+	  if (!is_let(new_let))
+	    find_let_error_nr(sc, sc->is_defined_symbol, let, new_let, 2, args);
+	  if ((new_let == sc->rootlet) && (is_pair(cddr(args))) && (ignore_globals != sc->F))
+	    {
+	      if (ignore_globals != sc->T) /* signature claims this should be a boolean */
+		return(method_or_bust(sc, ignore_globals, sc->is_defined_symbol, args, a_boolean_string, 3));
+	      return(sc->F);
+	    }
+	  let = new_let;
+	}
+      /* if (is_unlet(let)) return(make_boolean(sc, initial_value_is_defined(sc, sym))); */
+      /* this ^ is wrong: (with-let (unlet) (define xx 1) (list (defined? 'xx) (defined? 'xx (curlet)))) should be (#t #t) */
+
+      if (is_keyword(sym))                       /* if no "let", is global -> #t */
+	{                                        /* we're treating :x as 'x outside rootlet, but consider all keywords defined (as themselves) in rootlet? */
+	  if (let == sc->rootlet) return(sc->T); /* (defined? x (rootlet)) where x value is a keyword */
+	  sym = keyword_symbol(sym);             /* (defined? :print-length *s7*) */
+	}
+      if (let == sc->starlet)
+	return(make_boolean(sc, starlet_symbol_id(sym) != sl_no_field));
+      if (!is_boolean(ignore_globals))
+	return(method_or_bust(sc, ignore_globals, sc->is_defined_symbol, args, a_boolean_string, 3));
+      if (let == sc->rootlet) /* we checked (let? let) above */
+	{
+	  if (ignore_globals == sc->F)
+	    return(make_boolean(sc, is_slot(global_slot(sym)))); /* new_symbol and gensym initialize global_slot to #<undefined> */
+	  return(sc->F);
+	}
+      if (is_slot(symbol_to_local_slot(sc, sym, T_Let(let)))) return(sc->T);
+      return((ignore_globals == sc->T) ? sc->F : make_boolean(sc, is_slot(global_slot(sym))));
+    }
+  return((is_defined_global(sym)) ? sc->T : make_boolean(sc, is_bound_symbol(sc, sym)));
+}
+
+
+/* ---------------------------------------- funclet ---------------------------------------- */
+s7_pointer g_funclet(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer func = car(args);
+  if (is_symbol(func))
+    {
+      if ((func = s7_symbol_value(sc, func)) == sc->undefined)
+	error_nr(sc, sc->wrong_type_arg_symbol,
+		 set_elist_2(sc, wrap_string(sc, "funclet argument, '~S, is unbound", 33), car(args))); /* not func here */
+    }
+  if_method_exists_return_value(sc, func, sc->funclet_symbol, args);
+  if (!((is_any_procedure(func)) || (is_c_object(func))))
+    sole_arg_wrong_type_error_nr(sc, sc->funclet_symbol, func, a_procedure_or_a_macro_string);
+  return(find_let(sc, func));
+}
+
+
+/* ---------------------------------------- owlet ---------------------------------------- */
+s7_pointer g_owlet(s7_scheme *sc, s7_pointer args)
+{
+  /* if owlet is not copied, (define e (owlet)), e changes as owlet does! */
+
+  s7_pointer let;
+  const bool old_gc = sc->gc_off;
+  if (is_pair(args))
+    error_nr(sc, sc->wrong_number_of_args_symbol, set_elist_3(sc, too_many_arguments_string, sc->owlet_symbol, args));
+#if WITH_HISTORY
+  slot_set_value(sc->error_history, sanitize_history(sc, slot_value(sc->error_history)));
+#endif
+  let = let_copy(sc, sc->owlet);
+  gc_protect_via_stack(sc, let);
+
+  /* make sure the pairs/reals/strings/integers are copied: should be error-data, error-code, and error-history */
+  sc->gc_off = true;
+  for (s7_pointer slot = let_slots(let); is_not_slot_end(slot); slot = next_slot(slot))
+    if (is_pair(slot_value(slot)))
+      {
+	const s7_pointer new_list = copy_any_list(sc, slot_value(slot));
+	slot_set_value(slot, new_list);
+	for (s7_pointer p = new_list, sp = p; is_pair(p); p = cdr(p), sp = cdr(sp))
+	  {
+	    s7_pointer val = car(p);
+	    if (is_t_real(val))
+	      set_car(p, make_real(sc, real(val)));
+	    else
+	      if (is_string(val))
+		set_car(p, make_string_with_length(sc, string_value(val), string_length(val)));
+	      else
+		if (is_t_integer(val))
+		  set_car(p, make_integer(sc, integer(val)));
+	    p = cdr(p);
+	    if ((!is_pair(p)) || (p == sp)) break;
+	    val = car(p);
+	    if (is_t_real(val))
+	      set_car(p, make_real(sc, real(val)));
+	    else
+	      if (is_string(val))
+		set_car(p, make_string_with_length(sc, string_value(val), string_length(val)));
+	  }}
+  sc->gc_off = old_gc;
+  unstack_gc_protect(sc);
+  return(let);
+}

--- a/src/s7_scheme_let.h
+++ b/src/s7_scheme_let.h
@@ -1,0 +1,64 @@
+/* s7_scheme_let.h - let (environment) function declarations for s7 Scheme interpreter
+ *
+ * derived from s7, a Scheme interpreter
+ * SPDX-License-Identifier: 0BSD
+ */
+
+#ifndef S7_SCHEME_LET_H
+#define S7_SCHEME_LET_H
+
+#include "s7.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+s7_pointer g_unlet(s7_scheme *sc, s7_pointer unused_args);
+s7_pointer g_openlet(s7_scheme *sc, s7_pointer args);
+s7_pointer g_coverlet(s7_scheme *sc, s7_pointer args);
+s7_pointer g_varlet(s7_scheme *sc, s7_pointer args);
+s7_pointer g_cutlet(s7_scheme *sc, s7_pointer args);
+s7_pointer g_sublet(s7_scheme *sc, s7_pointer args);
+s7_pointer g_sublet_curlet(s7_scheme *sc, s7_pointer args);
+s7_pointer sublet_chooser(s7_scheme *sc, s7_pointer func, int32_t num_args, s7_pointer expr);
+s7_pointer g_simple_inlet(s7_scheme *sc, s7_pointer args);
+s7_pointer inlet_p_pp(s7_scheme *sc, s7_pointer symbol, s7_pointer value);
+s7_pointer internal_inlet(s7_scheme *sc, s7_int num_args, ...);
+s7_pointer inlet_chooser(s7_scheme *sc, s7_pointer func, int32_t args, s7_pointer expr);
+s7_pointer g_let_to_list(s7_scheme *sc, s7_pointer args);
+s7_pointer call_let_ref_fallback(s7_scheme *sc, s7_pointer let, s7_pointer symbol);
+s7_pointer call_let_set_fallback(s7_scheme *sc, s7_pointer let, s7_pointer symbol, s7_pointer value);
+s7_pointer let_ref(s7_scheme *sc, s7_pointer let, s7_pointer symbol);
+s7_pointer g_let_ref(s7_scheme *sc, s7_pointer args);
+s7_pointer slot_in_let(s7_scheme *sc, s7_pointer let, const s7_pointer sym);
+s7_pointer let_ref_p_pp(s7_scheme *sc, s7_pointer let, s7_pointer sym);
+s7_pointer g_cdr_let_ref(s7_scheme *sc, s7_pointer args);
+s7_pointer g_starlet_ref(s7_scheme *sc, s7_pointer args);
+s7_pointer g_rootlet_ref(s7_scheme *sc, s7_pointer args);
+s7_pointer let_ref_chooser(s7_scheme *sc, s7_pointer func, int32_t unused_args, s7_pointer expr);
+s7_pointer let_set_1(s7_scheme *sc, s7_pointer let, s7_pointer symbol, s7_pointer value);
+s7_pointer let_set_2(s7_scheme *sc, s7_pointer let, s7_pointer symbol, s7_pointer value);
+s7_pointer g_let_set(s7_scheme *sc, s7_pointer args);
+s7_pointer let_set_p_ppp_2(s7_scheme *sc, s7_pointer let, s7_pointer sym, s7_pointer val);
+s7_pointer g_cdr_let_set(s7_scheme *sc, s7_pointer args);
+s7_pointer g_starlet_set(s7_scheme *sc, s7_pointer args);
+s7_pointer g_unlet_set(s7_scheme *sc, s7_pointer args);
+s7_pointer let_set_chooser(s7_scheme *sc, s7_pointer func, int32_t unused_args, s7_pointer expr);
+s7_pointer reverse_slots(s7_pointer let_slots);
+s7_pointer let_copy(s7_scheme *sc, s7_pointer let);
+void update_symbol_ids(s7_scheme *sc, s7_pointer let);
+s7_pointer outlet_p_p(s7_scheme *sc, s7_pointer let);
+s7_pointer outlet_chooser(s7_scheme *sc, s7_pointer func, int32_t num_args, s7_pointer expr);
+s7_pointer g_set_outlet(s7_scheme *sc, s7_pointer args);
+s7_pointer g_symbol_to_value(s7_scheme *sc, s7_pointer args);
+s7_pointer symbol_to_value_chooser(s7_scheme *sc, s7_pointer func, int32_t unused_args, s7_pointer expr);
+s7_pointer g_symbol_to_dynamic_value(s7_scheme *sc, s7_pointer args);
+s7_pointer g_is_defined(s7_scheme *sc, s7_pointer args);
+s7_pointer g_funclet(s7_scheme *sc, s7_pointer args);
+s7_pointer g_owlet(s7_scheme *sc, s7_pointer args);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* S7_SCHEME_LET_H */

--- a/xmake.lua
+++ b/xmake.lua
@@ -134,6 +134,7 @@ target ("goldfish") do
     add_files ("src/s7_ctables.c", {languages = "c11"})
     add_files ("src/s7_dtoa.c", {languages = "c11"})
     add_files ("src/s7_continuation.c", {languages = "c11"})
+    add_files ("src/s7_scheme_let.c", {languages = "c11"})
     add_packages("tbox")
     add_packages("argh")
     add_packages("nlohmann_json")


### PR DESCRIPTION
## Summary
- 从 `src/s7.c` 迁出 let（环境）相关函数到新增的 `src/s7_scheme_let.c` / `src/s7_scheme_let.h`：unlet、openlet、coverlet、varlet、cutlet、sublet、inlet、let->list、let-ref、let-set!、rootlet、curlet、outlet、symbol->value、symbol->dynamic-value、defined?、funclet、owlet 及其私有辅助，共 63 个区段，s7.c 缩减约 1200 行
- `src/s7_internal.h` 追加迁移所需的宏（含 S7_DEBUGGING / WITH_GCC 多分支变体）、`starlet_t` 枚举、外部全局变量与函数声明；热函数用 `extern inline` 模式保持 s7.c 内联
- s7.c 中约 39 个 static 函数去 static（含 5 个仅 debug 模式编译的调试函数），通过新头文件暴露给 s7_scheme_let.c

## Test plan
- [x] `xmake b goldfish` release 构建通过
- [x] debug 模式（-DS7_DEBUGGING）两个 TU 编译 + 符号交叉检查通过
- [x] 20 个 let 测试文件（tests/liii/base/）全部通过
- [x] `bin/gf test --all` 1492 项全部通过
- [x] `bin/gf doc funclet` / `bin/gf doc let-set!` 正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)