### PR TITLE
[0111] gf fmt 支持 .stem 格式：quote/unquote 保持原样

### DIFF
--- a/devel/0111.md
+++ b/devel/0111.md
@@ -1,0 +1,46 @@
+# [0111] gf fmt 支持 .stem 格式：quote/unquote 保持原样
+
+## 任务相关的代码文件
+- tools/fmt/liii/stem-fmt.scm（新增）
+- tools/fmt/liii/goldfmt-scan.scm
+- tools/fmt/liii/goldfmt-format.scm
+- tools/fmt/liii/goldfmt-config.scm
+- tools/fmt/liii/goldfmt.scm
+- tools/fmt/tests/liii/goldfmt-format/stem-mode-test.scm（新增）
+- tools/fmt/tests/liii/stem-fmt-test.scm（新增）
+- tools/fmt/tests/resources/0111_01.stem（新增）
+
+## 如何测试
+```bash
+# 1. 构建
+xmake b goldfish
+
+# 2. 运行测试
+bin/gf test tools/fmt/tests/liii/goldfmt-format/stem-mode-test.scm
+bin/gf test tools/fmt/tests/liii/stem-fmt-test.scm
+
+# 3. 仓库级格式化检查（Scheme/C++/Stem 全部 OK）
+bin/gf fmt --check
+
+# 4. 真实 stem 文件验证（dry-run 不写回）
+bin/gf fmt --dry-run /path/to/env-base.stem
+```
+
+## 2026-08-14 gf fmt 支持 .stem 格式
+
+### What
+1. 新增 `(liii stem-fmt)` 语言 handler，注册 `.stem` 后缀，复用 goldfmt 的 scan/format 核心与缓存/配置机制。
+2. scan/format 引入 stem 模式动态开关（`call-with-stem-mode` / `stem-mode?`，定义于 goldfmt-scan，format 共享）：stem 模式下 `(quote x)`、`(quasiquote x)`、`(unquote x)`、`(unquote-splicing x)` 一律按普通列表输出，不糖化为 `'` `` ` `` `,` `,@`。
+3. 采用"结构原样"约定：stem 源码中的 `'x` / `` `x `` 字面形式统一输出为 `(quote x)` / `(quasiquote x)` 结构形式。
+4. scm 格式行为完全不变（quote-test.scm 等既有用例全量回归通过）。
+
+### Why
+`.stem` 文件（TeXmacs 宏包源格式，如 mogan 的 `TeXmacs/packages/environment/env-base.stem`）中的 quote/quasiquote/unquote 是 TeXmacs 的普通符号，不是 Scheme reader 语法。此前 `gf fmt` 对未知后缀兜底走 scheme handler，会把 `(unquote (arg "env"))` 改写成 `,(arg "env")`，TeXmacs 无法识别，文件被损坏。
+
+### How
+1. `goldfmt-scan.scm`：新增 `%stem-mode?` 动态标志（`let-temporarily` 实现）。
+   - `normalize-datum`：stem 模式下 quote 形式归一为符号 `quote` 引导的普通列表（`'x` 经 reader 变为 `(#_quote x)`，归一为 `(quote x)`）；跳过显式 quasiquote 模板正规化（避免 `(a unquote b)` 被改写为点对形式）。
+   - `scan-list`：stem 模式下跳过 quote env 特判，`(quote x)` 按普通列表扫描。
+2. `goldfmt-format.scm`：`quote-env?` / `reader-prefix-env?` 谓词在 stem 模式下恒为 #f（一处改动覆盖 format-inline / emit-inline! / walk-env! 三个调用点）；`format-reader-datum-inline` / `format-reader-datum-at` 的四个糖化分支加 stem 门控，并对 `(#_quote x)` 做防御性归一输出 `(quote x)`。
+3. `stem-fmt.scm`：照 scheme-fmt 的 handler 协议实现 collect / format-files / format-file / format-directory / check-file，scan 与 format 调用均以 `call-with-stem-mode` 包裹。
+4. `goldfmt-config.scm`：`default-suffixes` 增加 stem -> `(".stem")`；`goldfmt.scm` import `(liii stem-fmt)` 完成注册，帮助文本补充 stem 说明。

--- a/tools/fmt/liii/goldfmt-config.scm
+++ b/tools/fmt/liii/goldfmt-config.scm
@@ -48,6 +48,7 @@
     (define (default-suffixes lang)
       (cond ((eq? lang 'cpp) '(".hpp" ".cpp" ".h" ".c" ".cc" ".cxx"))
             ((eq? lang 'scheme) '(".scm"))
+            ((eq? lang 'stem) '(".stem"))
             (else '())
       ) ;cond
     ) ;define

--- a/tools/fmt/liii/goldfmt-format.scm
+++ b/tools/fmt/liii/goldfmt-format.scm
@@ -168,16 +168,21 @@
     ) ;define
 
     ;; ; 检查 env 是否为 quote 形式
+    ;; ; stem 模式下 quote 是普通符号，env 按普通列表输出，不糖化为 '
     (define (quote-env? node)
-      (and (env? node)
+      (and (not (stem-mode?))
+        (env? node)
         (or (string=? (env-tag-name node) "quote")
           (string=? (env-tag-name node) "#_quote")
         ) ;or
       ) ;and
     ) ;define
 
+    ;; ; stem 模式下 quasiquote/unquote/unquote-splicing 是普通符号，
+    ;; ; env 按普通列表输出，不糖化为 ` , ,@
     (define (reader-prefix-env? node)
-      (and (env? node)
+      (and (not (stem-mode?))
+        (env? node)
         (or (string=? (env-tag-name node) "quasiquote")
           (string=? (env-tag-name node) "unquote")
           (string=? (env-tag-name node) "unquote-splicing")
@@ -643,16 +648,21 @@
             ((dotted-tail? datum) (format-reader-datum-inline (dotted-tail-form datum)))
             ((raw-string-datum? datum) (cadr datum))
             ((comment-datum? datum) (format-comment-content (cadr datum)))
-            ((single-arg-symbol-form? datum 'quasiquote)
+            ;; ; stem 模式：quote/quasiquote/unquote 保持原样，按普通列表输出；
+            ;; ; (#_quote x) 防御性归一为 (quote x)（正常路径已在 scan 阶段归一）
+            ((and (stem-mode?) (quote-syntax-form? datum))
+             (format-reader-pair-inline (cons 'quote (cdr datum)))
+            ) ;
+            ((and (not (stem-mode?)) (single-arg-symbol-form? datum 'quasiquote))
              (string-append "`" (format-reader-datum-inline (cadr datum)))
             ) ;
-            ((single-arg-symbol-form? datum 'unquote)
+            ((and (not (stem-mode?)) (single-arg-symbol-form? datum 'unquote))
              (string-append "," (format-reader-datum-inline (cadr datum)))
             ) ;
-            ((single-arg-symbol-form? datum 'unquote-splicing)
+            ((and (not (stem-mode?)) (single-arg-symbol-form? datum 'unquote-splicing))
              (string-append ",@" (format-reader-datum-inline (cadr datum)))
             ) ;
-            ((quote-syntax-form? datum)
+            ((and (not (stem-mode?)) (quote-syntax-form? datum))
              (string-append "'" (format-reader-datum-inline (cadr datum)))
             ) ;
             ((pair? datum) (format-reader-pair-inline datum))
@@ -667,16 +677,21 @@
             ((dotted-tail? datum) (format-reader-datum-at (dotted-tail-form datum) indent))
             ((raw-string-datum? datum) (cadr datum))
             ((comment-datum? datum) (format-comment-content (cadr datum)))
-            ((single-arg-symbol-form? datum 'quasiquote)
+            ;; ; stem 模式：quote/quasiquote/unquote 保持原样，按普通列表输出；
+            ;; ; (#_quote x) 防御性归一为 (quote x)（正常路径已在 scan 阶段归一）
+            ((and (stem-mode?) (quote-syntax-form? datum))
+             (format-reader-pair-at (cons 'quote (cdr datum)) indent)
+            ) ;
+            ((and (not (stem-mode?)) (single-arg-symbol-form? datum 'quasiquote))
              (string-append "`" (format-reader-datum-at (cadr datum) (+ indent 1)))
             ) ;
-            ((single-arg-symbol-form? datum 'unquote)
+            ((and (not (stem-mode?)) (single-arg-symbol-form? datum 'unquote))
              (string-append "," (format-reader-datum-at (cadr datum) (+ indent 1)))
             ) ;
-            ((single-arg-symbol-form? datum 'unquote-splicing)
+            ((and (not (stem-mode?)) (single-arg-symbol-form? datum 'unquote-splicing))
              (string-append ",@" (format-reader-datum-at (cadr datum) (+ indent 2)))
             ) ;
-            ((quote-syntax-form? datum)
+            ((and (not (stem-mode?)) (quote-syntax-form? datum))
              (string-append "'" (format-reader-datum-at (cadr datum) (+ indent 1)))
             ) ;
             ((pair? datum) (format-reader-pair-at datum indent))

--- a/tools/fmt/liii/goldfmt-scan.scm
+++ b/tools/fmt/liii/goldfmt-scan.scm
@@ -15,7 +15,7 @@
 ;;
 
 (define-library (liii goldfmt-scan)
-  (export scan scan-string scan-file)
+  (export scan scan-string scan-file stem-mode? call-with-stem-mode)
   (import (liii base)
     (liii path)
     (liii raw-string)
@@ -31,6 +31,19 @@
   ) ;import
 
   (begin
+    ;; ; stem 模式开关：TeXmacs .stem 文件中的 quote/quasiquote/unquote 等
+    ;; ; 是普通符号而非 reader 语法，stem handler 通过 call-with-stem-mode
+    ;; ; 动态打开此开关，scan/format 共享，scm 格式不受影响的默认值为 #f。
+    (define %stem-mode? #f)
+
+    (define (stem-mode?)
+      %stem-mode?
+    ) ;define
+
+    (define (call-with-stem-mode thunk)
+      (let-temporarily ((%stem-mode? #t)) (thunk))
+    ) ;define
+
     (define (write-to-string value)
       (let ((port (open-output-string)))
         (let-temporarily (((*s7* 'print-length) 9223372036854775807))
@@ -349,10 +362,19 @@
             ((char-literal-form? datum)
              (make-char-literal :source (cadr datum) :value (caddr datum))
             ) ;
-            ((quote-form? datum) (list (car datum) (normalize-datum (cadr datum))))
+            ;; ; stem 模式：quote 不是 reader 语法，统一改写成符号 quote 引导的
+            ;; ; 普通列表（source 中的 'x 经 reader 变为 (#_quote x)，这里归一为
+            ;; ; (quote x)），使 format 阶段按普通列表原样输出
+            ((quote-form? datum)
+             (if (stem-mode?)
+               (list 'quote (normalize-datum (cadr datum)))
+               (list (car datum) (normalize-datum (cadr datum)))
+             ) ;if
+            ) ;
             ;; ; 显式 (quasiquote T)：reader 不展开，模板中的 (a . ,b) 读出为 (a unquote b)，
             ;; ; 需要模板级走查恢复点对结构
-            ((explicit-quasiquote-form? datum)
+            ;; ; stem 模式下 quasiquote 是普通符号，跳过模板正规化，按普通列表处理
+            ((and (not (stem-mode?)) (explicit-quasiquote-form? datum))
              (list 'quasiquote (normalize-explicit-qq-template (cadr datum)))
             ) ;
             ((internal-list-values-form? datum)
@@ -424,7 +446,8 @@
     (define (scan-list lst depth)
       (let* ((first (car lst)) (rest (cdr lst)))
         ;; ; 处理 quote 形式：整个作为一个 env，没有 children
-        (cond ((quote-form? lst)
+        ;; ; stem 模式下 quote 是普通符号，跳过此特判，按普通列表扫描
+        (cond ((and (not (stem-mode?)) (quote-form? lst))
                (make-env :tag-name
                  (if (syntax? first) "#_quote" (symbol->string first))
                  :depth

--- a/tools/fmt/liii/goldfmt.scm
+++ b/tools/fmt/liii/goldfmt.scm
@@ -57,6 +57,7 @@
     (liii goldtool-changed)
     (liii scheme-fmt)
     (liii cpp-fmt)
+    (liii stem-fmt)
   ) ;import
   (export main
     format-datum
@@ -176,7 +177,7 @@
       (display "      --dry-run    预览模式（不写回文件；目录路径不支持）"
       ) ;display
       (newline)
-      (display "  -e, --extension EXT    按语言名或后缀指定：-e cpp 涵盖 .cpp/.hpp/.h/.c/.cc/.cxx；-e scheme 涵盖 .scm；也可直接写后缀 -e scm,sld"
+      (display "  -e, --extension EXT    按语言名或后缀指定：-e cpp 涵盖 .cpp/.hpp/.h/.c/.cc/.cxx；-e scheme 涵盖 .scm；-e stem 涵盖 .stem；也可直接写后缀 -e scm,sld"
       ) ;display
       (newline)
       (display "      --changed-since REV    仅格式化自 REV 以来变更的文件（按 -e 过滤；未指定 -e 时包含所有语言）"
@@ -190,7 +191,7 @@
       (newline)
       (display "  path    要格式化的文件或目录路径（可选）")
       (newline)
-      (display "          无 path 时：读 gf_fmt.json 仓库批量格式化所有语言（scheme + cpp）"
+      (display "          无 path 时：读 gf_fmt.json 仓库批量格式化所有语言（scheme + cpp + stem）"
       ) ;display
       (newline)
       (newline)

--- a/tools/fmt/liii/stem-fmt.scm
+++ b/tools/fmt/liii/stem-fmt.scm
@@ -1,0 +1,296 @@
+;;
+;; Copyright (C) 2026 The Goldfish Scheme Authors
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+;; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+
+;; TeXmacs stem 语言处理器：(liii stem-fmt)。
+;; .stem 文件是 TeXmacs 宏包的源格式，其中的 quote/quasiquote/unquote/
+;; unquote-splicing 是普通符号而非 Scheme reader 语法，格式化时必须保持原样，
+;; 不能糖化为 ' ` , ,@（TeXmacs 无法识别这些写法，改写会损坏文件）。
+;; 格式化核心复用 (liii goldfmt-scan) / (liii goldfmt-format)，
+;; 通过 call-with-stem-mode 动态打开 stem 模式（结构原样约定：
+;; 源码中的 'x / ,x 统一输出为 (quote x) / (unquote x)）。
+;; 加载时通过 register-lang! 把自己注册进 (liii goldfmt-lang)。
+
+(define-library (liii stem-fmt)
+  (import (liii base)
+    (liii path)
+    (liii string)
+    (liii goldfmt-cache)
+    (liii goldfmt-scan)
+    (liii goldfmt-format)
+    (liii goldfmt-lang)
+    (liii goldfmt-config)
+  ) ;import
+  (export stem-extensions)
+  (begin
+
+    ;; stem 语言接管的后缀表（带点）。gf_fmt.json 未写 stem.suffix 时也用此表。
+    (define stem-extensions '(".stem"))
+
+    ;; scan / format 都必须在 stem 模式下进行，两个包装函数统一入口。
+    (define (stem-scan-file path-str)
+      (call-with-stem-mode (lambda () (scan-file path-str)))
+    ) ;define
+
+    (define (stem-format-nodes nodes)
+      (call-with-stem-mode (lambda () (format-nodes nodes)))
+    ) ;define
+
+    ;; ---- 单文件格式化 ---------------------------------------------------
+    ;; dry-run 模式：输出到终端，不写回。
+    (define (format-file-dry-run path-str)
+      (let ((formatted (stem-format-nodes (stem-scan-file path-str))))
+        (display formatted)
+      ) ;let
+    ) ;define
+
+    ;; 覆盖原文件。返回 'cached / #t(有变更) / #f(无变更)。
+    (define* (format-file path-str (use-cache? #t))
+      (if (and use-cache? (fmt-cache-hit? path-str))
+        'cached
+        (let* ((p (path path-str))
+               (original-content (path-read-text p))
+               (formatted (stem-format-nodes (stem-scan-file path-str)))
+              ) ;
+          (if (string=? original-content formatted)
+            (begin
+              (when use-cache?
+                (fmt-cache-touch path-str)
+              ) ;when
+              #f
+            ) ;begin
+            (begin
+              (path-write-text p formatted)
+              (when use-cache?
+                (fmt-cache-touch path-str)
+              ) ;when
+              #t
+            ) ;begin
+          ) ;if
+        ) ;let*
+      ) ;if
+    ) ;define*
+
+    ;; ---- 文件列表批量格式化 --------------------------------------------
+    ;; 返回 (values total updated cached)。
+    (define (format-file-list files dry-run excludes)
+      (let loop
+        ((remaining files) (total 0) (updated 0) (cached 0))
+        (if (null? remaining)
+          (values total updated cached)
+          (let ((file (car remaining)))
+            (if (file-excluded? file excludes)
+              (loop (cdr remaining) total updated cached)
+              (if dry-run
+                (begin
+                  (display (string-append "Formatting: " file))
+                  (newline)
+                  (format-file-dry-run file)
+                  (loop (cdr remaining) (+ total 1) updated cached)
+                ) ;begin
+                (let ((result (format-file file)))
+                  (cond ((eq? result 'cached) (loop (cdr remaining) (+ total 1) updated (+ cached 1)))
+                        (result (display (string-append "  Updated: " file))
+                          (newline)
+                          (loop (cdr remaining) (+ total 1) (+ updated 1) cached)
+                        ) ;result
+                        (else (display (string-append "Formatting: " file))
+                          (newline)
+                          (loop (cdr remaining) (+ total 1) updated cached)
+                        ) ;else
+                  ) ;cond
+                ) ;let
+              ) ;if
+            ) ;if
+          ) ;let
+        ) ;if
+      ) ;let
+    ) ;define
+
+    (define (file-extension-match? filename extensions)
+      (let loop
+        ((exts extensions))
+        (if (null? exts)
+          #f
+          (if (string-ends? filename (car exts)) #t (loop (cdr exts)))
+        ) ;if
+      ) ;let
+    ) ;define
+
+    ;; ---- 单文件入口（供主入口有路径参数时调用）-------------------------
+    ;; 返回 #t（正常结束）。
+    (define (format-single-file path-str dry-run excludes)
+      (if (file-excluded? path-str excludes)
+        (begin
+          (display (string-append "Skipped (excluded): " path-str))
+          (newline)
+          #t
+        ) ;begin
+        (if dry-run
+          (format-file-dry-run path-str)
+          (let ((result (format-file path-str)))
+            (cond ((eq? result 'cached) #f)
+                  (result (display (string-append "  Updated: " path-str)) (newline))
+                  (else (display (string-append "Formatting: " path-str)) (newline))
+            ) ;cond
+            (display (string-append "Total files formatted: 1, Files updated: "
+                       (if (eq? result #t) "1" "0")
+                       ", Files cached: "
+                       (if (eq? result 'cached) "1" "0")
+                     ) ;string-append
+            ) ;display
+            (newline)
+            #t
+          ) ;let
+        ) ;if
+      ) ;if
+    ) ;define
+
+    ;; ---- 目录递归格式化 ------------------------------------------------
+    ;; 返回 (values total updated cached)。dry-run 不支持目录（保持原约定）。
+    (define (format-directory dir-path extensions excludes dry-run)
+      (if dry-run
+        (begin
+          (display "错误: --dry-run 选项仅支持单个文件")
+          (newline)
+          (exit 1)
+        ) ;begin
+        (let ((entries (path-list-path (path dir-path))))
+          (let loop
+            ((i 0) (total 0) (updated 0) (cached 0))
+            (if (>= i (vector-length entries))
+              (values total updated cached)
+              (let ((entry (vector-ref entries i)))
+                (cond ((path-file? entry)
+                       (let ((entry-str (path->string entry)))
+                         (if (and (file-extension-match? entry-str extensions)
+                               (not (file-excluded? entry-str excludes))
+                             ) ;and
+                           (let ((result (format-file entry-str)))
+                             (cond ((eq? result 'cached) (loop (+ i 1) (+ total 1) updated (+ cached 1)))
+                                   (result (display (string-append "  Updated: " entry-str))
+                                     (newline)
+                                     (loop (+ i 1) (+ total 1) (+ updated 1) cached)
+                                   ) ;result
+                                   (else (display (string-append "Formatting: " entry-str))
+                                     (newline)
+                                     (loop (+ i 1) (+ total 1) updated cached)
+                                   ) ;else
+                             ) ;cond
+                           ) ;let
+                           (loop (+ i 1) total updated cached)
+                         ) ;if
+                       ) ;let
+                      ) ;
+                      ((path-dir? entry)
+                       (let ((dir-str (path->string entry)))
+                         (if (file-excluded? dir-str excludes)
+                           (loop (+ i 1) total updated cached)
+                           (call-with-values (lambda () (format-directory dir-str extensions excludes dry-run))
+                             (lambda (sub-total sub-updated sub-cached)
+                               (loop (+ i 1) (+ total sub-total) (+ updated sub-updated) (+ cached sub-cached))
+                             ) ;lambda
+                           ) ;call-with-values
+                         ) ;if
+                       ) ;let
+                      ) ;
+                      (else (loop (+ i 1) total updated cached))
+                ) ;cond
+              ) ;let
+            ) ;if
+          ) ;let
+        ) ;let
+      ) ;if
+    ) ;define
+
+    ;; ---- handler 协议实现（供仓库批量 / check 使用）---------------------
+    ;; 各方法统一接收 cfg，内部用 goldfmt-config 访问器自取本语言的 path/exclude。
+
+    ;; 仓库批量收集：从 cfg 的 stem.path 递归收集所有 stem 后缀文件
+    ;; （默认 .stem，尊重 gf_fmt.json 的 stem.suffix 与 stem.exclude）。
+    (define (stem-collect cfg)
+      (let ((paths (lang-paths 'stem cfg))
+            (suffixes (lang-suffixes 'stem cfg))
+            (excludes (lang-excludes 'stem cfg))
+           ) ;
+        (let loop
+          ((ps paths) (acc '()))
+          (if (null? ps)
+            acc
+            (if (path-dir? (path (car ps)))
+              (loop (cdr ps) (append (collect-files (car ps) suffixes excludes) acc))
+              (loop (cdr ps) acc)
+            ) ;if
+          ) ;if
+        ) ;let
+      ) ;let
+    ) ;define
+
+    ;; 仓库批量格式化：dry-run 恒为 #f（写回），返回 (total updated cached) 列表。
+    (define (stem-format-files files cfg)
+      (call-with-values (lambda () (format-file-list files #f (lang-excludes 'stem cfg)))
+        (lambda (total updated cached) (list total updated cached))
+      ) ;call-with-values
+    ) ;define
+
+    ;; 单文件 check：scan + format-nodes 与磁盘逐字节比；命中 exclude 视为通过（#t）。
+    (define (stem-check-file path-str cfg)
+      (let ((excludes (lang-excludes 'stem cfg)))
+        (if (file-excluded? path-str excludes)
+          #t
+          (let ((ondisk (path-read-text (path path-str))))
+            (string=? ondisk (stem-format-nodes (stem-scan-file path-str)))
+          ) ;let
+        ) ;if
+      ) ;let
+    ) ;define
+
+    ;; 目录格式化（协议适配）：若传入 cfg，以 gf_fmt.json 为准收集并格式化；
+    ;; 否则递归格式化指定 dir。dry-run 不支持目录。返回 (total updated cached) 列表。
+    (define (stem-format-directory dir extensions excludes dry-run . maybe-cfg)
+      (if dry-run
+        (begin
+          (display "错误: --dry-run 选项仅支持单个文件")
+          (newline)
+          (exit 1)
+        ) ;begin
+        (let ((cfg (if (null? maybe-cfg) #f (car maybe-cfg))))
+          (if cfg
+            (stem-format-files (stem-collect cfg) cfg)
+            (call-with-values (lambda () (format-directory dir extensions excludes dry-run))
+              (lambda (total updated cached) (list total updated cached))
+            ) ;call-with-values
+          ) ;if
+        ) ;let
+      ) ;if
+    ) ;define
+
+    ;; 注册到语言注册表。
+    (define stem-handler
+      (list (cons 'name 'stem)
+        (cons 'label "TeXmacs Stem")
+        (cons 'extensions stem-extensions)
+        (cons 'collect stem-collect)
+        (cons 'format-files stem-format-files)
+        (cons 'format-file format-single-file)
+        (cons 'format-directory stem-format-directory)
+        (cons 'check-file stem-check-file)
+      ) ;list
+    ) ;define
+
+    (register-lang! stem-handler)
+
+  ) ;begin
+) ;define-library

--- a/tools/fmt/tests/liii/goldfmt-format/stem-mode-test.scm
+++ b/tools/fmt/tests/liii/goldfmt-format/stem-mode-test.scm
@@ -1,0 +1,72 @@
+(import (liii check) (liii goldfmt-scan) (liii goldfmt-format))
+
+(check-set-mode! 'report-failed)
+
+;; stem 模式：TeXmacs .stem 文件中的 quote/quasiquote/unquote/unquote-splicing
+;; 是普通的过程/语法符号，不是 Scheme reader 语法，格式化时必须保持原样，
+;; 不能糖化为 ' ` , ,@（TeXmacs 无法识别这些写法，改写会损坏文件）。
+;;
+;; 约定（方案A：结构原样）：源码中的 'x / ,x 字面形式在 stem 模式下
+;; 统一输出为 (quote x) / (unquote x) 结构形式。
+
+(define (format-string-stem source)
+  (call-with-stem-mode (lambda () (format-string source)))
+) ;define
+
+;; (quote x) 保持原样，不转换为 'x
+(check (format-string-stem "(quote x)") => "(quote x)\n")
+(check (format-string-stem "(quote (a b))") => "(quote (a b))\n")
+
+;; (unquote x) 保持原样，不转换为 ,x
+(check (format-string-stem "(unquote x)") => "(unquote x)\n")
+(check (format-string-stem "(unquote (arg \"env\"))")
+  =>
+  "(unquote (arg \"env\"))\n"
+) ;check
+
+;; (unquote-splicing x) 保持原样，不转换为 ,@x
+(check (format-string-stem "(unquote-splicing x)") => "(unquote-splicing x)\n")
+
+;; (quasiquote x) 保持原样，不转换为 `x
+(check (format-string-stem "(quasiquote (a b))") => "(quasiquote (a b))\n")
+
+;; 显式 quasiquote 模板中的 unquote 符号保持原样
+;; scm 模式下 (quasiquote (a unquote b)) 会被正规化为 `(a . ,b)，
+;; stem 模式下整个形式按普通列表处理，模板符号原样保留
+(check (format-string-stem "(quasiquote (a unquote b))")
+  =>
+  "(quasiquote (a unquote b))\n"
+) ;check
+
+;; env-base.stem 真实场景：quasi + 嵌套 unquote（超长行触发换行布局）
+(check (format-string-stem "(quasi (concat (add-to-counter-group (unquote (arg \"env\")) (unquote (arg \"grp\")))))"
+       ) ;format-string-stem
+  =>
+  "(quasi (concat (add-to-counter-group (unquote (arg \"env\")) (unquote (arg \"grp\"))))\n) ;quasi\n"
+) ;check
+
+;; 嵌套列表中的 quote/unquote 保持原样
+(check (format-string-stem "(assign \"x\" (macro (unquote (arg \"env\"))))")
+  =>
+  "(assign \"x\" (macro (unquote (arg \"env\"))))\n"
+) ;check
+
+;; 结构原样：源码中的 'x 统一输出为 (quote x)
+(check (format-string-stem "'x") => "(quote x)\n")
+(check (format-string-stem "'(a b)") => "(quote (a b))\n")
+(check (format-string-stem "''(a b)") => "(quote (quote (a b)))\n")
+
+;; 结构原样：源码中的 `x 统一输出为 (quasiquote x)
+(check (format-string-stem "`(a ,b)") => "(quasiquote (a (unquote b)))\n")
+
+;; 幂等：格式化输出再次格式化结果不变
+(check (format-string-stem (format-string-stem "(quasi (unquote x))"))
+  =>
+  "(quasi (unquote x))\n"
+) ;check
+
+;; scm 模式不受影响：quote/unquote 仍然糖化（回归保证）
+(check (format-string "(quote x)") => "'x\n")
+(check (format-string "(quasiquote (a ,b))") => "`(a ,b)\n")
+
+(check-report)

--- a/tools/fmt/tests/liii/stem-fmt-test.scm
+++ b/tools/fmt/tests/liii/stem-fmt-test.scm
@@ -1,0 +1,54 @@
+(import (liii check)
+  (liii os)
+  (liii goldfmt-lang)
+  (liii goldfmt-scan)
+  (liii goldfmt-format)
+  (liii stem-fmt)
+  (srfi srfi-13)
+) ;import
+
+(check-set-mode! 'report-failed)
+
+(define (resource-file filename)
+  (let ((local-path (string-append "tests/resources/" filename))
+        (abs-path (string-append "tools/fmt/tests/resources/" filename)))
+    (if (access local-path 'R_OK)
+        local-path
+        abs-path)
+  ) ;let
+) ;define
+
+;; .stem 后缀派发：注册表能按后缀找到 stem handler
+(check (lang-name (lang-for-extension ".stem")) => 'stem)
+(check (lang-extensions (lang-for-extension ".stem")) => '(".stem"))
+
+;; 按语言名查询后缀（gf fmt -e stem 走此路径）
+(check (extensions-for-lang-name "stem") => '(".stem"))
+
+;; 真实 .stem 文件：stem 模式下格式化后 quote/unquote 保持原样
+(define stem-text
+  (call-with-stem-mode (lambda ()
+                         (format-nodes (scan-file (resource-file "0111_01.stem")))
+                       ) ;lambda
+  ) ;call-with-stem-mode
+) ;define
+
+(check-true (string-contains stem-text "(unquote (arg \"env\"))"))
+(check-true (string-contains stem-text "(unquote (merge (arg \"env\") \"-text\"))"))
+(check-true (string-contains stem-text "(quote (a b))"))
+
+;; 不能被糖化为 , 或 '
+(check-false (string-contains stem-text ",(arg"))
+(check-false (string-contains stem-text "'(a b)"))
+
+;; 幂等：格式化结果再次格式化不变
+(check (call-with-stem-mode (lambda () (format-string stem-text))) => stem-text)
+
+;; 同一文件在 scm 模式（默认）下会被糖化，证明派发模式确实生效
+(define scm-text
+  (format-nodes (scan-file (resource-file "0111_01.stem")))
+) ;define
+(check-true (string-contains scm-text ",(arg \"env\")"))
+(check-true (string-contains scm-text "'(a b)"))
+
+(check-report)

--- a/tools/fmt/tests/resources/0111_01.stem
+++ b/tools/fmt/tests/resources/0111_01.stem
@@ -1,0 +1,1 @@
+(document (TeXmacs "2.1.4") (style (tuple "source")) (body (document (assign "new-env" (macro "env" "name" "grp" (quasi (concat (add-to-counter-group (unquote (arg "env")) (unquote (arg "grp"))) (assign (unquote (merge (arg "env") "-text")) (macro (localize (unquote (arg "name"))))))))) (quote (a b)))))


### PR DESCRIPTION
## 背景

`.stem` 文件（TeXmacs 宏包源格式，如 mogan 的 `TeXmacs/packages/environment/env-base.stem`）中的 quote/quasiquote/unquote 是 TeXmacs 的普通符号，不是 Scheme reader 语法。此前 `gf fmt` 对未知后缀兜底走 scheme handler，会把 `(unquote (arg "env"))` 改写成 `,(arg "env")`，TeXmacs 无法识别，文件被损坏。

## 改动

- 新增 `(liii stem-fmt)` 语言 handler，注册 `.stem` 后缀，复用 scan/format/缓存/配置机制
- scan/format 引入 stem 模式动态开关（`call-with-stem-mode` / `stem-mode?`）：stem 模式下 `(quote x)`、`(quasiquote x)`、`(unquote x)`、`(unquote-splicing x)` 一律按普通列表输出，不糖化为 `'` ``` ` `,` `,@`
- 结构原样约定：stem 源码中的 `'x` / ``` `x` ` 字面形式统一输出为 `(quote x)` / `(quasiquote x)`
- scm 格式行为完全不变

## 测试

- 新增 `stem-mode-test.scm`（16 用例）与 `stem-fmt-test.scm`（11 用例，含真实 .stem 资源文件与 scm 模式对照）
- `tools/fmt/tests` 全部测试通过（含既有 quote-test.scm 回归）
- `bin/gf fmt --check` 仓库级检查：Scheme / C++ / TeXmacs Stem 全部 OK
- 真实文件 `env-base.stem` dry-run 验证：76 处 `(unquote ...)` 全部保持原样，0 处糖化

详见 `devel/0111.md`。