### PR TITLE
[0094] 用 C 实现 vector-filter 提升性能

### DIFF
--- a/devel/0094.md
+++ b/devel/0094.md
@@ -1,0 +1,46 @@
+# [0094] 用 C 实现 vector-filter 提升性能
+
+## 任务相关的代码文件
+- src/s7_liii_vector.c
+- src/s7_liii_vector.h
+- src/s7.c
+- goldfish/liii/vector.scm
+- tests/liii/vector/vector-filter-test.scm
+- bench/vector-filter.scm
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf fmt goldfish/liii/vector.scm
+bin/gf fmt tests/liii/vector/vector-filter-test.scm
+bin/gf tests/liii/vector/vector-filter-test.scm
+bin/gf bench/vector-filter.scm
+```
+
+## 2026-07-30 用 C 实现 vector-filter 提升性能
+
+### What
+1. 在 `src/s7_liii_vector.c` 新增 `g_vector_filter`，并在 `s7_liii_vector.h` 声明
+2. 在 `src/s7.c` 中通过 `s7_define_semisafe_typed_function` 注册 `g_vector_filter`
+3. `goldfish/liii/vector.scm` 中 `vector-filter` 改为直接绑定 `g_vector_filter`
+4. 测试补充错误处理用例（pred 非过程、vec 非向量时抛 `wrong-type-arg`）
+
+### Why
+原实现通过 `vector-fold-right` 构造中间列表再 `list->vector`，有一次完整的列表分配和转换开销。
+
+### How
+仿照 [0089] `g_take` / `g_filter` 的模式：
+- 按原向量长度预分配结果向量，单次遍历调用谓词并填充（谓词只调用一次，副作用谓词语义正确）
+- 用 anchor pair 把 `pred`、`vec`、结果向量挂在 `s7_gc_protect_via_stack` 上，保证谓词回调期间 GC 安全
+- 若有过滤掉的元素，最后复制到精确大小的新向量返回
+
+### 性能对比（bench/vector-filter.scm）
+
+| 场景 | 优化前（秒） | 优化后（秒） | 提升 |
+|---|---|---|---|
+| 空向量 (100000 次） | 0.0233 | 0.0078 | ~3.0x |
+| 小向量（10）全匹配 (100000 次） | 0.1365 | 0.0491 | ~2.8x |
+| 小向量（10）半匹配 (100000 次） | 0.1238 | 0.0224 | ~5.5x |
+| 中向量（100）半匹配 (100000 次） | 1.0396 | 0.1501 | ~6.9x |
+| 大向量（1000）半匹配 (10000 次） | 1.0505 | 0.1670 | ~6.3x |
+| 超大向量（10000) (1000 次） | 1.1090 | 0.1748 | ~6.3x |

--- a/goldfish/liii/vector.scm
+++ b/goldfish/liii/vector.scm
@@ -52,13 +52,7 @@
   ) ;export
   (begin
 
-    (define (vector-filter pred vec)
-      (list->vector (vector-fold-right (lambda (elem acc) (if (pred elem) (cons elem acc) acc))
-                      '()
-                      vec
-                    ) ;vector-fold-right
-      ) ;list->vector
-    ) ;define
+    (define vector-filter g_vector_filter)
 
     (define (vector-contains? vec elem . args)
       (let ((cmp (if (null? args) equal? (car args))))

--- a/src/s7.c
+++ b/src/s7.c
@@ -86917,6 +86917,10 @@ is #t, the string is also sent to the current-output-port."
   #define Q_drop_right s7_make_signature(sc, 3, sc->is_list_symbol, sc->is_list_symbol, sc->is_integer_symbol)
   s7_define_semisafe_typed_function(sc, "g_drop_right", g_drop_right, 2, 0, false, H_drop_right, Q_drop_right);
 
+  #define H_vector_filter "(g_vector_filter pred vec) returns a vector of the elements of vec for which (pred element) is not #f"
+  #define Q_vector_filter s7_make_signature(sc, 3, sc->is_vector_symbol, sc->is_procedure_symbol, sc->is_vector_symbol)
+  s7_define_semisafe_typed_function(sc, "g_vector_filter", g_vector_filter, 2, 0, false, H_vector_filter, Q_vector_filter);
+
   sc->length_symbol =                defun("length",		length,			1, 0, false);
   sc->copy_symbol =                  defun("copy",		copy,			1, 3, false);
   /* set_is_definer(sc->copy_symbol); */ /* (copy (inlet 'a 1) (curlet)), but this check needs to be smarter */

--- a/src/s7_liii_vector.c
+++ b/src/s7_liii_vector.c
@@ -354,6 +354,41 @@ s7_pointer g_list_to_vector(s7_scheme *sc, s7_pointer args)
   return(g_vector(sc, lst));
 }
 
+s7_pointer g_vector_filter(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer pred = s7_car(args);
+  s7_pointer vec = s7_cadr(args);
+  if (!s7_is_procedure(pred))
+    return(s7_wrong_type_arg_error(sc, "vector-filter", 1, pred, "a procedure"));
+  if (!s7_is_vector(vec))
+    return(s7_wrong_type_arg_error(sc, "vector-filter", 2, vec, "a vector"));
+  /* args may live in evaluator-recycled cells, so keep pred and vec in our own
+   * pair, with the result vector as the anchor's cdr; everything stays
+   * GC-reachable while pred runs */
+  s7_pointer anchor = s7_cons(sc, s7_cons(sc, pred, vec), s7_make_vector(sc, s7_vector_length(vec)));
+  s7_gc_protect_via_stack(sc, anchor);
+  s7_pointer result = s7_cdr(anchor);
+  s7_int len = s7_vector_length(vec);
+  s7_int count = 0;
+  for (s7_int i = 0; i < len; i++)
+    {
+      s7_pointer elem = s7_vector_ref(sc, vec, i);
+      if (s7i_is_true(sc, s7_apply_function(sc, pred, s7i_set_plist_1(sc, elem))))
+        {
+          s7_vector_set(sc, result, count, elem);
+          count++;
+        }
+    }
+  s7_gc_unprotect_via_stack(sc, anchor);
+  if (count == len) return(result);
+  {
+    s7_pointer exact = s7_make_vector(sc, count);
+    for (s7_int i = 0; i < count; i++)
+      s7_vector_set(sc, exact, i, s7_vector_ref(sc, result, i));
+    return(exact);
+  }
+}
+
 #if !WITH_PURE_S7
 
 s7_pointer g_vector_length(s7_scheme *sc, s7_pointer args)

--- a/src/s7_liii_vector.h
+++ b/src/s7_liii_vector.h
@@ -42,6 +42,7 @@ s7_pointer g_cv_ref_2(s7_scheme *sc, s7_pointer args);
 s7_pointer g_fv_ref_2(s7_scheme *sc, s7_pointer args);
 s7_pointer g_iv_ref_2(s7_scheme *sc, s7_pointer args);
 s7_pointer g_cv_set_3(s7_scheme *sc, s7_pointer args);
+s7_pointer g_vector_filter(s7_scheme *sc, s7_pointer args);
 
 #if !WITH_PURE_S7
 s7_pointer g_list_to_vector(s7_scheme *sc, s7_pointer args);

--- a/tests/liii/vector/vector-filter-test.scm
+++ b/tests/liii/vector/vector-filter-test.scm
@@ -39,5 +39,8 @@
 (check (vector-filter (lambda (x) #t) #()) => #())
 (check (vector-filter (lambda (x) #f) #(1 2 3)) => #())
 
+(check-catch 'wrong-type-arg (vector-filter 1 #(1 2 3)))
+(check-catch 'wrong-type-arg (vector-filter even? '(1 2 3)))
+
 
 (check-report)


### PR DESCRIPTION
## Summary
- 在 `src/s7_liii_vector.c` 新增 `g_vector_filter`（单次遍历、谓词只调用一次，anchor pair 保证 GC 安全），并在 `src/s7.c` 注册
- `goldfish/liii/vector.scm` 中 `vector-filter` 改为直接绑定 `g_vector_filter`，替代原先 `vector-fold-right` + `list->vector` 的实现
- 测试补充 `wrong-type-arg` 错误用例；新增 `devel/0094.md` 记录任务
- 性能提升：大向量场景约 6.3~6.9x，小向量约 2.8~5.5x（详见 devel/0094.md）

## Test plan
- [x] `xmake b goldfish` 构建通过
- [x] `bin/gf tests/liii/vector/vector-filter-test.scm`（7 项通过）
- [x] `bin/gf tests/liii/vector-test.scm` 及 vector/path 相关测试套件通过
- [x] `bin/gf bench/vector-filter.scm` 前后对比确认性能提升

🤖 Generated with [Claude Code](https://claude.com/claude-code)