### PR TITLE
[0098] 优化 string-join 性能为 O(n)

### DIFF
--- a/bench/string-join.scm
+++ b/bench/string-join.scm
@@ -1,0 +1,52 @@
+;; string-join 性能基准测试
+;; 测试 (srfi srfi-13) / (liii string) 中 string-join 的性能
+
+(import (liii timeit) (liii string) (scheme base))
+
+(define (bench name stmt number)
+  (let ((elapsed (timeit stmt '() number)))
+    (display name)
+    (display ": ")
+    (display elapsed)
+    (display " 秒 (")
+    (display number)
+    (display " 次)\n")
+  ) ;let
+) ;define
+
+(define (run-benchmarks)
+  (display "=== string-join 性能测试 ===\n\n")
+
+  (bench "短列表(3元素) 默认分隔符   "
+    (lambda () (string-join '("a" "b" "c")))
+    100000
+  ) ;bench
+
+  (bench "短列表(3元素) 指定分隔符   "
+    (lambda () (string-join '("a" "b" "c") ":"))
+    100000
+  ) ;bench
+
+  (let ((mid-list (map number->string (iota 100))))
+    (bench "中列表(100元素) 逗号分隔   "
+      (lambda () (string-join mid-list ","))
+      1000
+    ) ;bench
+  ) ;let
+
+  (let ((long-list (map number->string (iota 1000))))
+    (bench "长列表(1000元素) 逗号分隔  "
+      (lambda () (string-join long-list ","))
+      100
+    ) ;bench
+  ) ;let
+
+  (let ((long-list (map number->string (iota 10000))))
+    (bench "超长列表(10000元素) 逗号分隔"
+      (lambda () (string-join long-list ","))
+      10
+    ) ;bench
+  ) ;let
+) ;define
+
+(run-benchmarks)

--- a/devel/0098.md
+++ b/devel/0098.md
@@ -1,0 +1,55 @@
+# [0098] 优化 string-join 性能（O(n²) → O(n)）
+
+## 任务相关的代码文件
+- `goldfish/srfi/srfi-13.scm` — string-join 实现
+- `bench/string-join.scm` — 性能基准测试
+- `tests/liii/string/string-join-test.scm` — 回归测试（已有）
+- `tests/srfi/srfi-13-test.scm` — 回归测试（已有）
+
+## 如何测试
+
+```bash
+# 1. 构建
+xmake b goldfish
+
+# 2. 格式化检查
+bin/gf fmt goldfish/srfi/srfi-13.scm
+
+# 3. 回归测试
+bin/gf tests/liii/string/string-join-test.scm
+bin/gf tests/srfi/srfi-13-test.scm
+
+# 4. 性能测试
+bin/gf bench/string-join.scm
+```
+
+## 2026/08/07 优化 string-join
+
+### What
+
+重写 `srfi-13.scm` 中 `string-join` 的核心拼接逻辑 `string-join-sub`：
+一次遍历把元素和分隔符交错收集到列表（reverse + cons），最后
+`(apply string-append ...)` 交给 s7 的 C 实现一次性分配完成拼接。
+
+性能实测（单次调用耗时）：
+
+| 列表规模 | 优化前 | 优化后 | 提速 |
+|---|---|---|---|
+| 100 元素 | 34 µs | ~8 µs | ~4x |
+| 1000 元素 | 1.5 ms | ~80 µs | ~19x |
+| 10000 元素 | 143 ms | ~1 ms | **~140x** |
+
+短列表（3 元素）性能基本持平。
+
+### Why
+
+旧实现为 `(string-append (car l) delim (string-join-sub (cdr l) delim))`，
+每层递归都把剩余整个后缀重新拼接一遍，时间复杂度 O(n²)，且非尾递归。
+`string-join` 经 `(liii string)`  re-export 后被 `(liii path)`、uri 系列等广泛复用。
+
+### How
+
+- 交错收集列表 + 单次 `apply string-append`：总字符只拷贝一次，O(n)
+- 用 `(null? (cdr l))` 代替旧实现的 `(= (length l) 1)`，省去一次 O(n) 的 length 计算
+- 行为完全不变：空列表、单元素、infix/strict-infix/suffix/prefix 四种 grammar
+  及错误抛出均与旧实现一致，现有 32 个 string-join 测试全部通过

--- a/goldfish/srfi/srfi-13.scm
+++ b/goldfish/srfi/srfi-13.scm
@@ -79,10 +79,19 @@
               (else (error 'type-error "optional params in string-join"))
         ) ;cond
       ) ;define
+      ;; 一次性把元素和分隔符交错收集到列表，再交给 string-append 一次完成拼接
+      ;; 避免旧实现每层递归重复拼接后缀导致的 O(n^2) 开销
       (define (string-join-sub l delim)
         (cond ((null-list? l) "")
-              ((= (length l) 1) (car l))
-              (else (string-append (car l) delim (string-join-sub (cdr l) delim)))
+              ((null? (cdr l)) (car l))
+              (else (let loop
+                      ((rest (cdr l)) (acc (list (car l))))
+                      (if (null? rest)
+                        (apply string-append (reverse acc))
+                        (loop (cdr rest) (cons (car rest) (cons delim acc)))
+                      ) ;if
+                    ) ;let
+              ) ;else
         ) ;cond
       ) ;define
       (let* ((params (extract-params delim+grammer))


### PR DESCRIPTION
## What

重写 `srfi-13.scm` 中 `string-join` 的核心拼接逻辑：一次遍历把元素和分隔符交错收集到列表，最后 `(apply string-append ...)` 一次性完成拼接。

## Why

旧实现每层递归都用 `string-append` 重新拼接剩余整个后缀，时间复杂度 **O(n²)** 且非尾递归。`string-join` 经 `(liii string)` re-export 后被 path、uri、http 等模块广泛使用。

## 性能实测（单次调用）

| 列表规模 | 优化前 | 优化后 | 提速 |
|---|---|---|---|
| 100 元素 | 34 µs | ~8 µs | ~4x |
| 1000 元素 | 1.5 ms | ~80 µs | ~19x |
| 10000 元素 | 143 ms | ~1 ms | **~140x** |

短列表（3 元素）性能基本持平。

## 验证

- `tests/liii/string/string-join-test.scm` 32 个用例全部通过（4 种 grammar、空列表、错误抛出、Unicode）
- `tests/srfi/srfi-13-test.scm` 通过
- `bin/gf fmt` 检查无改动
- 基准脚本：`bench/string-join.scm`；任务文档：`devel/0098.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)