### PR TITLE
[0108] 修复 gf fmt 将注释行后的闭合括号合并到注释行末尾 (fix #912)

### DIFF
--- a/devel/0108.md
+++ b/devel/0108.md
@@ -1,0 +1,35 @@
+# [0108] 修复 gf fmt 将注释行后的闭合括号合并到注释行末尾 (fix #912)
+
+## 任务相关的代码文件
+- tools/fmt/liii/goldfmt-format.scm
+- tools/fmt/tests/liii/goldfmt-format/format-string-test.scm
+- gf_fmt.json
+
+## 如何测试
+```bash
+# 构建
+xmake b goldfish
+
+# 运行 fmt 测试套件
+bin/gf test tools/fmt/tests/
+
+# 端到端测试
+bin/gf fmt --dry-run /tmp/test_912.scm
+```
+
+## 2026-08-11 修复 reader-append-rest 注释后闭合括号换行
+
+### What
+修复了 `gf fmt` 在 `reader-datum` 格式化路径中，当最后一个元素是注释时，闭合括号被错误合并到注释行末尾的问题 (fix #912)。
+
+1. 在 `reader-append-rest` 中增加了检测：当 rest 列表的最后一个元素是 `comment-datum?` 时，在注释文本后附加换行和缩进，确保闭合括号独占一行
+2. 添加了 4 个测试用例覆盖各种场景（walker 路径、reader-datum 路径、嵌套 form、quote 形式）
+3. 在 `gf_fmt.json` 中排除了 `tools/fmt` 目录，防止 `gf fmt` 破坏 fmt 工具自身的测试文件（其中包含 `(*comment* ...)` 和 `(*newline* N)` 等特殊标记）
+
+### Why
+`reader-append-rest` 处理每个子元素后都会追加 `\n` 和缩进，但 `reader-append-close` 只在结果以 `;#` 结尾时（vector 闭合）才追加换行。对于普通列表，闭合括号直接拼接到最后一行末尾。当最后一行是注释时，`;; comment)` 这样的输出破坏了代码结构。
+
+walker 路径（`walk-env!`）通过始终在 `)` 前插入换行来避免此问题，但 reader-datum 路径（用于 quote/quasiquote 内部格式化）缺少对应的处理。
+
+### How
+修改 `reader-append-rest` 中非 newline-marker 元素的分支：在处理元素前先检查它是否是最后一个元素且为 comment datum。若是，在拼接的字符串末尾追加 `"\n" + spaces(close-indent)`。这样当后续的 `reader-append-close` 追加 `)` 时，闭合括号自然出现在独立行上。

--- a/gf_fmt.json
+++ b/gf_fmt.json
@@ -14,7 +14,8 @@
     "suffix": ["scm"],
     "path": ["goldfish", "tools"],
     "exclude": [
-      "tests"
+      "tests",
+      "tools/fmt"
     ]
   }
 }

--- a/tools/fmt/liii/goldfmt-format.scm
+++ b/tools/fmt/liii/goldfmt-format.scm
@@ -506,17 +506,23 @@
                    #t
                    close-indent
                  ) ;reader-append-rest
-                 (reader-append-rest (cdr current)
-                   (string-append result
-                     (if prefix-ready? "" (string-append "\n" (spaces rest-indent)))
-                     (format-reader-datum-at item
-                       (if prefix-ready? (last-line-column result) rest-indent)
-                     ) ;format-reader-datum-at
-                   ) ;string-append
-                   rest-indent
-                   #f
-                   close-indent
-                 ) ;reader-append-rest
+                 (let ((is-last-comment? (and (null? (cdr current)) (comment-datum? item)))
+                       (item-text (format-reader-datum-at item
+                                    (if prefix-ready? (last-line-column result) rest-indent)
+                                  ) ;format-reader-datum-at
+                       ) ;item-text
+                      ) ;
+                   (reader-append-rest (cdr current)
+                     (string-append result
+                       (if prefix-ready? "" (string-append "\n" (spaces rest-indent)))
+                       item-text
+                       (if is-last-comment? (string-append "\n" (spaces close-indent)) "")
+                     ) ;string-append
+                     rest-indent
+                     #f
+                     close-indent
+                   ) ;reader-append-rest
+                 ) ;let
                ) ;if
              ) ;let
             ) ;

--- a/tools/fmt/tests/liii/goldfmt-format/format-string-test.scm
+++ b/tools/fmt/tests/liii/goldfmt-format/format-string-test.scm
@@ -286,4 +286,34 @@
 "OUT"
 ) ;check
 
+;; issue 912: 当最后一个元素是注释时，闭合括号不应合并到注释行末尾
+;; 测试 1: format-datum 处理 comment datum — 闭合括号应独占一行
+;; 使用 list 构建 datum，避免 gf fmt 将 (*comment* ...) 转换为 ;; ……
+(check (format-datum (list 'operator_field "$" "@" "%%" "%" (list '*comment* " ${var##pat} ${var%pat} ...")))
+  =>
+  "(operator_field \"$\"\n  \"@\"\n  \"%%\"\n  \"%\"\n  ;; ${var##pat} ${var%pat} ...\n) ;operator_field"
+) ;check
+
+;; 测试 2: format-string 处理嵌套 form，注释是内部 form 的最后一个子元素
+(check (format-string "(define f\n  (operator_field \"$\"\n    \"@\"\n    \"%%\"\n    \"%\"\n    (*comment* \" ${var##pat} ${var%pat} ...\")\n  )\n)\n"
+       ) ;format-string
+  =>
+  "(define f\n  (operator_field \"$\"\n    \"@\"\n    \"%%\"\n    \"%\"\n    ;; ${var##pat} ${var%pat} ...\n  ) ;operator_field\n) ;define\n"
+) ;check
+
+;; 测试 3: format-string 直接测试 operator_field 中有注释作为最后一个元素
+(check (format-string "(operator_field \"$\"\n  \"@\"\n  \"%%\"\n  \"%\"\n  (*comment* \" ${var##pat} ${var%pat} ...\")\n)\n"
+       ) ;format-string
+  =>
+  "(operator_field \"$\"\n  \"@\"\n  \"%%\"\n  \"%\"\n  ;; ${var##pat} ${var%pat} ...\n) ;operator_field\n"
+) ;check
+
+;; 测试 4: quote 形式中注释是最后一个元素 — reader-datum 路径
+;; format-datum 处理 '(operator_field ...)，内部走 format-reader-datum-at 路径
+;; 使用 list 构建 datum，避免 gf fmt 将 (*comment* ...) 转换为 ;; ……
+(check (format-datum (list 'quote (list 'operator_field "$" "@" "%%" "%" (list '*comment* " comment"))))
+  =>
+  "'(operator_field \"$\"\n   \"@\"\n   \"%%\"\n   \"%\"\n   ;; comment\n )"
+) ;check
+
 (check-report)


### PR DESCRIPTION
## 修复内容

修复 `gf fmt` 在 reader-datum 格式化路径中，当最后一个元素是注释时，闭合括号被错误合并到注释行末尾的问题。

### 根因
存在两套格式化路径：
- **walker 路径** (`walk-env!`) — 用于常规 form，始终在 `)` 前换行 ✓
- **reader-datum 路径** (`reader-append-rest` → `reader-append-close`) — 用于 quote/quasiquote 内部，`reader-append-close` 只在 vector 结尾时换行，普通列表直接追加 `)` 到上一行末尾 ✗

### 修复方法
在 `reader-append-rest` 中检测最后一个元素是否为 comment datum，若是则在注释文本后追加换行+缩进，确保闭合括号独占一行。

### 修改文件
| 文件 | 变更 |
|------|------|
| `tools/fmt/liii/goldfmt-format.scm` | 核心修复 |
| `tools/fmt/tests/liii/goldfmt-format/format-string-test.scm` | 新增 4 个测试用例 |
| `gf_fmt.json` | 排除 `tools/fmt` 目录 |

### 测试
- fmt 测试套件: **27/27** 通过
- scheme/base 测试套件: **212/212** 通过

Closes #912

🤖 Generated with [Claude Code](https://claude.com/claude-code)