### PR TITLE
[0102] 用 C 实现优化 string-starts? 和 string-ends?

### DIFF
--- a/bench/string-starts-ends.scm
+++ b/bench/string-starts-ends.scm
@@ -1,0 +1,142 @@
+;; string-starts? / string-ends? 性能基准测试
+;; 对比旧 Scheme 实现（基于 srfi-13 string-prefix?/string-suffix?）
+;; 与新 C 实现（liii_string.cpp 的 g_string-starts?/g_string-ends?）
+
+(import (liii timeit) (liii string) (scheme base) (srfi srfi-13))
+
+;; 旧 Scheme 实现（优化前 liii string 中的定义）
+
+(define (string-starts?-scheme str prefix)
+  (if (and (string? str) (string? prefix))
+    (string-prefix? prefix str)
+    (error 'type-error "string-starts? parameter is not a string")
+  ) ;if
+) ;define
+
+(define (string-ends?-scheme str suffix)
+  (if (and (string? str) (string? suffix))
+    (string-suffix? suffix str)
+    (error 'type-error "string-ends? parameter is not a string")
+  ) ;if
+) ;define
+
+(define (bench name stmt number)
+  (let ((elapsed (timeit stmt '() number)))
+    (display name)
+    (display ": ")
+    (display elapsed)
+    (display " 秒 (")
+    (display number)
+    (display " 次)\n")
+  ) ;let
+) ;define
+
+(define (run-benchmarks)
+  (display "=== string-starts? / string-ends? 性能测试 ===\n\n")
+
+  ;; 短字符串，短前缀/后缀（最常见场景：扩展名、路径判断）
+  (bench "starts? Scheme 短串匹配      "
+    (lambda () (string-starts?-scheme "document.txt" "doc"))
+    100000
+  ) ;bench
+  (bench "starts? C      短串匹配      "
+    (lambda () (string-starts? "document.txt" "doc"))
+    100000
+  ) ;bench
+  (bench "starts? Scheme 短串不匹配    "
+    (lambda () (string-starts?-scheme "document.txt" "txt"))
+    100000
+  ) ;bench
+  (bench "starts? C      短串不匹配    "
+    (lambda () (string-starts? "document.txt" "txt"))
+    100000
+  ) ;bench
+  (bench "ends?   Scheme 短串匹配      "
+    (lambda () (string-ends?-scheme "document.txt" ".txt"))
+    100000
+  ) ;bench
+  (bench "ends?   C      短串匹配      "
+    (lambda () (string-ends? "document.txt" ".txt"))
+    100000
+  ) ;bench
+  (bench "ends?   Scheme 短串不匹配    "
+    (lambda () (string-ends?-scheme "document.txt" ".pdf"))
+    100000
+  ) ;bench
+  (bench "ends?   C      短串不匹配    "
+    (lambda () (string-ends? "document.txt" ".pdf"))
+    100000
+  ) ;bench
+  (newline)
+
+  ;; 长字符串 + 长前缀/后缀完全匹配（旧实现要 substring + string=?）
+  (let* ((long-str (make-string 1000 #\a))
+         (prefix (make-string 100 #\a))
+         (suffix (make-string 100 #\a))
+        ) ;
+    (bench "starts? Scheme 长串匹配      "
+      (lambda () (string-starts?-scheme long-str prefix))
+      100000
+    ) ;bench
+    (bench "starts? C      长串匹配      "
+      (lambda () (string-starts? long-str prefix))
+      100000
+    ) ;bench
+    (bench "ends?   Scheme 长串匹配      "
+      (lambda () (string-ends?-scheme long-str suffix))
+      100000
+    ) ;bench
+    (bench "ends?   C      长串匹配      "
+      (lambda () (string-ends? long-str suffix))
+      100000
+    ) ;bench
+  ) ;let*
+  (newline)
+
+  ;; 边界：空前缀/后缀、前缀比串长
+  (bench "starts? Scheme 空前缀        "
+    (lambda () (string-starts?-scheme "hello" ""))
+    100000
+  ) ;bench
+  (bench "starts? C      空前缀        "
+    (lambda () (string-starts? "hello" ""))
+    100000
+  ) ;bench
+  (bench "starts? Scheme 前缀过长      "
+    (lambda () (string-starts?-scheme "hi" "hello"))
+    100000
+  ) ;bench
+  (bench "starts? C      前缀过长      "
+    (lambda () (string-starts? "hi" "hello"))
+    100000
+  ) ;bench
+  (bench "ends?   Scheme 后缀过长      "
+    (lambda () (string-ends?-scheme "hi" "hello"))
+    100000
+  ) ;bench
+  (bench "ends?   C      后缀过长      "
+    (lambda () (string-ends? "hi" "hello"))
+    100000
+  ) ;bench
+  (newline)
+
+  ;; 中文 UTF-8 场景
+  (bench "starts? Scheme 中文匹配      "
+    (lambda () (string-starts?-scheme "中文测试字符串" "中文"))
+    100000
+  ) ;bench
+  (bench "starts? C      中文匹配      "
+    (lambda () (string-starts? "中文测试字符串" "中文"))
+    100000
+  ) ;bench
+  (bench "ends?   Scheme 中文匹配      "
+    (lambda () (string-ends?-scheme "中文测试字符串" "串"))
+    100000
+  ) ;bench
+  (bench "ends?   C      中文匹配      "
+    (lambda () (string-ends? "中文测试字符串" "串"))
+    100000
+  ) ;bench
+) ;define
+
+(run-benchmarks)

--- a/devel/0102.md
+++ b/devel/0102.md
@@ -1,0 +1,70 @@
+# [0102] 用 C 实现优化 liii string 的 string-starts? 和 string-ends?
+
+相关文档：[0098](0098.md) 优化 string-join 性能为 O(n)
+
+## 任务相关的代码文件
+- `src/liii_string.cpp` — 新增 `g_string-starts?` / `g_string-ends?` C 实现
+- `goldfish/liii/string.scm` — string-starts? / string-ends? 直接绑定 C 实现
+- `tests/liii/string/string-starts-p-test.scm` / `tests/liii/string/string-ends-p-test.scm` — 回归测试（沿用既有用例）
+- `bench/string-starts-ends.scm` — 性能基准测试
+
+## 如何测试
+
+```bash
+# 1. 构建
+xmake b goldfish
+
+# 2. 格式化检查
+bin/gf fmt goldfish/liii/string.scm
+bin/gf fmt bench/string-starts-ends.scm
+
+# 3. 回归测试
+bin/gf tests/liii/string/string-starts-p-test.scm
+bin/gf tests/liii/string/string-ends-p-test.scm
+bin/gf test --all
+
+# 4. 性能测试
+bin/gf bench/string-starts-ends.scm
+```
+
+## 2026/08/08 用 C 实现 string-starts? 和 string-ends?
+
+### What
+
+在 `liii_string.cpp` 中新增 `g_string-starts?` / `g_string-ends?`，
+`liii/string.scm` 中两个函数直接绑定到 C 实现，非字符串参数的
+`type-error` 契约（错误符号与消息文本）保持不变。
+`bin/gf test --all` 1493 项全部通过。
+
+性能实测（秒，越少越好，`bin/gf bench/string-starts-ends.scm`，100000 次）：
+
+| 场景 | 基线 | C 实现 | 加速比 |
+|---|---|---|---|
+| starts? 短串匹配 | 0.0114 | 0.0029 | ~3.9x |
+| starts? 短串不匹配 | 0.0114 | 0.0035 | ~3.3x |
+| ends? 短串匹配 | 0.0121 | 0.0036 | ~3.4x |
+| ends? 短串不匹配 | 0.0125 | 0.0036 | ~3.4x |
+| starts? 长串匹配(1000/100) | 0.0150 | 0.0042 | ~3.6x |
+| ends? 长串匹配(1000/100) | 0.0141 | 0.0044 | ~3.2x |
+| starts? 空前缀 | 0.0131 | 0.0043 | ~3.1x |
+| starts? 前缀过长 | 0.0071 | 0.0035 | ~2.1x |
+| ends? 后缀过长 | 0.0066 | 0.0041 | ~1.6x |
+| starts? 中文匹配 | 0.0128 | 0.0043 | ~2.9x |
+| ends? 中文匹配 | 0.0140 | 0.0042 | ~3.4x |
+
+### Why
+
+string-starts? / string-ends? 是路径、扩展名、URL 判断的高频函数。
+旧实现基于 srfi-13 的 string-prefix?/string-suffix?，每次调用都要
+substring 分配临时字符串再做 string=? 比较，加上类型检查的 Scheme
+层开销，C 化后一次 memcmp 即可完成。
+
+### How
+
+- 沿用 [0098](0098.md) 的模式：C 函数在 `glue_liii_string` 中注册为
+  `g_string-starts?` / `g_string-ends?`，Scheme 侧 `(define string-starts? g_string-starts?)`
+- 字节级 `memcmp` 比较：UTF-8 是自同步编码，字节前缀/后缀匹配与码点
+  前缀/后缀匹配完全等价，无需解码
+- 无 Scheme 回调、无内存分配（除错误路径），不涉及 GC anchor
+- 错误路径用 `s7_error` 抛出 `(type-error "string-starts? parameter is not a string")`，
+  与旧实现的契约逐字一致

--- a/goldfish/liii/string.scm
+++ b/goldfish/liii/string.scm
@@ -47,12 +47,7 @@
     ;; ; 基于 SRFI-13 的 string-trim 实现
     (define string-trim-left string-trim)
 
-    (define (string-starts? str prefix)
-      (if (and (string? str) (string? prefix))
-        (string-prefix? prefix str)
-        (type-error "string-starts? parameter is not a string")
-      ) ;if
-    ) ;define
+    (define string-starts? g_string-starts?)
 
     (define string-contains?
       (typed-lambda ((str string?) (sub-str string?)) (string-contains str sub-str))
@@ -121,12 +116,7 @@
       ) ;let
     ) ;define
 
-    (define (string-ends? str suffix)
-      (if (and (string? str) (string? suffix))
-        (string-suffix? suffix str)
-        (type-error "string-ends? parameter is not a string")
-      ) ;if
-    ) ;define
+    (define string-ends? g_string-ends?)
 
     (define string-remove-prefix
       (typed-lambda ((str string?) (prefix string?))

--- a/src/liii_string.cpp
+++ b/src/liii_string.cpp
@@ -129,7 +129,7 @@ f_string_split (s7_scheme* sc, s7_pointer args) {
 
 static s7_pointer
 f_string_starts_p (s7_scheme* sc, s7_pointer args) {
-  s7_pointer str_arg= s7_car (args);
+  s7_pointer str_arg   = s7_car (args);
   s7_pointer prefix_arg= s7_cadr (args);
 
   if (!s7_is_string (str_arg) || !s7_is_string (prefix_arg)) {
@@ -146,7 +146,7 @@ f_string_starts_p (s7_scheme* sc, s7_pointer args) {
 
 static s7_pointer
 f_string_ends_p (s7_scheme* sc, s7_pointer args) {
-  s7_pointer str_arg= s7_car (args);
+  s7_pointer str_arg   = s7_car (args);
   s7_pointer suffix_arg= s7_cadr (args);
 
   if (!s7_is_string (str_arg) || !s7_is_string (suffix_arg)) {

--- a/src/liii_string.cpp
+++ b/src/liii_string.cpp
@@ -15,6 +15,7 @@
 //
 
 #include "s7.h"
+#include <cstring>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -126,6 +127,54 @@ f_string_split (s7_scheme* sc, s7_pointer args) {
   return s7_cdr (head);
 }
 
+static s7_pointer
+f_string_starts_p (s7_scheme* sc, s7_pointer args) {
+  s7_pointer str_arg= s7_car (args);
+  s7_pointer prefix_arg= s7_cadr (args);
+
+  if (!s7_is_string (str_arg) || !s7_is_string (prefix_arg)) {
+    return s7_error (sc, s7_make_symbol (sc, "type-error"),
+                     s7_list (sc, 1, s7_make_string (sc, "string-starts? parameter is not a string")));
+  }
+
+  // UTF-8 字节级前缀比较是精确的：前缀字节序列必然落在码点边界上
+  const size_t str_len   = (size_t) s7_string_length (str_arg);
+  const size_t prefix_len= (size_t) s7_string_length (prefix_arg);
+  if (prefix_len > str_len) return s7_f (sc);
+  return s7_make_boolean (sc, std::memcmp (s7_string (str_arg), s7_string (prefix_arg), prefix_len) == 0);
+}
+
+static s7_pointer
+f_string_ends_p (s7_scheme* sc, s7_pointer args) {
+  s7_pointer str_arg= s7_car (args);
+  s7_pointer suffix_arg= s7_cadr (args);
+
+  if (!s7_is_string (str_arg) || !s7_is_string (suffix_arg)) {
+    return s7_error (sc, s7_make_symbol (sc, "type-error"),
+                     s7_list (sc, 1, s7_make_string (sc, "string-ends? parameter is not a string")));
+  }
+
+  const size_t str_len   = (size_t) s7_string_length (str_arg);
+  const size_t suffix_len= (size_t) s7_string_length (suffix_arg);
+  if (suffix_len > str_len) return s7_f (sc);
+  const char* tail= s7_string (str_arg) + (str_len - suffix_len);
+  return s7_make_boolean (sc, std::memcmp (tail, s7_string (suffix_arg), suffix_len) == 0);
+}
+
+static void
+glue_string_starts_p (s7_scheme* sc) {
+  const char* name= "g_string-starts?";
+  const char* desc= "(g_string-starts? str prefix) => boolean";
+  s7_define_function (sc, name, f_string_starts_p, 2, 0, false, desc);
+}
+
+static void
+glue_string_ends_p (s7_scheme* sc) {
+  const char* name= "g_string-ends?";
+  const char* desc= "(g_string-ends? str suffix) => boolean";
+  s7_define_function (sc, name, f_string_ends_p, 2, 0, false, desc);
+}
+
 static void
 glue_string_split (s7_scheme* sc) {
   const char* name= "g_string-split";
@@ -135,6 +184,8 @@ glue_string_split (s7_scheme* sc) {
 
 void
 glue_liii_string (s7_scheme* sc) {
+  glue_string_starts_p (sc);
+  glue_string_ends_p (sc);
   glue_string_split (sc);
 }
 


### PR DESCRIPTION
## What

在 `src/liii_string.cpp` 新增 `g_string-starts?` / `g_string-ends?` C 实现，`(liii string)` 中两个函数直接绑定到 C 实现，不再经过 srfi-13 的 substring + string=? 路径。非字符串参数的 `type-error` 契约（错误符号与消息文本）逐字保持不变。

## How

- 字节级 `memcmp` 一次比较完成：UTF-8 自同步编码，字节前缀/后缀匹配与码点匹配完全等价
- 无 Scheme 回调、无内存分配（除错误路径），无需 GC anchor
- 沿用 [0098] string-split 的注册模式（`glue_liii_string`）

## 性能（100000 次，秒，越少越好）

| 场景 | 基线 | C 实现 | 加速比 |
|---|---|---|---|
| starts? 短串匹配 | 0.0114 | 0.0029 | ~3.9x |
| ends? 短串匹配 | 0.0121 | 0.0036 | ~3.4x |
| starts? 长串匹配(1000/100) | 0.0150 | 0.0042 | ~3.6x |
| ends? 长串匹配(1000/100) | 0.0141 | 0.0044 | ~3.2x |
| starts?/ends? 中文匹配 | 0.013~0.014 | 0.004 | ~2.9~3.4x |

基准脚本：`bin/gf bench/string-starts-ends.scm`

## 测试

- `bin/gf test --all`：1493 项全部通过（含 string-starts?/ends? 既有 31 + 120 个用例）

详细文档见 `devel/0102.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)