### PR TITLE
[0105] 复用 C 实现优化 srfi-13 的 string-prefix? 和 string-suffix?

### DIFF
--- a/bench/string-prefix-suffix.scm
+++ b/bench/string-prefix-suffix.scm
@@ -1,0 +1,142 @@
+;; string-prefix? / string-suffix? 性能基准测试
+;; 对比旧 Scheme 实现（substring 分配临时串 + string=?）
+;; 与新实现（复用 liii_string.cpp 的 g_string-starts?/g_string-ends?）
+
+(import (liii timeit) (scheme base) (srfi srfi-13))
+
+;; 旧 Scheme 实现（优化前 srfi-13 中的定义）
+
+(define (string-prefix?-scheme prefix str)
+  (let* ((prefix-len (string-length prefix)) (str-len (string-length str)))
+    (and (<= prefix-len str-len) (string=? prefix (substring str 0 prefix-len)))
+  ) ;let*
+) ;define
+
+(define (string-suffix?-scheme suffix str)
+  (let* ((suffix-len (string-length suffix)) (str-len (string-length str)))
+    (and (<= suffix-len str-len)
+      (string=? suffix (substring str (- str-len suffix-len) str-len))
+    ) ;and
+  ) ;let*
+) ;define
+
+(define (bench name stmt number)
+  (let ((elapsed (timeit stmt '() number)))
+    (display name)
+    (display ": ")
+    (display elapsed)
+    (display " 秒 (")
+    (display number)
+    (display " 次)\n")
+  ) ;let
+) ;define
+
+(define (run-benchmarks)
+  (display "=== string-prefix? / string-suffix? 性能测试 ===\n\n")
+
+  ;; 短字符串，短前缀/后缀（最常见场景：扩展名、路径判断）
+  (bench "prefix? Scheme 短串匹配      "
+    (lambda () (string-prefix?-scheme "doc" "document.txt"))
+    100000
+  ) ;bench
+  (bench "prefix? C      短串匹配      "
+    (lambda () (string-prefix? "doc" "document.txt"))
+    100000
+  ) ;bench
+  (bench "prefix? Scheme 短串不匹配    "
+    (lambda () (string-prefix?-scheme "txt" "document.txt"))
+    100000
+  ) ;bench
+  (bench "prefix? C      短串不匹配    "
+    (lambda () (string-prefix? "txt" "document.txt"))
+    100000
+  ) ;bench
+  (bench "suffix? Scheme 短串匹配      "
+    (lambda () (string-suffix?-scheme ".txt" "document.txt"))
+    100000
+  ) ;bench
+  (bench "suffix? C      短串匹配      "
+    (lambda () (string-suffix? ".txt" "document.txt"))
+    100000
+  ) ;bench
+  (bench "suffix? Scheme 短串不匹配    "
+    (lambda () (string-suffix?-scheme ".pdf" "document.txt"))
+    100000
+  ) ;bench
+  (bench "suffix? C      短串不匹配    "
+    (lambda () (string-suffix? ".pdf" "document.txt"))
+    100000
+  ) ;bench
+  (newline)
+
+  ;; 长字符串 + 长前缀/后缀完全匹配（旧实现要 substring + string=?）
+  (let* ((long-str (make-string 1000 #\a))
+         (prefix (make-string 100 #\a))
+         (suffix (make-string 100 #\a))
+        ) ;
+    (bench "prefix? Scheme 长串匹配      "
+      (lambda () (string-prefix?-scheme prefix long-str))
+      100000
+    ) ;bench
+    (bench "prefix? C      长串匹配      "
+      (lambda () (string-prefix? prefix long-str))
+      100000
+    ) ;bench
+    (bench "suffix? Scheme 长串匹配      "
+      (lambda () (string-suffix?-scheme suffix long-str))
+      100000
+    ) ;bench
+    (bench "suffix? C      长串匹配      "
+      (lambda () (string-suffix? suffix long-str))
+      100000
+    ) ;bench
+  ) ;let*
+  (newline)
+
+  ;; 边界：空前缀/后缀、前缀比串长
+  (bench "prefix? Scheme 空前缀        "
+    (lambda () (string-prefix?-scheme "" "hello"))
+    100000
+  ) ;bench
+  (bench "prefix? C      空前缀        "
+    (lambda () (string-prefix? "" "hello"))
+    100000
+  ) ;bench
+  (bench "prefix? Scheme 前缀过长      "
+    (lambda () (string-prefix?-scheme "hello" "hi"))
+    100000
+  ) ;bench
+  (bench "prefix? C      前缀过长      "
+    (lambda () (string-prefix? "hello" "hi"))
+    100000
+  ) ;bench
+  (bench "suffix? Scheme 后缀过长      "
+    (lambda () (string-suffix?-scheme "hello" "hi"))
+    100000
+  ) ;bench
+  (bench "suffix? C      后缀过长      "
+    (lambda () (string-suffix? "hello" "hi"))
+    100000
+  ) ;bench
+  (newline)
+
+  ;; 中文 UTF-8 场景
+  (bench "prefix? Scheme 中文匹配      "
+    (lambda () (string-prefix?-scheme "中文" "中文测试字符串"))
+    100000
+  ) ;bench
+  (bench "prefix? C      中文匹配      "
+    (lambda () (string-prefix? "中文" "中文测试字符串"))
+    100000
+  ) ;bench
+  (bench "suffix? Scheme 中文匹配      "
+    (lambda () (string-suffix?-scheme "串" "中文测试字符串"))
+    100000
+  ) ;bench
+  (bench "suffix? C      中文匹配      "
+    (lambda () (string-suffix? "串" "中文测试字符串"))
+    100000
+  ) ;bench
+) ;define
+
+(run-benchmarks)

--- a/devel/0105.md
+++ b/devel/0105.md
@@ -1,0 +1,66 @@
+# [0105] 复用 C 实现优化 srfi-13 的 string-prefix? 和 string-suffix?
+
+相关文档：[0102](0102.md) 用 C 实现优化 liii string 的 string-starts? 和 string-ends?
+
+## 任务相关的代码文件
+- `goldfish/srfi/srfi-13.scm` — string-prefix? / string-suffix? 改为复用 C 实现
+- `src/liii_string.cpp` — 被复用的 `g_string-starts?` / `g_string-ends?`（本任务无改动）
+- `tests/srfi/srfi-13/string-prefix-p-test.scm` / `tests/srfi/srfi-13/string-suffix-p-test.scm` — 回归测试（沿用既有用例）
+- `bench/string-prefix-suffix.scm` — 性能基准测试
+
+## 如何测试
+
+```bash
+# 1. 格式化检查
+bin/gf fmt goldfish/srfi/srfi-13.scm
+bin/gf fmt bench/string-prefix-suffix.scm
+
+# 2. 回归测试
+bin/gf tests/srfi/srfi-13/string-prefix-p-test.scm
+bin/gf tests/srfi/srfi-13/string-suffix-p-test.scm
+bin/gf test --all
+
+# 3. 性能测试
+bin/gf bench/string-prefix-suffix.scm
+```
+
+## 2026/08/08 复用 C 实现优化 string-prefix? 和 string-suffix?
+
+### What
+
+`srfi-13.scm` 中 `string-prefix?` / `string-suffix?` 不再自行
+`substring` + `string=?`，改为薄封装复用 [0102](0102.md) 引入的
+C 实现 `g_string-starts?` / `g_string-ends?`。
+既有测试 48 + 52 条全部通过，`bin/gf test --all` 无回归。
+
+性能实测（秒，越少越好，`bin/gf bench/string-prefix-suffix.scm`，100000 次）：
+
+| 场景 | 基线 | 新实现 | 加速比 |
+|---|---|---|---|
+| prefix? 短串匹配 | 0.0106 | 0.0073 | ~1.5x |
+| prefix? 短串不匹配 | 0.0109 | 0.0079 | ~1.4x |
+| suffix? 短串匹配 | 0.0114 | 0.0077 | ~1.5x |
+| suffix? 短串不匹配 | 0.0119 | 0.0075 | ~1.6x |
+| prefix? 长串匹配(1000/100) | 0.0133 | 0.0081 | ~1.6x |
+| suffix? 长串匹配(1000/100) | 0.0126 | 0.0080 | ~1.6x |
+| prefix? 空前缀 | 0.0115 | 0.0079 | ~1.5x |
+| prefix? 前缀过长 | 0.0062 | 0.0066 | 持平（均为长度短路） |
+| suffix? 后缀过长 | 0.0065 | 0.0070 | 持平（均为长度短路） |
+| prefix? 中文匹配 | 0.0115 | 0.0074 | ~1.5x |
+| suffix? 中文匹配 | 0.0121 | 0.0081 | ~1.5x |
+
+### Why
+
+string-prefix? / string-suffix? 是路径、扩展名判断的高频函数。
+旧实现每次调用都要 substring 分配一个与前缀等长的临时字符串再做
+string=? 比较；新实现零分配，C 侧一次 memcmp 完成。
+
+### How
+
+- 参数顺序相反：srfi-13 是 `(string-prefix? prefix str)`，
+  C 实现是 `(g_string-starts? str prefix)`，封装时交换
+- 错误契约不同：liii 的 string-starts?/string-ends? 抛 `type-error`，
+  而 srfi-13 既有测试契约是 `wrong-type-arg`（旧实现由 string-length
+  隐式抛出）。因此不能直接别名，Scheme 侧先做 string? 检查，
+  失败时显式抛 `wrong-type-arg`，类型检查开销可忽略
+- 字节级 memcmp 对 UTF-8 精确：字节前缀/后缀匹配与码点匹配等价

--- a/goldfish/srfi/srfi-13.scm
+++ b/goldfish/srfi/srfi-13.scm
@@ -287,18 +287,21 @@
       ) ;let
     ) ;define
 
+    ;; string-prefix?/string-suffix? 复用 C 实现的 g_string-starts?/g_string-ends?
+    ;; （见 src/liii_string.cpp），避免旧实现的 substring 临时分配；
+    ;; 注意参数顺序相反，且错误契约为 wrong-type-arg（区别于 liii 的 type-error）
     (define (string-prefix? prefix str)
-      (let* ((prefix-len (string-length prefix)) (str-len (string-length str)))
-        (and (<= prefix-len str-len) (string=? prefix (substring str 0 prefix-len)))
-      ) ;let*
+      (if (and (string? prefix) (string? str))
+        (g_string-starts? str prefix)
+        (error 'wrong-type-arg "string-prefix?: expected string arguments")
+      ) ;if
     ) ;define
 
     (define (string-suffix? suffix str)
-      (let* ((suffix-len (string-length suffix)) (str-len (string-length str)))
-        (and (<= suffix-len str-len)
-          (string=? suffix (substring str (- str-len suffix-len) str-len))
-        ) ;and
-      ) ;let*
+      (if (and (string? suffix) (string? str))
+        (g_string-ends? str suffix)
+        (error 'wrong-type-arg "string-suffix?: expected string arguments")
+      ) ;if
     ) ;define
 
     (define (string-index str char/pred? . start+end)


### PR DESCRIPTION
## What

`srfi-13.scm` 中 `string-prefix?` / `string-suffix?` 不再自行 `substring` + `string=?`，改为薄封装复用 [0102] 引入的 C 实现 `g_string-starts?` / `g_string-ends?`，消除每次调用的临时字符串分配。

详细文档见 `devel/0105.md`。

## 契约保持

- 参数顺序差异（srfi-13 前缀在前，liii 源串在前）在封装层交换
- srfi-13 的 `wrong-type-arg` 错误契约保持不变（liii 版为 `type-error`，故不直接别名）

## 测试

- `tests/srfi/srfi-13/string-prefix-p-test.scm` 48 条、`string-suffix-p-test.scm` 52 条全部通过（沿用既有用例，覆盖 Unicode/空串/大小写/错误类型）
- `bin/gf test --all`：1493 项全部通过

## 性能（bench/string-prefix-suffix.scm，100000 次）

| 场景 | 基线 | 新实现 | 加速比 |
|---|---|---|---|
| 短串匹配/不匹配 | 0.0106~0.0119s | 0.0073~0.0079s | ~1.4-1.6x |
| 长串匹配(1000/100) | 0.0126~0.0133s | 0.0080~0.0081s | ~1.6x |
| 中文匹配 | 0.0115~0.0121s | 0.0074~0.0081s | ~1.5x |
| 前缀/后缀过长 | 持平（均为长度短路） | | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)