### PR TITLE
[0096] 修复 gf fmt 对 ,@ 的格式化

### DIFF
--- a/devel/0096.md
+++ b/devel/0096.md
@@ -1,0 +1,32 @@
+# [0096] 修复 gf fmt 对 ,@ 的格式化
+
+## 任务相关的代码文件
+- tools/fmt/liii/goldfmt-scan.scm
+- tools/fmt/tests/liii/goldfmt-format/quote-test.scm
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf test tools/fmt/tests
+```
+
+## 2026-08-07 修复显式 quasiquote 中 ,@ 被格式化为 #_apply-values 的问题
+
+### What
+1. 在 `normalize-datum` 中新增对 `(unquote (#_apply-values x))` 形式的正规化，转换为 `(unquote-splicing x)`
+2. 裸的 `(#_apply-values x)` 形式同样正规化（防御性处理）
+3. 新增回归测试，覆盖 `,@b`、`,@(f x)`、`(quasiquote (... ,@(f)))`、点对内、define-macro 内等场景
+
+### Why
+S7 reader 在反引号上下文之外遇到 `,@x` 时（例如显式 `(quasiquote (a ,@(maxima-launchers)))`），
+会展开为 `(unquote (#_apply-values x))`。`normalize-datum` 之前只处理反引号整体展开出的
+`#_list-values` / `#_list*` 形式，导致 `#_apply-values` 这个 S7 内部 procedure 对象被直接打印，
+格式化成 `` `(a ,(#_apply-values (maxima-launchers))) ``。
+
+修复后 `(quasiquote (a ,@(maxima-launchers)))` 格式化为 `` `(a ,@(maxima-launchers)) ``，
+与既有 `(quasiquote (a b))` => `` `(a b) `` 行为一致（显式 quasiquote 统一转换为反引号形式）。
+
+### How
+在 `goldfmt-scan.scm` 中新增 `unquote-apply-values-form?` 谓词，识别
+`(unquote (#_apply-values x))` 组合形式；在 `normalize-datum` 的 `pair?` 分支之前
+插入两个正规化分支。已知未处理：`` ``(a ,@b) ``（双层嵌套）和 `` `#(a ,@b) ``（vector 内）。

--- a/tools/fmt/liii/goldfmt-scan.scm
+++ b/tools/fmt/liii/goldfmt-scan.scm
@@ -188,6 +188,16 @@
       (and (pair? value) (procedure-name=? (car value) "#_apply-values"))
     ) ;define
 
+    ;; ; 判断是否为 S7 reader 对 ` 上下文之外的 ,@x 的展开形式：(unquote (#_apply-values x))
+    (define (unquote-apply-values-form? value)
+      (and (pair? value)
+        (eq? (car value) 'unquote)
+        (pair? (cdr value))
+        (null? (cddr value))
+        (internal-apply-values-form? (cadr value))
+      ) ;and
+    ) ;define
+
     (define (internal-list-star-form? value)
       (and (pair? value)
         (let ((name (procedure-name (car value))))
@@ -268,6 +278,15 @@
             ) ;
             ((internal-list-star-form? datum)
              (list 'quasiquote (normalize-quasiquote-dotted-list datum))
+            ) ;
+            ;; ; S7 reader 会将不在 ` 上下文中的 ,@x 展开为 (unquote (#_apply-values x))
+            ;; ; 例如 (quasiquote (a ,@(f)))，需要正规化为 (unquote-splicing x)
+            ((unquote-apply-values-form? datum)
+             (list 'unquote-splicing (normalize-datum (cadr (cadr datum))))
+            ) ;
+            ;; ; 单独出现的 (#_apply-values x) 同样正规化为 (unquote-splicing x)
+            ((internal-apply-values-form? datum)
+             (list 'unquote-splicing (normalize-datum (cadr datum)))
             ) ;
             ((pair? datum)
              (cons (normalize-datum (car datum)) (normalize-datum (cdr datum)))

--- a/tools/fmt/tests/liii/goldfmt-format/quote-test.scm
+++ b/tools/fmt/tests/liii/goldfmt-format/quote-test.scm
@@ -8,4 +8,32 @@
 ;; 测试列表内部的 quote 形式应格式化为 'x
 (check (format-string "(list '(a b))") => "(list '(a b))\n")
 
+;; 测试 `,@ 形式应被格式化为 `,@，而不是展开为 S7 内部形式
+(check (format-string "`(a ,@b)") => "`(a ,@b)\n")
+(check (format-string "`(a ,b ,@c)") => "`(a ,b ,@c)\n")
+
+;; 多点对中的 ,@
+(check (format-string "`(a ,@b . c)") => "`(a ,@b . c)\n")
+;; define-macro 中的 ,@
+(check (format-string "(define-macro (m x) `(list ,@x))")
+  =>
+  "(define-macro (m x) `(list ,@x))\n"
+) ;check
+;; ,@ 后面紧跟右括号
+(check (format-string "`(,@a)") => "`(,@a)\n")
+;; ,@ 后面紧跟符号
+(check (format-string "`(,@a b)") => "`(,@a b)\n")
+;; ,@ 后面跟函数调用形式
+(check (format-string "`(a ,@(f x))") => "`(a ,@(f x))\n")
+(check (format-string "`(,@(maxima-launchers))") => "`(,@(maxima-launchers))\n")
+;; ,@ 出现在显式 (quasiquote ...) 形式中
+;; 与 (quasiquote (a b)) => `(a b) 的既有行为一致，显式 quasiquote 会转换为 ` 形式
+(check (format-string "(quasiquote (a ,@(maxima-launchers)))")
+  =>
+  "`(a ,@(maxima-launchers))\n"
+) ;check
+;; 确认不含 ,@ 的显式 quasiquote 的既有行为
+(check (format-string "(quasiquote (a b))") => "`(a b)\n")
+(check (format-string "(quasiquote (a ,b))") => "`(a ,b)\n")
+
 (check-report)


### PR DESCRIPTION
## What
修复 `gf fmt` 将显式 quasiquote 中的 `,@` 格式化为 S7 内部形式 `#_apply-values` 的问题。

修复前：
```scheme
(quasiquote (a ,@(maxima-launchers)))  =>  `(a ,(#_apply-values (maxima-launchers)))
```

修复后：
```scheme
(quasiquote (a ,@(maxima-launchers)))  =>  `(a ,@(maxima-launchers))
```

## Why
S7 reader 在反引号上下文之外遇到 `,@x` 时（例如显式 `(quasiquote ...)` 内部），会展开为 `(unquote (#_apply-values x))`。`normalize-datum` 之前只处理反引号整体展开出的 `#_list-values` / `#_list*` 形式，导致内部 procedure 对象被直接打印。

## How
- `tools/fmt/liii/goldfmt-scan.scm`：新增 `unquote-apply-values-form?` 谓词，在 `normalize-datum` 中将 `(unquote (#_apply-values x))` 和裸 `(#_apply-values x)` 正规化为 `(unquote-splicing x)`
- 新增回归测试，覆盖 `,@b`、`,@(f x)`、`(quasiquote (... ,@(f)))`、点对内、define-macro 内等场景

## 测试
```bash
xmake b goldfish
bin/gf test tools/fmt/tests   # 27/27 通过
```

已知未处理：`` ``(a ,@b) ``（双层嵌套）和 `` `#(a ,@b) ``（vector 内）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)