### PR TITLE
[0104] 用 C++ 实现优化 string-replace

### DIFF
--- a/bench/string-replace.scm
+++ b/bench/string-replace.scm
@@ -1,0 +1,72 @@
+;; string-replace 性能基准测试
+;; 测试 (liii string) 中 string-replace 的性能
+
+(import (liii timeit) (liii string) (scheme base))
+
+(define (bench name stmt number)
+  (let ((elapsed (timeit stmt '() number)))
+    (display name)
+    (display ": ")
+    (display elapsed)
+    (display " 秒 (")
+    (display number)
+    (display " 次)\n")
+  ) ;let
+) ;define
+
+(define (run-benchmarks)
+  (display "=== string-replace 性能测试 ===\n\n")
+
+  (bench "短字符串 单次替换          "
+    (lambda () (string-replace "hello world" "world" "Goldfish"))
+    100000
+  ) ;bench
+
+  (bench "短字符串 多次替换          "
+    (lambda () (string-replace "hello world hello" "hello" "hi"))
+    100000
+  ) ;bench
+
+  (bench "短字符串 无匹配            "
+    (lambda () (string-replace "hello world" "test" "hi"))
+    100000
+  ) ;bench
+
+  (bench "短字符串 count=1          "
+    (lambda () (string-replace "hello hello hello" "hello" "hi" 1))
+    100000
+  ) ;bench
+
+  (bench "短字符串 删除替换(new为空) "
+    (lambda () (string-replace "hello world hello" "hello" ""))
+    100000
+  ) ;bench
+
+  (bench "空pattern 插入            "
+    (lambda () (string-replace "hello" "" "x"))
+    100000
+  ) ;bench
+
+  (bench "中文字符串 替换           "
+    (lambda () (string-replace "测试测试字符串" "测试" "实验"))
+    100000
+  ) ;bench
+
+  (bench "Emoji 替换                "
+    (lambda () (string-replace "hello😀world😀" "😀" "!"))
+    100000
+  ) ;bench
+
+  (let ((long-str (string-join (map number->string (iota 1000)) ",")))
+    (bench "长字符串(约4000字符) 无匹配   "
+      (lambda () (string-replace long-str "not-found" "x"))
+      10000
+    ) ;bench
+    (bench "长字符串(约4000字符) 多次替换 "
+      (lambda () (string-replace long-str "," ";"))
+      10000
+    ) ;bench
+  ) ;let
+) ;define
+
+(run-benchmarks)

--- a/devel/0104.md
+++ b/devel/0104.md
@@ -1,0 +1,70 @@
+# [0104] 用 C++ 实现优化 string-replace
+
+相关文档：[0103](0103.md) 用 C 实现优化 string-join、[0102](0102.md) 用 C 实现优化 string-starts? 和 string-ends?
+
+## 任务相关的代码文件
+- `src/liii_string.cpp` — 新增 `g_string-replace` C++ 实现
+- `goldfish/liii/string.scm` — string-replace 直接绑定 C++ 实现
+- `tests/liii/string/string-replace-test.scm` — 回归测试（沿用既有用例，新增 count 为浮点数的契约测试）
+- `bench/string-replace.scm` — 性能基准测试（新增）
+
+## 如何测试
+
+```bash
+# 1. 构建
+xmake b goldfish
+
+# 2. 格式化检查
+bin/gf fmt goldfish/liii/string.scm
+bin/gf fmt bench/string-replace.scm
+
+# 3. 回归测试
+bin/gf tests/liii/string/string-replace-test.scm
+bin/gf test --all
+
+# 4. 性能测试
+bin/gf bench/string-replace.scm
+```
+
+## 2026/08/08 用 C++ 实现 string-replace
+
+### What
+
+先新增 `bench/string-replace.scm` 测出 Scheme 实现基线，再在
+`liii_string.cpp` 中新增 `g_string-replace`，`string.scm` 中
+`string-replace` 直接绑定到 C++ 实现。错误契约与旧 Scheme 实现保持一致：
+
+- str/old/new 非字符串：`type-error`（各自的提示信息不变）
+- count 非整数：`type-error "string-replace: count must be an integer"`
+- 参数超过 4 个或不足 3 个：由 s7 arity 检查自动抛出 `wrong-number-of-args`
+
+行为完全对齐旧实现：从左到右非重叠替换、count=0 返回副本、
+负数 count 替换全部、空 pattern 时按字节插入 new（Python 兼容）、
+无匹配时返回原内容的副本。count 为整数值的浮点数（如 `2.0`）也与
+旧实现的 `(integer? count)` 判定保持一致，予以接受（已补充契约测试，
+并验证旧实现同样接受浮点数 count）。
+
+`bin/gf test --all` 1493 项全部通过。
+
+### How
+
+入参先全部拷贝为 `std::string_view`，全程无 Scheme 回调，只在最后做
+一次 `s7_make_string_with_length` 堆分配，因此无需额外 GC anchor。
+非空 pattern 用 `std::string_view::find` 循环匹配（UTF-8 字节级匹配
+是精确的）；空 pattern 按旧实现的字节级插入语义逐字节拼接，并提前
+`reserve` 结果容量。
+
+性能实测（秒，越少越好，`bin/gf bench/string-replace.scm`）：
+
+| 场景 | 基线 | C++ 实现 | 加速比 |
+|---|---|---|---|
+| 短字符串 单次替换 (100000次) | 0.0836 | 0.0078 | ~10.7x |
+| 短字符串 多次替换 (100000次) | 0.1042 | 0.0084 | ~12.4x |
+| 短字符串 无匹配 (100000次) | 0.0660 | 0.0048 | ~13.7x |
+| 短字符串 count=1 (100000次) | 0.0966 | 0.0085 | ~11.4x |
+| 短字符串 删除替换 (100000次) | 0.0980 | 0.0082 | ~12.0x |
+| 空pattern 插入 (100000次) | 0.1233 | 0.0109 | ~11.3x |
+| 中文字符串 替换 (100000次) | 0.1124 | 0.0117 | ~9.6x |
+| Emoji 替换 (100000次) | 0.1163 | 0.0095 | ~12.2x |
+| 长字符串(约4000字符) 无匹配 (10000次) | 0.0139 | 0.0121 | ~1.2x |
+| 长字符串(约4000字符) 多次替换 (10000次) | 1.8127 | 0.1500 | ~12.1x |

--- a/goldfish/liii/string.scm
+++ b/goldfish/liii/string.scm
@@ -55,66 +55,7 @@
 
     (define string-split g_string-split)
 
-    (define (string-replace str old new . rest)
-      (when (> (length rest) 1)
-        (error 'wrong-number-of-args "string-replace: too many arguments")
-      ) ;when
-      (unless (string? str)
-        (type-error "string-replace: str must be a string")
-      ) ;unless
-      (unless (string? old)
-        (type-error "string-replace: old must be a string")
-      ) ;unless
-      (unless (string? new)
-        (type-error "string-replace: new must be a string")
-      ) ;unless
-      (let ((count (if (null? rest) -1 (car rest))))
-        (unless (integer? count)
-          (type-error "string-replace: count must be an integer")
-        ) ;unless
-        (let ((str-len (string-length str)) (old-len (string-length old)))
-          (cond ((zero? count) (string-copy str))
-                ((zero? old-len)
-                 (if (zero? str-len)
-                   new
-                   (let* ((max-inserts (+ str-len 1))
-                          (remaining (if (negative? count) max-inserts (min count max-inserts)))
-                         ) ;
-                     (let loop
-                       ((i 0) (acc '()) (r remaining))
-                       (cond ((and (= i str-len) (> r 0)) (apply string-append (reverse (cons new acc))))
-                             ((= i str-len) (apply string-append (reverse acc)))
-                             ((zero? r) (apply string-append (reverse (cons (substring str i str-len) acc))))
-                             (else (loop (+ i 1) (cons (substring str i (+ i 1)) (cons new acc)) (- r 1)))
-                       ) ;cond
-                     ) ;let
-                   ) ;let*
-                 ) ;if
-                ) ;
-                (else (let ((remaining (if (negative? count) -1 count)))
-                        (let loop
-                          ((search-start 0) (parts '()) (r remaining))
-                          (let ((next-pos (string-position old str search-start)))
-                            (if (and next-pos (not (zero? r)))
-                              (loop (+ next-pos old-len)
-                                (cons new (cons (substring str search-start next-pos) parts))
-                                (- r 1)
-                              ) ;loop
-                              (if (null? parts)
-                                (string-copy str)
-                                (apply string-append
-                                  (reverse (cons (substring str search-start str-len) parts))
-                                ) ;apply
-                              ) ;if
-                            ) ;if
-                          ) ;let
-                        ) ;let
-                      ) ;let
-                ) ;else
-          ) ;cond
-        ) ;let
-      ) ;let
-    ) ;define
+    (define string-replace g_string-replace)
 
     (define string-ends? g_string-ends?)
 

--- a/src/liii_string.cpp
+++ b/src/liii_string.cpp
@@ -15,6 +15,7 @@
 //
 
 #include "s7.h"
+#include <cmath>
 #include <cstring>
 #include <string>
 #include <string_view>
@@ -217,6 +218,95 @@ f_string_join (s7_scheme* sc, s7_pointer args) {
 }
 
 static s7_pointer
+f_string_replace (s7_scheme* sc, s7_pointer args) {
+  s7_pointer str_arg= s7_car (args);
+  s7_pointer old_arg= s7_cadr (args);
+  s7_pointer new_arg= s7_caddr (args);
+  s7_pointer rest   = s7_cdddr (args);
+
+  if (!s7_is_string (str_arg)) {
+    return liii_string_type_error (sc, "string-replace: str must be a string", str_arg);
+  }
+  if (!s7_is_string (old_arg)) {
+    return liii_string_type_error (sc, "string-replace: old must be a string", old_arg);
+  }
+  if (!s7_is_string (new_arg)) {
+    return liii_string_type_error (sc, "string-replace: new must be a string", new_arg);
+  }
+
+  s7_int count= -1;
+  if (!s7_is_null (sc, rest)) {
+    s7_pointer count_arg= s7_car (rest);
+    // 与旧实现 (integer? count) 的契约一致：整数或整数值的浮点数均可
+    if (s7_is_integer (count_arg)) {
+      count= s7_integer (count_arg);
+    }
+    else if (s7_is_real (count_arg) && std::floor (s7_real (count_arg)) == s7_real (count_arg)) {
+      count= (s7_int) s7_real (count_arg);
+    }
+    else {
+      return liii_string_type_error (sc, "string-replace: count must be an integer", count_arg);
+    }
+  }
+
+  /* 先全部拷入 C++ 缓冲区，之后只在最后做一次 Scheme 堆分配，
+   * 因此无需额外的 GC anchor（且全程没有 Scheme 回调） */
+  const std::string_view str (s7_string (str_arg), (size_t) s7_string_length (str_arg));
+  const std::string_view old_v (s7_string (old_arg), (size_t) s7_string_length (old_arg));
+  const std::string_view new_v (s7_string (new_arg), (size_t) s7_string_length (new_arg));
+
+  if (count == 0) {
+    return s7_make_string_with_length (sc, str.data (), (s7_int) str.size ());
+  }
+
+  std::string result;
+  if (old_v.empty ()) {
+    // 空 pattern：在每个字节之间插入 new（Python 兼容行为）
+    if (str.empty ()) {
+      result.assign (new_v);
+    }
+    else {
+      const size_t max_insert= str.size () + 1;
+      size_t remaining= (count < 0) ? max_insert : std::min ((size_t) count, max_insert);
+      result.reserve (str.size () + remaining * new_v.size ());
+      size_t i= 0;
+      while (i < str.size () && remaining > 0) {
+        result.append (new_v);
+        result.append (str, i, 1);
+        i++;
+        remaining--;
+      }
+      if (i == str.size ()) {
+        if (remaining > 0) result.append (new_v);
+      }
+      else {
+        result.append (str, i, str.size () - i);
+      }
+    }
+  }
+  else {
+    // 非空 pattern：从左到右、非重叠替换；UTF-8 字节级匹配是精确的
+    size_t remaining= (count < 0) ? std::string_view::npos : (size_t) count;
+    size_t start    = 0;
+    while (remaining > 0) {
+      size_t pos= str.find (old_v, start);
+      if (pos == std::string_view::npos) break;
+      result.append (str, start, pos - start);
+      result.append (new_v);
+      start= pos + old_v.size ();
+      remaining--;
+    }
+    if (start == 0) {
+      // 无匹配：返回原内容的副本
+      return s7_make_string_with_length (sc, str.data (), (s7_int) str.size ());
+    }
+    result.append (str, start, str.size () - start);
+  }
+
+  return s7_make_string_with_length (sc, result.data (), (s7_int) result.size ());
+}
+
+static s7_pointer
 f_string_starts_p (s7_scheme* sc, s7_pointer args) {
   s7_pointer str_arg   = s7_car (args);
   s7_pointer prefix_arg= s7_cadr (args);
@@ -272,6 +362,13 @@ glue_string_ends_p (s7_scheme* sc) {
 }
 
 static void
+glue_string_replace (s7_scheme* sc) {
+  const char* name= "g_string-replace";
+  const char* desc= "(g_string-replace str old new . count) => string";
+  s7_define_function (sc, name, f_string_replace, 3, 1, false, desc);
+}
+
+static void
 glue_string_split (s7_scheme* sc) {
   const char* name= "g_string-split";
   const char* desc= "(g_string-split str sep) => list of strings";
@@ -281,6 +378,7 @@ glue_string_split (s7_scheme* sc) {
 void
 glue_liii_string (s7_scheme* sc) {
   glue_string_join (sc);
+  glue_string_replace (sc);
   glue_string_starts_p (sc);
   glue_string_ends_p (sc);
   glue_string_split (sc);

--- a/src/liii_string.cpp
+++ b/src/liii_string.cpp
@@ -267,7 +267,7 @@ f_string_replace (s7_scheme* sc, s7_pointer args) {
     }
     else {
       const size_t max_insert= str.size () + 1;
-      size_t remaining= (count < 0) ? max_insert : std::min ((size_t) count, max_insert);
+      size_t       remaining = (count < 0) ? max_insert : std::min ((size_t) count, max_insert);
       result.reserve (str.size () + remaining * new_v.size ());
       size_t i= 0;
       while (i < str.size () && remaining > 0) {

--- a/tests/liii/string/string-replace-test.scm
+++ b/tests/liii/string/string-replace-test.scm
@@ -124,6 +124,10 @@
 (check (string-replace "aaa" "a" "b" 1) => "baa")
 (check (string-replace "aaa" "a" "b" 2) => "bba")
 
+;; count 为整数值的浮点数（integer? 判定为 #t）
+(check (string-replace "aaa" "a" "b" 2.0) => "bba")
+(check (string-replace "aaa" "a" "b" -1.0) => "bbb")
+
 ;; 空 pattern 时的 count 行为
 (check (string-replace "hello" "" "-" 1) => "-hello")
 (check (string-replace "hello" "" "-" 2) => "-h-ello")


### PR DESCRIPTION
## 概述
将 `(liii string)` 的 `string-replace` 从 Scheme 实现迁移到 C++（`g_string-replace`，位于 `src/liii_string.cpp`），先写基准测试再实现。

## 改动
- `bench/string-replace.scm`（新增）：基准测试，覆盖短字符串、count 参数、空 pattern、中文/Emoji、长字符串等 10 个场景
- `src/liii_string.cpp`：新增 `g_string-replace`，入参拷入 `std::string_view`，全程无 Scheme 回调，仅最后一次堆分配
- `goldfish/liii/string.scm`：`string-replace` 直接绑定 C++ 实现
- `tests/liii/string/string-replace-test.scm`：新增浮点数 count 契约测试（已验证与旧实现行为一致）
- `devel/0104.md`：任务文档

## 契约保持
- str/old/new 非字符串 → `type-error`；count 非整数 → `type-error`
- 超参/缺参由 s7 arity 检查自动抛 `wrong-number-of-args`
- 语义对齐：从左到右非重叠替换、count=0 返回副本、负数替换全部、空 pattern 按字节插入、无匹配返回副本

## 测试
- 回归测试 57 项全部通过；`bin/gf test --all` 1493 项全部通过

## 性能（秒，越少越好）
| 场景 | 基线 | C++ 实现 | 加速比 |
|---|---|---|---|
| 短字符串 单次替换 (100000次) | 0.0836 | 0.0078 | ~10.7x |
| 短字符串 多次替换 (100000次) | 0.1042 | 0.0084 | ~12.4x |
| 空pattern 插入 (100000次) | 0.1233 | 0.0109 | ~11.3x |
| 中文字符串 替换 (100000次) | 0.1124 | 0.0117 | ~9.6x |
| 长字符串(约4000字符) 多次替换 (10000次) | 1.8127 | 0.1500 | ~12.1x |