### PR TITLE
[0103] 用 C 实现优化 string-join

### DIFF
--- a/bench/string-join.scm
+++ b/bench/string-join.scm
@@ -27,24 +27,53 @@
     100000
   ) ;bench
 
+  (bench "短列表(3元素) suffix     "
+    (lambda () (string-join '("a" "b" "c") ":" 'suffix))
+    100000
+  ) ;bench
+
+  (bench "短列表(3元素) prefix     "
+    (lambda () (string-join '("a" "b" "c") ":" 'prefix))
+    100000
+  ) ;bench
+
+  (bench "短列表(3元素) strict-infix"
+    (lambda () (string-join '("a" "b" "c") ":" 'strict-infix))
+    100000
+  ) ;bench
+
+  (bench "短列表(3元素) 中文分隔符  "
+    (lambda () (string-join '("甲" "乙" "丙") "分隔"))
+    100000
+  ) ;bench
+
+  (bench "空列表 默认分隔符        " (lambda () (string-join '())) 100000)
+
   (let ((mid-list (map number->string (iota 100))))
     (bench "中列表(100元素) 逗号分隔   "
       (lambda () (string-join mid-list ","))
-      1000
+      10000
     ) ;bench
   ) ;let
 
   (let ((long-list (map number->string (iota 1000))))
     (bench "长列表(1000元素) 逗号分隔  "
       (lambda () (string-join long-list ","))
-      100
+      1000
     ) ;bench
   ) ;let
 
   (let ((long-list (map number->string (iota 10000))))
     (bench "超长列表(10000元素) 逗号分隔"
       (lambda () (string-join long-list ","))
-      10
+      100
+    ) ;bench
+  ) ;let
+
+  (let ((long-list (map number->string (iota 1000))))
+    (bench "长列表(1000元素) suffix  "
+      (lambda () (string-join long-list "," 'suffix))
+      1000
     ) ;bench
   ) ;let
 ) ;define

--- a/devel/0103.md
+++ b/devel/0103.md
@@ -1,0 +1,85 @@
+# [0103] 用 C 实现优化 string-join
+
+相关文档：[0098](0098.md) 优化 string-join 性能为 O(n)（Scheme 层）、[0102](0102.md) 用 C 实现优化 string-starts? 和 string-ends?
+
+## 任务相关的代码文件
+- `src/liii_string.cpp` — 新增 `g_string-join` C 实现
+- `goldfish/srfi/srfi-13.scm` — string-join 直接绑定 C 实现
+- `tests/liii/string/string-join-test.scm` — 回归测试（沿用既有用例，新增元素类型/列表类型契约测试）
+- `bench/string-join.scm` — 性能基准测试（新增 grammar/中文/空列表场景）
+
+## 如何测试
+
+```bash
+# 1. 构建
+xmake b goldfish
+
+# 2. 格式化检查
+bin/gf fmt goldfish/srfi/srfi-13.scm
+bin/gf fmt tests/liii/string/string-join-test.scm
+bin/gf fmt bench/string-join.scm
+
+# 3. 回归测试
+bin/gf tests/liii/string/string-join-test.scm
+bin/gf tests/srfi/srfi-13-test.scm
+bin/gf test --all
+
+# 4. 性能测试
+bin/gf bench/string-join.scm
+```
+
+## 2026/08/08 用 C 实现 string-join
+
+### What
+
+在 `liii_string.cpp` 中新增 `g_string-join`，`srfi-13.scm` 中
+`string-join` 直接绑定到 C 实现（`(liii string)` 经 re-export 自动获益）。
+错误契约与旧 Scheme 实现保持一致：
+
+- 分隔符非字符串 / grammar 非符号：`type-error "optional params in string-join"`
+- grammar 非四种之一：`value-error "invalid grammer"`
+- strict-infix 遇空列表：`value-error "empty list not allowed"`
+- 参数超过 3 个：由 s7 arity 检查自动抛出 `wrong-number-of-args`
+
+一处行为收紧：旧实现对单元素列表不校验元素类型（`(string-join '(1))`
+返回 `1`），C 实现统一校验所有元素，非字符串元素抛出 `type-error`，
+与文档描述一致。另外第一个参数非正规列表时也抛出 `type-error`。
+`bin/gf test --all` 1493 项全部通过。
+
+性能实测（秒，越少越好，`bin/gf bench/string-join.scm`）：
+
+| 场景 | 基线 | C 实现 | 加速比 |
+|---|---|---|---|
+| 短列表(3元素) 默认分隔符 (100000次) | 0.1002 | 0.0088 | ~11.4x |
+| 短列表(3元素) 指定分隔符 (100000次) | 0.1128 | 0.0109 | ~10.3x |
+| 短列表 suffix (100000次) | 0.1366 | 0.0133 | ~10.3x |
+| 短列表 prefix (100000次) | 0.1368 | 0.0124 | ~11.1x |
+| 短列表 strict-infix (100000次) | 0.1365 | 0.0118 | ~11.5x |
+| 短列表 中文分隔符 (100000次) | 0.1196 | 0.0125 | ~9.6x |
+| 空列表 (100000次) | 0.0860 | 0.0039 | ~22.1x |
+| 中列表(100元素) (10000次) | 0.0846 | 0.0111 | ~7.6x |
+| 长列表(1000元素) (1000次) | 0.0781 | 0.0107 | ~7.3x |
+| 超长列表(10000元素) (100次) | 0.0679 | 0.0101 | ~6.7x |
+| 长列表(1000元素) suffix (1000次) | 0.0653 | 0.0110 | ~5.9x |
+
+### Why
+
+string-join 是路径拼接、URI 构造等场景的高频函数（`(liii path)`、
+uri 系列均依赖它）。[0098](0098.md) 已把拼接优化为 O(n)，但 Scheme 层
+的参数解析（extract-params）、reverse/cons 交错收集列表、以及
+`apply string-append` 的中间列表分配仍有可观开销。C 化后零中间分配，
+短列表场景提速约 10 倍。
+
+### How
+
+- 沿用 [0102](0102.md) 的模式：C 函数在 `glue_liii_string` 中注册为
+  `g_string-join`（1 必选 + 2 可选参数，超出由 s7 抛 `wrong-number-of-args`），
+  Scheme 侧 `(define string-join g_string-join)`
+- 两趟扫描：第一趟校验元素均为字符串并累计总字节数；第二趟把元素和
+  分隔符按 grammar 追加到预分配（`reserve`）的 `std::string`，最后
+  `s7_make_string_with_length` 一次性拷入 Scheme 堆
+- 字节级拼接：UTF-8 字符串直接按字节拷贝即可，无需解码
+- 无 Scheme 回调，输入列表经 args 可达，结果先在 C++ 缓冲区构建，
+  不涉及 GC anchor
+- 报错顺序与旧实现一致：参数类型检查（extract-params）→ 元素校验
+  （string-join-sub）→ grammar 取值检查（case）

--- a/goldfish/srfi/srfi-13.scm
+++ b/goldfish/srfi/srfi-13.scm
@@ -61,55 +61,12 @@
       ) ;cond
     ) ;define
 
-    (define (string-join l . delim+grammer)
-      (define (extract-params params-l)
-        (cond ((null-list? params-l) (list "" 'infix))
-              ((and (= (length params-l) 1) (string? (car params-l)))
-               (list (car params-l) 'infix)
-              ) ;
-              ((and (= (length params-l) 2)
-                 (string? (first params-l))
-                 (symbol? (second params-l))
-               ) ;and
-               params-l
-              ) ;
-              ((> (length params-l) 2)
-               (error 'wrong-number-of-args "optional params in string-join")
-              ) ;
-              (else (error 'type-error "optional params in string-join"))
-        ) ;cond
-      ) ;define
-      ;; 一次性把元素和分隔符交错收集到列表，再交给 string-append 一次完成拼接
-      ;; 避免旧实现每层递归重复拼接后缀导致的 O(n^2) 开销
-      (define (string-join-sub l delim)
-        (cond ((null-list? l) "")
-              ((null? (cdr l)) (car l))
-              (else (let loop
-                      ((rest (cdr l)) (acc (list (car l))))
-                      (if (null? rest)
-                        (apply string-append (reverse acc))
-                        (loop (cdr rest) (cons (car rest) (cons delim acc)))
-                      ) ;if
-                    ) ;let
-              ) ;else
-        ) ;cond
-      ) ;define
-      (let* ((params (extract-params delim+grammer))
-             (delim (first params))
-             (grammer (second params))
-             (ret (string-join-sub l delim))
-            ) ;
-        (case grammer
-         ('infix ret)
-         ('strict-infix
-          (if (null-list? l) (error 'value-error "empty list not allowed") ret)
-         ) ;
-         ('suffix (if (null-list? l) "" (string-append ret delim)))
-         ('prefix (if (null-list? l) "" (string-append delim ret)))
-         (else (error 'value-error "invalid grammer"))
-        ) ;case
-      ) ;let*
-    ) ;define
+    ;; string-join 的 C 实现见 src/liii_string.cpp 的 g_string-join
+    ;; 错误契约与旧 Scheme 实现一致：
+    ;;   type-error "optional params in string-join"（分隔符非字符串或 grammar 非符号）
+    ;;   value-error "invalid grammer"（grammar 非四种之一）
+    ;;   value-error "empty list not allowed"（strict-infix 遇到空列表）
+    (define string-join g_string-join)
 
     (define (string-null? str)
       (if (not (string? str))

--- a/src/liii_string.cpp
+++ b/src/liii_string.cpp
@@ -127,6 +127,97 @@ f_string_split (s7_scheme* sc, s7_pointer args) {
   return s7_cdr (head);
 }
 
+enum class string_join_grammar { infix, strict_infix, suffix, prefix };
+
+static s7_pointer
+f_string_join (s7_scheme* sc, s7_pointer args) {
+  s7_pointer l   = s7_car (args);
+  s7_pointer rest= s7_cdr (args);
+
+  std::string delim;
+  if (!s7_is_null (sc, rest)) {
+    s7_pointer delim_arg= s7_car (rest);
+    if (!s7_is_string (delim_arg)) {
+      return liii_string_type_error (sc, "optional params in string-join", delim_arg);
+    }
+    delim.assign (s7_string (delim_arg), (size_t) s7_string_length (delim_arg));
+    rest= s7_cdr (rest);
+  }
+
+  string_join_grammar grammar= string_join_grammar::infix;
+  bool                grammar_valid= true;
+  if (!s7_is_null (sc, rest)) {
+    s7_pointer grammar_arg= s7_car (rest);
+    if (!s7_is_symbol (grammar_arg)) {
+      return liii_string_type_error (sc, "optional params in string-join", grammar_arg);
+    }
+    const char* name= s7_symbol_name (grammar_arg);
+    if (std::strcmp (name, "infix") == 0) grammar= string_join_grammar::infix;
+    else if (std::strcmp (name, "strict-infix") == 0) grammar= string_join_grammar::strict_infix;
+    else if (std::strcmp (name, "suffix") == 0) grammar= string_join_grammar::suffix;
+    else if (std::strcmp (name, "prefix") == 0) grammar= string_join_grammar::prefix;
+    else grammar_valid= false;
+  }
+
+  // 第一趟：校验元素均为字符串并累计总字节数，与旧实现一样在 grammar 分支之前报错
+  size_t     count    = 0;
+  size_t     total_len= 0;
+  s7_pointer p        = l;
+  while (s7_is_pair (p)) {
+    s7_pointer elem= s7_car (p);
+    if (!s7_is_string (elem)) {
+      return liii_string_type_error (sc, "string-join: elements must be strings", elem);
+    }
+    total_len+= (size_t) s7_string_length (elem);
+    count++;
+    p= s7_cdr (p);
+  }
+  if (!s7_is_null (sc, p)) {
+    return liii_string_type_error (sc, "string-join: first parameter must be a proper list", l);
+  }
+
+  if (!grammar_valid) {
+    return s7_error (sc, s7_make_symbol (sc, "value-error"),
+                     s7_list (sc, 1, s7_make_string (sc, "invalid grammer")));
+  }
+
+  if (grammar == string_join_grammar::strict_infix && count == 0) {
+    return s7_error (sc, s7_make_symbol (sc, "value-error"),
+                     s7_list (sc, 1, s7_make_string (sc, "empty list not allowed")));
+  }
+
+  const size_t delim_len    = delim.size ();
+  size_t       delim_count  = 0;
+  switch (grammar) {
+  case string_join_grammar::infix:
+  case string_join_grammar::strict_infix:
+    delim_count= (count > 0) ? count - 1 : 0;
+    break;
+  case string_join_grammar::suffix:
+  case string_join_grammar::prefix:
+    delim_count= count;
+    break;
+  }
+
+  std::string result;
+  result.reserve (total_len + delim_count * delim_len);
+  size_t i= 0;
+  for (p= l; s7_is_pair (p); p= s7_cdr (p), i++) {
+    if (grammar == string_join_grammar::prefix ||
+        (i > 0 && grammar != string_join_grammar::suffix)) {
+      result.append (delim);
+    }
+    s7_pointer elem= s7_car (p);
+    result.append (s7_string (elem), (size_t) s7_string_length (elem));
+    if (grammar == string_join_grammar::suffix) result.append (delim);
+  }
+
+  /* no Scheme callbacks here, so args (and the strings reachable from the
+   * input list) stay put; the result is built in a C++ buffer first and
+   * copied into the Scheme heap in a single allocation */
+  return s7_make_string_with_length (sc, result.data (), (s7_int) result.size ());
+}
+
 static s7_pointer
 f_string_starts_p (s7_scheme* sc, s7_pointer args) {
   s7_pointer str_arg   = s7_car (args);
@@ -162,6 +253,13 @@ f_string_ends_p (s7_scheme* sc, s7_pointer args) {
 }
 
 static void
+glue_string_join (s7_scheme* sc) {
+  const char* name= "g_string-join";
+  const char* desc= "(g_string-join string-list . delim+grammar) => string";
+  s7_define_function (sc, name, f_string_join, 1, 2, false, desc);
+}
+
+static void
 glue_string_starts_p (s7_scheme* sc) {
   const char* name= "g_string-starts?";
   const char* desc= "(g_string-starts? str prefix) => boolean";
@@ -184,6 +282,7 @@ glue_string_split (s7_scheme* sc) {
 
 void
 glue_liii_string (s7_scheme* sc) {
+  glue_string_join (sc);
   glue_string_starts_p (sc);
   glue_string_ends_p (sc);
   glue_string_split (sc);

--- a/src/liii_string.cpp
+++ b/src/liii_string.cpp
@@ -144,7 +144,7 @@ f_string_join (s7_scheme* sc, s7_pointer args) {
     rest= s7_cdr (rest);
   }
 
-  string_join_grammar grammar= string_join_grammar::infix;
+  string_join_grammar grammar      = string_join_grammar::infix;
   bool                grammar_valid= true;
   if (!s7_is_null (sc, rest)) {
     s7_pointer grammar_arg= s7_car (rest);
@@ -177,8 +177,7 @@ f_string_join (s7_scheme* sc, s7_pointer args) {
   }
 
   if (!grammar_valid) {
-    return s7_error (sc, s7_make_symbol (sc, "value-error"),
-                     s7_list (sc, 1, s7_make_string (sc, "invalid grammer")));
+    return s7_error (sc, s7_make_symbol (sc, "value-error"), s7_list (sc, 1, s7_make_string (sc, "invalid grammer")));
   }
 
   if (grammar == string_join_grammar::strict_infix && count == 0) {
@@ -186,8 +185,8 @@ f_string_join (s7_scheme* sc, s7_pointer args) {
                      s7_list (sc, 1, s7_make_string (sc, "empty list not allowed")));
   }
 
-  const size_t delim_len    = delim.size ();
-  size_t       delim_count  = 0;
+  const size_t delim_len  = delim.size ();
+  size_t       delim_count= 0;
   switch (grammar) {
   case string_join_grammar::infix:
   case string_join_grammar::strict_infix:
@@ -203,8 +202,7 @@ f_string_join (s7_scheme* sc, s7_pointer args) {
   result.reserve (total_len + delim_count * delim_len);
   size_t i= 0;
   for (p= l; s7_is_pair (p); p= s7_cdr (p), i++) {
-    if (grammar == string_join_grammar::prefix ||
-        (i > 0 && grammar != string_join_grammar::suffix)) {
+    if (grammar == string_join_grammar::prefix || (i > 0 && grammar != string_join_grammar::suffix)) {
       result.append (delim);
     }
     s7_pointer elem= s7_car (p);

--- a/tests/liii/string/string-join-test.scm
+++ b/tests/liii/string/string-join-test.scm
@@ -70,6 +70,16 @@
 (check-catch 'value-error (string-join '() ":" 'no-such-grammer))
 (check-catch 'wrong-number-of-args (string-join '() ":" 1 2 3))
 
+;; 元素类型测试：每个元素必须是字符串（C 实现统一校验，
+;; 旧 Scheme 实现对单元素列表不校验，直接返回该元素）
+(check-catch 'type-error (string-join '("a" 1 "b") ":"))
+(check-catch 'type-error (string-join '(1) ":"))
+(check-catch 'type-error (string-join '(1)))
+
+;; 第一个参数必须是正规列表
+(check-catch 'type-error (string-join "ab" ":"))
+(check-catch 'type-error (string-join '("a" . "b") ":"))
+
 ;; 空字符串元素边界测试
 (check (string-join '("" "") ":") => ":")
 (check (string-join '("" "" "") ":") => "::")


### PR DESCRIPTION
## 概述

将 `string-join`（srfi-13 / liii string）从 Scheme 实现迁移到 C 实现（`g_string-join`，注册于 `glue_liii_string`），沿用 [0102] string-starts?/string-ends? 的模式。参数解析（分隔符 + grammar）全部在 C 侧处理。

详细文档见 `devel/0103.md`。

## 改动

- `src/liii_string.cpp`：新增 `f_string_join`，两趟扫描（校验元素 + 累计字节数 → reserve 后一次拼接），字节级拷贝
- `goldfish/srfi/srfi-13.scm`：`string-join` 直接绑定 `g_string-join`，删除旧 Scheme 实现
- `bench/string-join.scm`：新增 grammar/中文/空列表基准场景
- `tests/liii/string/string-join-test.scm`：新增非字符串元素、非正规列表的 type-error 契约测试（32 → 37 项）

## 错误契约（与旧实现一致）

- 分隔符非字符串 / grammar 非符号：`type-error "optional params in string-join"`
- grammar 非四种之一：`value-error "invalid grammer"`
- strict-infix 遇空列表：`value-error "empty list not allowed"`
- 参数超过 3 个：s7 arity 检查自动抛 `wrong-number-of-args`

一处行为收紧：旧实现对单元素列表不校验元素类型（`(string-join '(1))` 返回 `1`），C 实现统一校验并抛 `type-error`，与文档描述一致。

## 性能

| 场景 | 基线 | C 实现 | 加速比 |
|---|---|---|---|
| 短列表(3元素) 指定分隔符 | 0.113s | 0.011s | ~10x |
| 空列表 | 0.086s | 0.004s | ~22x |
| 中列表(100元素) | 0.085s | 0.011s | ~7.6x |
| 超长列表(10000元素) | 0.068s | 0.010s | ~6.7x |

## 测试

- `bin/gf test --all`：1493 项全部通过
- `bin/gf tests/liii/string/string-join-test.scm`：37 项全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)