### PR TITLE
[0106] 用 C++ 实现优化 srfi-132 的 list-sorted?

### DIFF
--- a/bench/list-sorted-p.scm
+++ b/bench/list-sorted-p.scm
@@ -1,0 +1,101 @@
+;; list-sorted? 性能基准测试
+;; 对比旧 Scheme 实现（do 循环逐对比较）
+;; 与新实现（liii_sort.cpp 的 g_list-sorted?）
+
+(import (liii timeit) (scheme base) (liii sort))
+
+;; 旧 Scheme 实现（优化前 srfi-132 中的定义）
+
+(define (list-sorted?-scheme less-p lis)
+  (if (null? lis)
+    #t
+    (do ((first lis (cdr first))
+         (second (cdr lis) (cdr second))
+         (res #t (not (less-p (car second) (car first))))
+        ) ;
+      ((or (null? second) (not res)) res)
+    ) ;do
+  ) ;if
+) ;define
+
+(define (bench name stmt number)
+  (let ((elapsed (timeit stmt '() number)))
+    (display name)
+    (display ": ")
+    (display elapsed)
+    (display " 秒 (")
+    (display number)
+    (display " 次)\n")
+  ) ;let
+) ;define
+
+(define sorted-long (iota 1000))
+
+(define sorted-short '(1 2 3 4 5 6 7 8 9 10))
+
+(define unsorted-head '(5 1 2 3 4 6 7 8 9 10))
+
+(define unsorted-tail (append (iota 999) '(-1)))
+
+(define (run-benchmarks)
+  (display "=== list-sorted? 性能测试 ===\n\n")
+
+  ;; 长列表全有序（最坏情况：遍历整个列表）
+  (bench "Scheme 长列表有序(1000)  "
+    (lambda () (list-sorted?-scheme < sorted-long))
+    10000
+  ) ;bench
+  (bench "C++    长列表有序(1000)  "
+    (lambda () (list-sorted? < sorted-long))
+    10000
+  ) ;bench
+
+  ;; 短列表全有序
+  (bench "Scheme 短列表有序(10)    "
+    (lambda () (list-sorted?-scheme < sorted-short))
+    100000
+  ) ;bench
+  (bench "C++    短列表有序(10)    "
+    (lambda () (list-sorted? < sorted-short))
+    100000
+  ) ;bench
+
+  ;; 头部即逆序（最快返回）
+  (bench "Scheme 头部逆序          "
+    (lambda () (list-sorted?-scheme < unsorted-head))
+    100000
+  ) ;bench
+  (bench "C++    头部逆序          "
+    (lambda () (list-sorted? < unsorted-head))
+    100000
+  ) ;bench
+
+  ;; 尾部才逆序
+  (bench "Scheme 尾部逆序(1000)    "
+    (lambda () (list-sorted?-scheme < unsorted-tail))
+    10000
+  ) ;bench
+  (bench "C++    尾部逆序(1000)    "
+    (lambda () (list-sorted? < unsorted-tail))
+    10000
+  ) ;bench
+
+  ;; 空列表与单元素
+  (bench "Scheme 空列表            "
+    (lambda () (list-sorted?-scheme < '()))
+    100000
+  ) ;bench
+  (bench "C++    空列表            " (lambda () (list-sorted? < '())) 100000)
+
+  ;; 自定义 lambda 比较器（回调开销主导）
+  (bench "Scheme lambda比较器(100) "
+    (lambda () (list-sorted?-scheme (lambda (a b) (< a b)) (iota 100)))
+    10000
+  ) ;bench
+  (bench "C++    lambda比较器(100) "
+    (lambda () (list-sorted? (lambda (a b) (< a b)) (iota 100)))
+    10000
+  ) ;bench
+) ;define
+
+(run-benchmarks)

--- a/devel/0106.md
+++ b/devel/0106.md
@@ -1,0 +1,71 @@
+# [0106] 用 C++ 实现优化 srfi-132 的 list-sorted?
+
+相关文档：[0104](0104.md) 用 C++ 实现优化 string-replace
+
+## 任务相关的代码文件
+- `src/liii_sort.cpp` — 新增，`g_list-sorted?` 的 C++ 实现
+- `src/goldfish.hpp` — 声明并调用 `glue_liii_sort`
+- `xmake.lua` — 新增 `src/liii_sort.cpp` 编译单元
+- `goldfish/srfi/srfi-132.scm` — `list-sorted?` 改为薄封装复用 C++ 实现
+- `tests/liii/sort/list-sorted-p-test.scm` — 补充边界用例（相等元素、lambda 比较器、错误契约）
+- `bench/list-sorted-p.scm` — 性能基准测试
+
+## 如何测试
+
+```bash
+# 1. 构建
+xmake b goldfish
+
+# 2. 格式化检查
+bin/gf fmt goldfish/srfi/srfi-132.scm
+bin/gf fmt tests/liii/sort/list-sorted-p-test.scm
+bin/gf fmt bench/list-sorted-p.scm
+
+# 3. 回归测试
+bin/gf tests/liii/sort/list-sorted-p-test.scm
+bin/gf test --all
+
+# 4. 性能测试
+bin/gf bench/list-sorted-p.scm
+```
+
+## 2026/08/09 用 C++ 实现优化 list-sorted?
+
+### What
+
+`srfi-132.scm` 中 `list-sorted?` 不再使用 Scheme 的 `do` 循环逐对比较，
+改为薄封装复用新增 `liii_sort.cpp` 的 C++ 实现 `g_list-sorted?`。
+测试 22 条全部通过，`bin/gf test --all` 1493 条无回归。
+
+性能实测（秒，越少越好，`bin/gf bench/list-sorted-p.scm`）：
+
+| 场景 | 基线(Scheme) | 新实现(C++) | 加速比 |
+|---|---|---|---|
+| 长列表有序(1000)，10000 次 | 0.381 | 0.050 | ~7.7x |
+| 短列表有序(10)，100000 次 | 0.058 | 0.020 | ~2.9x |
+| 头部逆序，100000 次 | 0.022 | 0.012 | ~1.7x |
+| 尾部逆序(1000)，10000 次 | 0.432 | 0.051 | ~8.5x |
+| 空列表，100000 次 | 0.0049 | 0.0077 | 略慢（多一层薄封装调用，单次约 28ns，可忽略） |
+| lambda 比较器(100)，10000 次 | 0.079 | 0.061 | ~1.3x |
+
+### Why
+
+`list-sorted?` 是排序正确性验证和有序性判断的常用函数。
+旧 Scheme 实现每个元素对都要经过解释器 `do` 循环的变量更新、`car`/`cdr`/`not`
+多次求值，开销集中在解释器调度而非比较本身；C++ 实现把遍历循环放到 C 层，
+每对元素只做一次 `s7_apply_function` 回调。
+
+### How
+
+- 判定标准与 SRFI-132 参考实现严格一致：对所有相邻元素对，
+  `(less-p next prev)` 返回非 `#f` 即视为逆序。因此 `<` 允许相邻相等、
+  `<=` 不允许，测试用例已固化该语义
+- **GC 保护**：`args` 的 cons 单元在 `less-p` 回调期间可能被求值器复用，
+  因此自建 anchor `(less_p lis . call_args)` 并用 `s7_gc_protect_via_stack`
+  保护，保证回调触发 GC 时比较器、列表脊柱和调用参数列表全部可达
+- **可复用调用列表**：自建二元参数列表，循环中只 `s7_set_car` 替换两个槽位，
+  避免每对元素都分配新 cons
+- 错误契约与旧实现一致：非正规列表、非过程比较器均抛 `wrong-type-arg`；
+  已在头部发现逆序时即使列表尾部不正规也直接返回 `#f`（与旧实现行为相同）
+- 空列表路径旧实现直接走 `null?` 快路径，新实现多一层 Scheme 薄封装调用，
+  单次开销约 28ns，可接受

--- a/goldfish/srfi/srfi-132.scm
+++ b/goldfish/srfi/srfi-132.scm
@@ -33,16 +33,9 @@
   (import (liii list) (liii error) (scheme case-lambda))
   (begin
 
+    ;; list-sorted? 复用 liii_sort.cpp 的 C++ 实现 g_list-sorted?
     (define (list-sorted? less-p lis)
-      (if (null? lis)
-        #t
-        (do ((first lis (cdr first))
-             (second (cdr lis) (cdr second))
-             (res #t (not (less-p (car second) (car first))))
-            ) ;
-          ((or (null? second) (not res)) res)
-        ) ;do
-      ) ;if
+      (g_list-sorted? less-p lis)
     ) ;define
 
     (define vector-sorted?

--- a/src/goldfish.hpp
+++ b/src/goldfish.hpp
@@ -116,6 +116,7 @@ void glue_scheme_char (s7_scheme* sc);
 void glue_liii_hashlib (s7_scheme* sc);
 void glue_liii_os (s7_scheme* sc);
 void glue_liii_path (s7_scheme* sc);
+void glue_liii_sort (s7_scheme* sc);
 void glue_liii_string (s7_scheme* sc);
 void glue_subprocess_run_values (s7_scheme* sc);
 
@@ -700,6 +701,7 @@ glue_for_community_edition (s7_scheme* sc) {
   glue_liii_os (sc);
   glue_subprocess_run_values (sc);
   glue_liii_path (sc);
+  glue_liii_sort (sc);
   glue_liii_list (sc);
   glue_liii_string (sc);
   glue_liii_time (sc);

--- a/src/liii_sort.cpp
+++ b/src/liii_sort.cpp
@@ -24,7 +24,7 @@ namespace goldfish {
 static s7_pointer
 f_list_sorted_p (s7_scheme* sc, s7_pointer args) {
   s7_pointer less_p= s7_car (args);
-  s7_pointer lis= s7_cadr (args);
+  s7_pointer lis   = s7_cadr (args);
 
   if (!s7_is_procedure (less_p)) {
     return s7_wrong_type_arg_error (sc, "list-sorted?", 1, less_p, "a procedure");
@@ -38,13 +38,13 @@ f_list_sorted_p (s7_scheme* sc, s7_pointer args) {
    * 因此把 less_p、列表头和我们自建的二元调用列表放进同一个
    * 栈上保护的 anchor，保证回调触发 GC 时全部可达 */
   s7_pointer call_args= s7_cons (sc, s7_f (sc), s7_cons (sc, s7_f (sc), s7_nil (sc)));
-  s7_pointer anchor= s7_cons (sc, less_p, s7_cons (sc, lis, call_args));
+  s7_pointer anchor   = s7_cons (sc, less_p, s7_cons (sc, lis, call_args));
   s7_gc_protect_via_stack (sc, anchor);
   s7_pointer call_args_second= s7_cdr (call_args);
 
-  bool        sorted= true;
-  s7_pointer  prev= s7_car (lis);
-  s7_pointer  p= s7_cdr (lis);
+  bool       sorted= true;
+  s7_pointer prev  = s7_car (lis);
+  s7_pointer p     = s7_cdr (lis);
   while (s7_is_pair (p)) {
     s7_pointer cur= s7_car (p);
     s7_set_car (call_args, cur);
@@ -54,7 +54,7 @@ f_list_sorted_p (s7_scheme* sc, s7_pointer args) {
       break;
     }
     prev= cur;
-    p= s7_cdr (p);
+    p   = s7_cdr (p);
   }
   s7_gc_unprotect_via_stack (sc, anchor);
 

--- a/src/liii_sort.cpp
+++ b/src/liii_sort.cpp
@@ -1,0 +1,80 @@
+//
+// Copyright (C) 2026 The Goldfish Scheme Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "s7.h"
+
+namespace goldfish {
+
+// (g_list-sorted? less-p lis) => boolean
+// 判定标准与 SRFI-132 参考实现一致：对所有相邻元素对，
+// (less-p next prev) 为真（非 #f）即视为逆序。
+static s7_pointer
+f_list_sorted_p (s7_scheme* sc, s7_pointer args) {
+  s7_pointer less_p= s7_car (args);
+  s7_pointer lis= s7_cadr (args);
+
+  if (!s7_is_procedure (less_p)) {
+    return s7_wrong_type_arg_error (sc, "list-sorted?", 1, less_p, "a procedure");
+  }
+  if (!s7_is_pair (lis)) {
+    if (s7_is_null (sc, lis)) return s7_t (sc);
+    return s7_wrong_type_arg_error (sc, "list-sorted?", 2, lis, "a proper list");
+  }
+
+  /* args 的 cons 单元在 less_p 回调期间可能被求值器复用，
+   * 因此把 less_p、列表头和我们自建的二元调用列表放进同一个
+   * 栈上保护的 anchor，保证回调触发 GC 时全部可达 */
+  s7_pointer call_args= s7_cons (sc, s7_f (sc), s7_cons (sc, s7_f (sc), s7_nil (sc)));
+  s7_pointer anchor= s7_cons (sc, less_p, s7_cons (sc, lis, call_args));
+  s7_gc_protect_via_stack (sc, anchor);
+  s7_pointer call_args_second= s7_cdr (call_args);
+
+  bool        sorted= true;
+  s7_pointer  prev= s7_car (lis);
+  s7_pointer  p= s7_cdr (lis);
+  while (s7_is_pair (p)) {
+    s7_pointer cur= s7_car (p);
+    s7_set_car (call_args, cur);
+    s7_set_car (call_args_second, prev);
+    if (s7_apply_function (sc, less_p, call_args) != s7_f (sc)) {
+      sorted= false;
+      break;
+    }
+    prev= cur;
+    p= s7_cdr (p);
+  }
+  s7_gc_unprotect_via_stack (sc, anchor);
+
+  if (!sorted) return s7_f (sc);
+  if (!s7_is_null (sc, p)) {
+    return s7_wrong_type_arg_error (sc, "list-sorted?", 2, lis, "a proper list");
+  }
+  return s7_t (sc);
+}
+
+static void
+glue_list_sorted_p (s7_scheme* sc) {
+  const char* name= "g_list-sorted?";
+  const char* desc= "(g_list-sorted? less-p lis) => boolean";
+  s7_define_function (sc, name, f_list_sorted_p, 2, 0, false, desc);
+}
+
+void
+glue_liii_sort (s7_scheme* sc) {
+  glue_list_sorted_p (sc);
+}
+
+} // namespace goldfish

--- a/tests/liii/sort/list-sorted-p-test.scm
+++ b/tests/liii/sort/list-sorted-p-test.scm
@@ -31,7 +31,7 @@
 ;;
 ;; 错误处理
 ;; ----
-;; 无
+;; cmp 不是过程、lst 不是正规列表时抛出错误
 
 
 (check-false (list-sorted? < '(1 5 1 0 -1 9 2 4 3)))
@@ -40,6 +40,35 @@
 (check-true (list-sorted? < '(42)))
 (check-true (list-sorted? > '(5 4 3 2 1)))
 (check-false (list-sorted? > '(1 2 3 4 5)))
+
+;; 两个元素的边界情况
+(check-true (list-sorted? < '(1 2)))
+(check-false (list-sorted? < '(2 1)))
+
+;; 相等元素：判定标准是 (not (less-p next prev))，与 SRFI-132 参考实现一致
+;; < 允许相邻相等，<= 不允许（1 <= 1 为真即视为逆序）
+(check-true (list-sorted? < '(1 1 2 2 3)))
+(check-false (list-sorted? <= '(1 1 2 2 3)))
+(check-false (list-sorted? > '(1 1 2 2 3)))
+
+;; 自定义比较器（lambda）
+(check-true (list-sorted? (lambda (a b) (< (abs a) (abs b))) '(1 -2 3 -4)))
+(check-false (list-sorted? (lambda (a b) (< (abs a) (abs b))) '(1 -3 2)))
+
+;; 字符串比较器
+(check-true (list-sorted? string<? '("a" "b" "c")))
+(check-false (list-sorted? string<? '("b" "a")))
+
+;; 字符比较器
+(check-true (list-sorted? char<? '(#\a #\b #\c)))
+(check-false (list-sorted? char<? '(#\b #\a)))
+
+;; 错误：lst 不是正规列表
+(check-catch 'wrong-type-arg (list-sorted? < '(1 2 . 3)))
+(check-catch 'wrong-type-arg (list-sorted? < 3))
+
+;; 错误：cmp 不是过程
+(check-catch 'wrong-type-arg (list-sorted? 3 '(1 2 3)))
 
 
 ;; 配合排序函数使用

--- a/xmake.lua
+++ b/xmake.lua
@@ -111,6 +111,7 @@ target ("goldfish") do
     end
     add_files ("src/liii_os.cpp")
     add_files ("src/liii_path.cpp")
+    add_files ("src/liii_sort.cpp")
     add_files ("src/liii_string.cpp")
     add_files ("src/liii_hashlib.cpp")
     add_files ("src/liii_base64.cpp")


### PR DESCRIPTION
## 概述

`srfi-132` 的 `list-sorted?` 原为 Scheme `do` 循环实现，本 PR 改为薄封装复用新增 `src/liii_sort.cpp` 的 C++ 实现 `g_list-sorted?`。

详细文档见 [devel/0106.md](devel/0106.md)。

## 性能

| 场景 | 基线(Scheme) | C++ | 加速比 |
|---|---|---|---|
| 长列表有序(1000) | 0.381s | 0.050s | ~7.7x |
| 尾部逆序(1000) | 0.432s | 0.051s | ~8.5x |
| 短列表有序(10) | 0.058s | 0.020s | ~2.9x |
| lambda 比较器(100) | 0.079s | 0.061s | ~1.3x |

## 实现要点

- 判定标准与 SRFI-132 参考实现一致：`(not (less-p next prev))`（`<` 允许相邻相等，`<=` 不允许，已固化进测试）
- GC 保护：自建 anchor + `s7_gc_protect_via_stack`，防止 `less-p` 回调期间求值器复用 args 单元
- 循环零分配：自建二元调用列表，循环内仅 `s7_set_car` 换槽位
- 错误契约不变：非正规列表 / 非过程比较器抛 `wrong-type-arg`

## 测试

- 新增/补充 `tests/liii/sort/list-sorted-p-test.scm` 至 22 条用例，全部通过
- `bin/gf test --all`：1493 条全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)