### PR TITLE
[0101] 用 C 实现优化 srfi-1 的 fold 和 fold-right

### DIFF
--- a/bench/fold-fold-right.scm
+++ b/bench/fold-fold-right.scm
@@ -1,0 +1,73 @@
+;; fold / fold-right 性能基准测试
+;; 测试 (liii list) 中 fold / fold-right 单列表路径的性能，
+;; 为 C 实现（s7_liii_list.c 的 g_fold / g_fold_right）提供基准数据
+
+(import (liii timeit) (liii list) (scheme base))
+
+;; 运行单次 benchmark
+
+(define (bench name stmt number)
+  (let ((elapsed (timeit stmt '() number)))
+    (display name)
+    (display ": ")
+    (display elapsed)
+    (display " 秒 (")
+    (display number)
+    (display " 次)\n")
+  ) ;let
+) ;define
+
+;; 性能测试
+
+(define (run-benchmarks)
+  (display "=== fold / fold-right 性能测试 ===\n\n")
+
+  ;; 空列表
+  (let ((empty '()))
+    (bench "fold 空列表                " (lambda () (fold + 0 empty)) 100000)
+    (bench "fold-right 空列表          "
+      (lambda () (fold-right + 0 empty))
+      100000
+    ) ;bench
+  ) ;let
+
+  ;; 小列表 (10 元素)
+  (let ((small (iota 10)))
+    (bench "fold 小列表(10)求和        " (lambda () (fold + 0 small)) 100000)
+    (bench "fold-right 小列表(10)求和  "
+      (lambda () (fold-right + 0 small))
+      100000
+    ) ;bench
+    (bench "fold 小列表(10)cons       " (lambda () (fold cons '() small)) 100000)
+    (bench "fold-right 小列表(10)cons "
+      (lambda () (fold-right cons '() small))
+      100000
+    ) ;bench
+  ) ;let
+
+  ;; 中列表 (100 元素)
+  (let ((medium (iota 100)))
+    (bench "fold 中列表(100)求和       " (lambda () (fold + 0 medium)) 100000)
+    (bench "fold-right 中列表(100)求和 "
+      (lambda () (fold-right + 0 medium))
+      100000
+    ) ;bench
+  ) ;let
+
+  ;; 大列表 (1000 元素)
+  (let ((large (iota 1000)))
+    (bench "fold 大列表(1000)求和      " (lambda () (fold + 0 large)) 10000)
+    (bench "fold-right 大列表(1000)求和"
+      (lambda () (fold-right + 0 large))
+      10000
+    ) ;bench
+  ) ;let
+
+  ;; 超大列表 (10000 元素)：fold-right 的 Scheme 实现非尾递归，顺带压栈
+  (let ((huge (iota 10000)))
+    (bench "fold 超大列表(10000)求和   " (lambda () (fold + 0 huge)) 1000)
+    (bench "fold-right 超大列表(10000) " (lambda () (fold-right + 0 huge)) 1000)
+  ) ;let
+) ;define
+
+(run-benchmarks)

--- a/devel/0101.md
+++ b/devel/0101.md
@@ -1,0 +1,76 @@
+# [0101] 用 C 实现优化 srfi-1 的 fold 和 fold-right
+
+相关文档：[0100](0100.md) 用 C 实现优化 srfi-1 的 any 和 every
+
+## 任务相关的代码文件
+- `src/s7_liii_list.c` — 新增 `g_fold` / `g_fold_right` C 实现
+- `src/s7_liii_list.h` — `g_fold` / `g_fold_right` 声明
+- `src/s7.c` — 注册 `g_fold` / `g_fold_right` 为 semisafe typed function
+- `goldfish/srfi/srfi-1.scm` — fold / fold-right 单列表路径改调 C 实现
+- `tests/liii/list/fold-test.scm` / `tests/liii/list/fold-right-test.scm` — 补充错误/深列表/GC 回归测试
+- `bench/fold-fold-right.scm` — 性能基准测试
+
+## 如何测试
+
+```bash
+# 1. 构建
+xmake b goldfish
+
+# 2. 格式化检查
+bin/gf fmt goldfish/srfi/srfi-1.scm
+bin/gf fmt tests/liii/list/fold-test.scm
+bin/gf fmt tests/liii/list/fold-right-test.scm
+
+# 3. 回归测试
+bin/gf tests/liii/list/fold-test.scm
+bin/gf tests/liii/list/fold-right-test.scm
+bin/gf test --all
+
+# 4. 性能测试
+bin/gf bench/fold-fold-right.scm
+```
+
+## 2026/08/08 用 C 实现 fold 和 fold-right 单列表路径
+
+### What
+
+在 `s7_liii_list.c` 中新增 `g_fold` / `g_fold_right`，`srfi-1.scm` 中
+fold / fold-right 的单 proper-list 分支改调 C 实现，多列表分支保持原
+Scheme 实现，`f` 非过程的 `type-error` 契约不变。
+
+测试补充：点列表 wrong-type-arg、10 万元素深折叠（fold-right 原 Scheme
+实现非尾递归，C 化后不再消耗 Scheme 栈）、GC 压力回归。
+`bin/gf test --all` 1493 项全部通过。
+
+性能实测（秒，越少越好，`bin/gf bench/fold-fold-right.scm`）：
+
+| 场景 | 基线 | C 实现 | 加速比 |
+|---|---|---|---|
+| fold 小列表(10)求和 (100000次) | 0.0479 | 0.0236 | ~2.0x |
+| fold 小列表(10)cons (100000次) | 0.0491 | 0.0350 | ~1.4x |
+| fold 中列表(100)求和 (100000次) | 0.2974 | 0.1280 | ~2.3x |
+| fold 大列表(1000)求和 (10000次) | 0.3607 | 0.1755 | ~2.1x |
+| fold 超大列表(10000)求和 (1000次) | 0.3366 | 0.1810 | ~1.9x |
+| fold-right 小列表(10)求和 (100000次) | 0.0709 | 0.0401 | ~1.8x |
+| fold-right 小列表(10)cons (100000次) | 0.1088 | 0.0526 | ~2.1x |
+| fold-right 中列表(100)求和 (100000次) | 1.0091 | 0.2127 | ~4.7x |
+| fold-right 大列表(1000)求和 (10000次) | 1.0746 | 0.2667 | ~4.0x |
+| fold-right 超大列表(10000)求和 (1000次) | 0.9901 | 0.2482 | ~4.0x |
+
+### Why
+
+fold 是最基础的列表迭代器，单列表路径是最常用的调用形式。
+fold-right 的 Scheme 单列表路径是非尾递归，深度受 Scheme 栈限制，
+C 化同时消除了这个限制。
+
+### How
+
+- 沿用 [0100](0100.md) `g_any` 的 GC 模式：args 可能住在求值器复用的
+  临时 cell 里，anchor 保存 f / lst；acc 放在 anchor 挂着的专用 cell 里，
+  每轮 `s7_apply_function` 后立即写回，保证中间累加值对 GC 可见
+- f 按 SRFI-1 签名 `(f elem acc)` 经 `s7i_set_plist_2` 调用
+- fold-right 先把元素复制成逆序列表（挂在 anchor 上），再正向遍历执行
+  acc = f(elem, acc)——等价于右结合展开，且把 Scheme 栈递归换成 O(n) 堆分配
+- 空列表直接返回 initial，不构造 anchor
+- 多列表分支每步要 map car/cdr + apply，C 化收益低、复杂度高，
+  保持原 Scheme 实现

--- a/goldfish/srfi/srfi-1.scm
+++ b/goldfish/srfi/srfi-1.scm
@@ -183,10 +183,7 @@
       ) ;unless
       (cond ((null? lists) initial)
             ((and (pair? lists) (null? (cdr lists)) (list? (car lists)))
-             (let loop
-               ((acc initial) (lst (car lists)))
-               (if (null? lst) acc (loop (f (car lst) acc) (cdr lst)))
-             ) ;let
+             (g_fold f initial (car lists))
             ) ;
             (else (let loop
                     ((acc initial) (lsts lists))
@@ -207,10 +204,7 @@
       ) ;unless
       (cond ((null? lists) initial)
             ((and (pair? lists) (null? (cdr lists)) (list? (car lists)))
-             (let loop
-               ((lst (car lists)))
-               (if (null? lst) initial (f (car lst) (loop (cdr lst))))
-             ) ;let
+             (g_fold_right f initial (car lists))
             ) ;
             (else (let loop
                     ((lsts lists))

--- a/src/s7.c
+++ b/src/s7.c
@@ -85753,6 +85753,14 @@ is #t, the string is also sent to the current-output-port."
   #define Q_every s7_make_signature(sc, 3, sc->is_boolean_symbol, sc->is_procedure_symbol, sc->is_list_symbol)
   s7_define_semisafe_typed_function(sc, "g_every", g_every, 2, 0, false, H_every, Q_every);
 
+  #define H_fold "(g_fold f init lst) folds f over the elements of lst: (f elem acc)"
+  #define Q_fold s7_make_signature(sc, 4, sc->T, sc->is_procedure_symbol, sc->T, sc->is_list_symbol)
+  s7_define_semisafe_typed_function(sc, "g_fold", g_fold, 3, 0, false, H_fold, Q_fold);
+
+  #define H_fold_right "(g_fold_right f init lst) folds f from the right over the elements of lst: (f elem acc)"
+  #define Q_fold_right s7_make_signature(sc, 4, sc->T, sc->is_procedure_symbol, sc->T, sc->is_list_symbol)
+  s7_define_semisafe_typed_function(sc, "g_fold_right", g_fold_right, 3, 0, false, H_fold_right, Q_fold_right);
+
   #define H_take "(g_take lst k) returns a list of the first k elements of lst"
   #define Q_take s7_make_signature(sc, 3, sc->is_list_symbol, sc->is_list_symbol, sc->is_integer_symbol)
   s7_define_semisafe_typed_function(sc, "g_take", g_take, 2, 0, false, H_take, Q_take);

--- a/src/s7_liii_list.c
+++ b/src/s7_liii_list.c
@@ -636,6 +636,81 @@ s7_pointer g_every(s7_scheme *sc, s7_pointer args)
   return(s7_t(sc));
 }
 
+/* -------------------------------- fold / fold-right -------------------------------- */
+
+s7_pointer g_fold(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_caddr(args);
+  if (!s7_is_pair(lst))
+    {
+      if (s7_is_null(sc, lst)) return(s7_cadr(args));
+      return(s7_wrong_type_arg_error(sc, "fold", 3, lst, "a proper list"));
+    }
+  /* args may live in evaluator-recycled cells: keep f and lst in our own pairs,
+   * and the accumulator in a dedicated cell we rewrite each iteration, so every
+   * intermediate value stays GC-reachable while f runs */
+  s7_pointer keep = s7_cons(sc, s7_car(args), lst);
+  s7_pointer anchor = s7_cons(sc, keep, s7_cons(sc, s7_cadr(args), s7_nil(sc)));
+  s7_gc_protect_via_stack(sc, anchor);
+  s7_pointer f = s7_car(keep);
+  s7_pointer acc_cell = s7_cdr(anchor);
+  s7_pointer p = lst;
+  while (s7_is_pair(p))
+    {
+      s7_set_car(acc_cell, s7_apply_function(sc, f, s7i_set_plist_2(sc, s7_car(p), s7_car(acc_cell))));
+      p = s7_cdr(p);
+    }
+  if (!s7_is_null(sc, p))
+    {
+      s7_gc_unprotect_via_stack(sc, anchor);
+      return(s7_wrong_type_arg_error(sc, "fold", 3, lst, "a proper list"));
+    }
+  s7_pointer result = s7_car(acc_cell);
+  s7_gc_unprotect_via_stack(sc, anchor);
+  return(result);
+}
+
+s7_pointer g_fold_right(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer lst = s7_caddr(args);
+  if (!s7_is_pair(lst))
+    {
+      if (s7_is_null(sc, lst)) return(s7_cadr(args));
+      return(s7_wrong_type_arg_error(sc, "fold-right", 3, lst, "a proper list"));
+    }
+  /* fold-right(f, init, (e1 ... en)) applies f from the right:
+   * f(e1, f(e2, ... f(en, init))), i.e. acc = f(elem, acc) walking elements
+   * in reverse; first copy the elements into a reversed list so the walk
+   * needs no Scheme-stack recursion */
+  s7_pointer keep = s7_cons(sc, s7_car(args), lst);
+  s7_pointer anchor = s7_cons(sc, keep, s7_cons(sc, s7_cadr(args), s7_nil(sc)));
+  s7_gc_protect_via_stack(sc, anchor);
+  s7_pointer rev = s7_nil(sc);
+  s7_set_cdr(s7_cdr(anchor), rev);
+  s7_pointer p = lst;
+  while (s7_is_pair(p))
+    {
+      rev = s7_cons(sc, s7_car(p), rev);
+      s7_set_cdr(s7_cdr(anchor), rev);
+      p = s7_cdr(p);
+    }
+  if (!s7_is_null(sc, p))
+    {
+      s7_gc_unprotect_via_stack(sc, anchor);
+      return(s7_wrong_type_arg_error(sc, "fold-right", 3, lst, "a proper list"));
+    }
+  s7_pointer f = s7_car(keep);
+  s7_pointer acc_cell = s7_cdr(anchor);
+  while (s7_is_pair(rev))
+    {
+      s7_set_car(acc_cell, s7_apply_function(sc, f, s7i_set_plist_2(sc, s7_car(rev), s7_car(acc_cell))));
+      rev = s7_cdr(rev);
+    }
+  s7_pointer result = s7_car(acc_cell);
+  s7_gc_unprotect_via_stack(sc, anchor);
+  return(result);
+}
+
 /* -------------------------------- take -------------------------------- */
 
 s7_pointer g_take(s7_scheme *sc, s7_pointer args)

--- a/src/s7_liii_list.h
+++ b/src/s7_liii_list.h
@@ -61,6 +61,8 @@ s7_pointer g_filter(s7_scheme *sc, s7_pointer args);
 s7_pointer g_find(s7_scheme *sc, s7_pointer args);
 s7_pointer g_any(s7_scheme *sc, s7_pointer args);
 s7_pointer g_every(s7_scheme *sc, s7_pointer args);
+s7_pointer g_fold(s7_scheme *sc, s7_pointer args);
+s7_pointer g_fold_right(s7_scheme *sc, s7_pointer args);
 s7_pointer g_take(s7_scheme *sc, s7_pointer args);
 s7_pointer g_take_right(s7_scheme *sc, s7_pointer args);
 s7_pointer g_drop_right(s7_scheme *sc, s7_pointer args);

--- a/tests/liii/list/fold-right-test.scm
+++ b/tests/liii/list/fold-right-test.scm
@@ -60,4 +60,30 @@
 (check-catch 'type-error (fold-right 0 + '(1 2 3) 'a))
 
 
+
+;; fold-right 保持右结合顺序
+(check (fold-right (lambda (x acc) (string-append x acc)) "" '("a" "b" "c"))
+  =>
+  "abc"
+) ;check
+
+;; 单列表点列表抛 wrong-type-arg
+(check-catch 'wrong-type-arg (fold-right + 0 '(1 2 . 3)))
+
+;; 单列表路径深层右折叠不消耗 Scheme 栈
+(let ((l (iota 100000)))
+  (check (fold-right + 0 l) => 4999950000)
+) ;let
+
+;; GC 压力回归测试：闭包 f + 逆序副本 + 中间累加值，反复触发 GC
+(let ((l (iota 10000)))
+  (do ((i 0 (+ i 1)))
+    ((= i 200))
+    (fold-right (lambda (x acc) (if (even? x) (+ acc 1) acc)) 0 l)
+    (fold-right cons '() (map (lambda (x) (list x)) '(1 2 3 4 5)))
+  ) ;do
+  (check (fold-right (lambda (x acc) (if (even? x) (+ acc 1) acc)) 0 l) => 5000)
+) ;let
+
+
 (check-report)

--- a/tests/liii/list/fold-test.scm
+++ b/tests/liii/list/fold-test.scm
@@ -62,4 +62,24 @@
 (check-catch 'type-error (fold 0 + '(1 2 3) 'a))
 
 
+
+;; 单列表点列表抛 wrong-type-arg
+(check-catch 'wrong-type-arg (fold + 0 '(1 2 . 3)))
+
+;; 单列表路径深层折叠不消耗 Scheme 栈
+(let ((l (iota 100000)))
+  (check (fold + 0 l) => 4999950000)
+) ;let
+
+;; GC 压力回归测试：闭包 f + 中间累加值，反复触发 GC
+(let ((l (iota 10000)))
+  (do ((i 0 (+ i 1)))
+    ((= i 200))
+    (fold (lambda (x acc) (if (even? x) (+ acc 1) acc)) 0 l)
+    (fold cons '() (map (lambda (x) (list x)) '(1 2 3 4 5)))
+  ) ;do
+  (check (fold (lambda (x acc) (if (even? x) (+ acc 1) acc)) 0 l) => 5000)
+) ;let
+
+
 (check-report)


### PR DESCRIPTION
## 改动内容

在 `src/s7_liii_list.c` 中新增 `g_fold` / `g_fold_right` C 实现，`goldfish/srfi/srfi-1.scm` 中 fold / fold-right 的单 proper-list 分支改调 C 实现；多列表分支保持原 Scheme 实现，`f` 非过程的 `type-error` 契约不变。

### How
- 沿用 [0100] `g_any` 的 GC anchor 模式：anchor 保存 f / lst，累加值放在专用 cell 每轮写回，保证中间值对 GC 可见
- fold-right 先复制逆序列表再正向遍历，等价右结合展开，同时消除原 Scheme 非尾递归对 Scheme 栈的消耗

## 性能实测（`bin/gf bench/fold-fold-right.scm`，秒）

| 场景 | 基线 | C 实现 | 加速比 |
|---|---|---|---|
| fold 小列表(10)求和 (100000次) | 0.0479 | 0.0236 | ~2.0x |
| fold 中列表(100)求和 (100000次) | 0.2974 | 0.1280 | ~2.3x |
| fold 大列表(1000)求和 (10000次) | 0.3607 | 0.1755 | ~2.1x |
| fold-right 小列表(10)求和 (100000次) | 0.0709 | 0.0401 | ~1.8x |
| fold-right 中列表(100)求和 (100000次) | 1.0091 | 0.2127 | ~4.7x |
| fold-right 大列表(1000)求和 (10000次) | 1.0746 | 0.2667 | ~4.0x |

## 测试
- `tests/liii/list/fold-test.scm` / `fold-right-test.scm` 补充点列表 wrong-type-arg、10 万元素深折叠、GC 压力回归用例
- `bin/gf test --all` 1493 项全部通过

详细文档见 `devel/0101.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)