### PR TITLE
[0112] 用 C 语言实现符合 R7RS 标准的 define-library 和 import

### DIFF
--- a/bench/import-perf.scm
+++ b/bench/import-perf.scm
@@ -1,0 +1,91 @@
+;;
+;; Copyright (C) 2026 The Goldfish Scheme Authors
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+;; License for the specific language governing permissions and limitations
+;; under the License.
+;;
+
+;; import 性能基准测试（热路径：库已加载后的重复导入）
+;; 覆盖：无修饰符导入、only/except/prefix/rename 修饰符、嵌套修饰符、多库导入
+;; 冷加载（首次 load 库文件）的分层归因见 list-import-perf.scm
+;;
+;; 注：嵌套修饰符用例需要 [0112] 的 C 版 import；旧 Scheme 实现会直接报错
+;; （r7rs-import-library-filename 无法解析嵌套 import set）。
+;; 参考对比（10000 次，单次耗时）：旧 Scheme 版 → 新 C 版
+;;   无修饰符   2.48μs → 1.46μs（1.7x）
+;;   only 取5   1.97μs → 0.54μs（3.6x）
+;;   except     4.59μs → 4.35μs（基本持平）
+;;   prefix    10.96μs → 5.00μs（2.2x）
+;;   rename     6.03μs → 4.24μs（1.4x）
+
+(import (liii timeit) (liii list) (liii string) (scheme base))
+
+(define (bench name stmt number)
+  (let ((elapsed (timeit stmt '() number)))
+    (display name)
+    (display ": ")
+    (display elapsed)
+    (display " 秒 (")
+    (display number)
+    (display " 次)\n")
+  ) ;let
+) ;define
+
+(define (run-benchmarks)
+  (display "=== import 性能测试（热路径，库已加载） ===\n\n")
+
+  (bench "无修饰符 (import (liii list))          "
+    (lambda () (import (liii list)))
+    10000
+  ) ;bench
+
+  (bench "only 取5个名字                          "
+    (lambda () (import (only (liii list) first second third fourth fifth)))
+    10000
+  ) ;bench
+
+  (bench "except 排除5个名字                      "
+    (lambda () (import (except (liii list) first second third fourth fifth)))
+    10000
+  ) ;bench
+
+  (bench "prefix 加前缀                           "
+    (lambda () (import (prefix (liii list) list:)))
+    10000
+  ) ;bench
+
+  (bench "rename 重命名2个名字                    "
+    (lambda ()
+      (import (rename (liii list) (first list-first) (second list-second)))
+    ) ;lambda
+    10000
+  ) ;bench
+
+  (bench "嵌套 only(except(...))                  "
+    (lambda () (import (only (except (liii list) first) second third)))
+    10000
+  ) ;bench
+
+  (bench "嵌套 prefix(only(...))                  "
+    (lambda () (import (prefix (only (liii list) first second) list:)))
+    10000
+  ) ;bench
+
+  (bench "多库 (import (liii list) (liii string)) "
+    (lambda () (import (liii list) (liii string)))
+    10000
+  ) ;bench
+
+  (display "\n=== 测试完成 ===\n")
+) ;define
+
+(run-benchmarks)

--- a/devel/0112.md
+++ b/devel/0112.md
@@ -14,6 +14,22 @@ xmake b goldfish
 bin/gf tests/scheme/boot-test.scm
 ```
 
+## 2026-08-14 0112_4 + 0112_5：cond-expand 与 include 系列声明
+
+### What
+1. define-library 支持 `cond-expand` 声明：特性标识符、`(library ...)` 条件、and/or/not 组合、else、嵌套
+2. define-library 支持 `include` / `include-ci` / `include-library-declarations` 声明
+3. C 版 `cond-expand`（g_cond_expand_r7rs）替换 s7 内置的读时 expansion——原版不支持 `(library ...)` 条件，且子句多形式时会展开成 apply-values 垃圾
+4. 全量测试 1493/1493 通过；boot-test.scm 69 项通过
+
+### How
+- g_define_library 重构为三趟 walker（EVAL/VALIDATE/POPULATE），cond-expand 与 include-library-declarations 在 walker 中递归展开
+- 遮蔽 s7 内置 cond-expand：新版注册为普通 c-macro（无 T_EXPANSION 位），读时钩子查到的绑定不是 expansion 便不再展开，cond-expand 形式原样到达求值器/define-library
+- (library name) 条件：查注册表，或按库名映射路径在 *load-path* 各目录中查文件存在性（不 load，无副作用）
+- include 路径解析顺序：当前正在加载文件所在目录 → *load-path* 各目录 → 原名（cwd 相对）
+- include 经 s7_open_input_string + s7_read 逐形式读取；字符串端口引用 C 缓冲区（不拷贝），读取循环期间端口受 GC 保护、结束后才释放缓冲区
+- include-ci 暂与 include 等价（s7 reader 无大小写折叠模式）
+
 ## 2026-08-14 0112_3：C 版 import
 
 ### What

--- a/devel/0112.md
+++ b/devel/0112.md
@@ -48,6 +48,18 @@ bin/gf tests/scheme/boot-test.scm
 - 单进程加载全部 102 个库文件：60ms → 47ms（约 22% 提升）
 - 进程级启动时间不变（13ms）
 - 中途发现并修复一个回归：C define-library 曾把 rootlet 再导出名字（eqv? 等约 400 个）物化进导出环境，导致每次 import 多拷贝数百槽位，全库加载从 1159ms 退化到 1249ms；恢复"只物化库体自有绑定"后回到 1116ms
+- import 热路径基准（bench/import-perf.scm，10000 次重复导入取单次耗时，旧 Scheme 版 → 新 C 版）：
+
+| 场景 | 旧 Scheme 版 | 新 C 版 | 变化 |
+|---|---|---|---|
+| 无修饰符 `(import (liii list))` | 2.48μs | 1.46μs | 1.7x |
+| only 取 5 个名字 | 1.97μs | 0.54μs | 3.6x |
+| except 排除 5 个名字 | 4.59μs | 4.35μs | 持平 |
+| prefix 加前缀 | 10.96μs | 5.00μs | 2.2x |
+| rename 重命名 2 个 | 6.03μs | 4.24μs | 1.4x |
+| 嵌套 only(except(...)) | 报错不支持 | 2.16μs | 新能力 |
+| 嵌套 prefix(only(...)) | 报错不支持 | 0.53μs | 新能力 |
+| 多库导入（两个库） | — | 2.73μs | — |
 
 ## 2026-08-14 0112_2：C 版 define-library
 

--- a/devel/0112.md
+++ b/devel/0112.md
@@ -1,0 +1,49 @@
+# [0112] 用 C 语言实现符合 R7RS 标准的 define-library 和 import
+
+## 任务相关的代码文件
+- src/s7_r7rs_library.c（新增）
+- src/s7_r7rs_library.h（新增）
+- src/goldfish.hpp（glue_for_community_edition 中注册）
+- goldfish/scheme/boot.scm（Scheme 版实现保留为后备）
+- tests/scheme/boot-test.scm（测试）
+- xmake.lua（新增源文件）
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf tests/scheme/boot-test.scm
+```
+
+## 2026-08-14 0112_1：C 侧库注册表基础设施
+
+### What
+1. 新增 src/s7_r7rs_library.c/h：`*r7rs-libraries*` 注册表 + `g_library-register!`/`g_library-defined?`/`g_library-ref`/`g_library-unregister!` 四个 C 函数
+2. `glue_r7rs_library` 挂载到 goldfish.hpp 的 `glue_for_community_edition`
+3. tests/scheme/boot-test.scm 新增注册表测试（24 项全部通过）
+
+### How
+- 注册表为 rootlet 变量 `*r7rs-libraries*` 中的 s7 hash table（equal? 键），key 为库名列表，value 为 let 环境，GC 可达
+- s7 hash table 无删除 API，unregister 通过存入 #f 实现；defined?/ref 只接受 let 值
+- 库名校验：先排除非 pair/非 null（字符串等），再用 s7_list_length 排除 improper/circular list，元素必须是 symbol 或非负整数
+
+## 2026-08-14 任务规划
+
+### What
+将 boot.scm 中基于 define-macro 的 define-library/import 迁移到 C 实现。
+
+子任务拆分（每个子任务一个 PR）：
+1. 0112_1：C 侧库注册表基础设施（`*r7rs-libraries*` hash table + g_library-register!/defined?/ref/unregister!）
+2. 0112_2：C 版 define-library（export/import/begin 声明）
+3. 0112_3：C 版 import（only/except/prefix/rename，支持嵌套）
+
+后续视情况再做：cond-expand、include/include-ci、export rename 语法。
+
+### Why
+- 现有 Scheme 实现每次 import 都要宏展开 + object->string 拼接 + 全局符号查找，启动开销可观
+- 现有实现不支持嵌套 import set 修饰符等 R7RS 特性
+
+### How
+- 新增独立 C 文件，不修改 s7.c
+- 用 s7_define_macro 注册 define-library/import 语法形式
+- 库注册表为 rootlet 中的 hash table，key 为库名列表，value 为 let 环境
+- boot.scm 的 Scheme 版用 (unless (defined? ...) ...) 包裹，作为后备

--- a/devel/0112.md
+++ b/devel/0112.md
@@ -14,6 +14,25 @@ xmake b goldfish
 bin/gf tests/scheme/boot-test.scm
 ```
 
+## 2026-08-14 0112_3：C 版 import
+
+### What
+1. src/s7_r7rs_library.c 新增 `g_import`，用 `s7_define_macro` 注册 `import`
+2. 支持 only/except/prefix/rename 四种修饰符，且**支持任意嵌套**（旧 Scheme 实现不支持嵌套，会直接报错或重复 load）
+3. 库首次引用时按库名映射路径（(liii base) → liii/base.scm，整数组件支持 (srfi 1) → srfi/1.scm）经 `*load-path*` 搜索 load；注册表保证每个库只 load 一次（嵌套修饰符不再绕过缓存）
+4. boot.scm 的 Scheme 版 import 改为 `(unless (defined? 'import) ...)` 后备
+5. 全量测试 1493/1493 通过；boot-test.scm 51 项通过
+
+### How
+- s7 应用 c-macro 时不改变 sc->curlet（apply_c_macro 直接调用，无 set_curlet），因此宏函数内 `s7_curlet(sc)` 就是 import 形式所在的词法环境，直接 `s7_varlet` 进去，返回 #t 作为展开式
+- 曾尝试返回 `(varlet (curlet) merged)` 展开式，但 varlet 复制 let 槽位时顺序反转（append_let 前插），会导致多 import set 同名绑定的覆盖优先级与旧实现相反（(liii path) 依赖 (liii os) 的 remove 覆盖 (liii base) 的 srfi-1 remove），故放弃该方案
+- 修饰符（only/except/prefix/rename）递归求值 import set 得到环境，再在 C 中构建新 inlet 做筛选/改名
+
+### 性能
+- 单进程加载全部 102 个库文件：60ms → 47ms（约 22% 提升）
+- 进程级启动时间不变（13ms）
+- 中途发现并修复一个回归：C define-library 曾把 rootlet 再导出名字（eqv? 等约 400 个）物化进导出环境，导致每次 import 多拷贝数百槽位，全库加载从 1159ms 退化到 1249ms；恢复"只物化库体自有绑定"后回到 1116ms
+
 ## 2026-08-14 0112_2：C 版 define-library
 
 ### What

--- a/devel/0112.md
+++ b/devel/0112.md
@@ -14,6 +14,25 @@ xmake b goldfish
 bin/gf tests/scheme/boot-test.scm
 ```
 
+## 2026-08-14 0112_2：C 版 define-library
+
+### What
+1. src/s7_r7rs_library.c 新增 `g_define_library`，用 `s7_define_macro` 注册 `define-library`
+2. boot.scm 的 Scheme 版 define-library 改为 `(unless (defined? 'define-library) ...)` 后备
+3. 支持 export（含 `(rename old new)`）、import、begin 声明；无 export 子句时导出全部绑定
+4. 清理幽灵导出（导出但未实现的名字，旧实现静默丢弃，C 版会报 unbound-variable）：
+   - scheme/base.scm：移除 open-binary-input-file、open-binary-output-file（R7RS 中属于 (scheme file)）
+   - srfi-125.scm + liii/hash-table.scm：移除 hash-table-unfold、hash-table-mutable?、hash-table-intern!、hash-table-pop!
+   - srfi-224.scm + liii/fxmapping.scm：移除 fxmapping-accumulate、fxmapping-update、fxmapping-alter、fxmapping-update-min、fxmapping-update-max、fxmapping->generator、fxmapping->decreasing-generator、fxmapping-relation-map
+   - guenchi/json.scm：移除 json-string-unescape
+5. 全量测试 1493/1493 通过
+
+### How
+- 工作环境为 rootlet 的 sublet；pass 1 用 s7_eval 在库环境中求值 import/begin 等声明；pass 2 校验导出名字（允许穿透到 rootlet，如 (scheme base) 再导出 eqv?）；pass 3 用 s7_varlet 填充导出环境
+- 兼容旧 Scheme 版 import：同时在 rootlet 定义 "(liii base)" 形式的全局符号
+- s7 禁止语法符号（define* 等）作为 let 槽位：穿透导出的 rootlet 语法绑定静默跳过，与旧实现一致
+- 导出未定义的名字报 unbound-variable 错误（R7RS 要求）
+
 ## 2026-08-14 0112_1：C 侧库注册表基础设施
 
 ### What

--- a/goldfish/guenchi/json.scm
+++ b/goldfish/guenchi/json.scm
@@ -27,9 +27,9 @@
     (liii string)
     (liii unicode)
   ) ;import
-  (export json-string-escape string->json json->string
-    json-ref json-ref* json-set json-set* json-push json-push* json-drop
-    json-drop* json-reduce json-reduce*
+  (export json-string-escape string->json json->string json-ref json-ref*
+    json-set json-set* json-push json-push* json-drop json-drop* json-reduce
+    json-reduce*
   ) ;export
   (begin
 

--- a/goldfish/guenchi/json.scm
+++ b/goldfish/guenchi/json.scm
@@ -27,7 +27,7 @@
     (liii string)
     (liii unicode)
   ) ;import
-  (export json-string-escape json-string-unescape string->json json->string
+  (export json-string-escape string->json json->string
     json-ref json-ref* json-set json-set* json-push json-push* json-drop
     json-drop* json-reduce json-reduce*
   ) ;export

--- a/goldfish/liii/fxmapping.scm
+++ b/goldfish/liii/fxmapping.scm
@@ -4,7 +4,6 @@
     ;; Constructors
     fxmapping
     fxmapping-unfold
-    fxmapping-accumulate
     alist->fxmapping
     alist->fxmapping/combinator
     ;; Predicates
@@ -23,13 +22,9 @@
     fxmapping-adjust
     fxmapping-delete
     fxmapping-delete-all
-    fxmapping-update
-    fxmapping-alter
     fxmapping-delete-min
-    fxmapping-update-min
     fxmapping-pop-min
     fxmapping-delete-max
-    fxmapping-update-max
     fxmapping-pop-max
     ;; Whole fxmapping
     fxmapping-size
@@ -51,8 +46,6 @@
     fxmapping->decreasing-alist
     fxmapping-keys
     fxmapping-values
-    fxmapping->generator
-    fxmapping->decreasing-generator
     ;; Comparison
     fxmapping=?
     fxmapping<?
@@ -78,6 +71,5 @@
     fxsubmapping>=
     fxmapping-split
     ;; Relations
-    fxmapping-relation-map
   ) ;export
 ) ;define-library

--- a/goldfish/liii/hash-table.scm
+++ b/goldfish/liii/hash-table.scm
@@ -1,13 +1,12 @@
 (define-library (liii hash-table)
   (import (srfi srfi-125) (srfi srfi-128))
-  (export make-hash-table hash-table alist->hash-table
-    hash-table? hash-table-contains? hash-table-empty? hash-table=?
-    hash-table-ref hash-table-ref/default hash-table-set!
-    hash-table-delete! hash-table-update!
-    hash-table-update!/default hash-table-clear! hash-table-size
-    hash-table-keys hash-table-values hash-table-entries hash-table-find
-    hash-table-count hash-table-fold hash-table-for-each hash-table-map->list
-    hash-table->alist hash-table-copy
+  (export make-hash-table hash-table alist->hash-table hash-table?
+    hash-table-contains? hash-table-empty? hash-table=? hash-table-ref
+    hash-table-ref/default hash-table-set! hash-table-delete! hash-table-update!
+    hash-table-update!/default hash-table-clear! hash-table-size hash-table-keys
+    hash-table-values hash-table-entries hash-table-find hash-table-count
+    hash-table-fold hash-table-for-each hash-table-map->list hash-table->alist
+    hash-table-copy
   ) ;export
   (begin
   ) ;begin

--- a/goldfish/liii/hash-table.scm
+++ b/goldfish/liii/hash-table.scm
@@ -1,10 +1,10 @@
 (define-library (liii hash-table)
   (import (srfi srfi-125) (srfi srfi-128))
-  (export make-hash-table hash-table hash-table-unfold alist->hash-table
+  (export make-hash-table hash-table alist->hash-table
     hash-table? hash-table-contains? hash-table-empty? hash-table=?
-    hash-table-mutable? hash-table-ref hash-table-ref/default hash-table-set!
-    hash-table-delete! hash-table-intern! hash-table-update!
-    hash-table-update!/default hash-table-pop! hash-table-clear! hash-table-size
+    hash-table-ref hash-table-ref/default hash-table-set!
+    hash-table-delete! hash-table-update!
+    hash-table-update!/default hash-table-clear! hash-table-size
     hash-table-keys hash-table-values hash-table-entries hash-table-find
     hash-table-count hash-table-fold hash-table-for-each hash-table-map->list
     hash-table->alist hash-table-copy

--- a/goldfish/scheme/base.scm
+++ b/goldfish/scheme/base.scm
@@ -183,8 +183,6 @@
     current-error-port
     open-input-file
     open-output-file
-    open-binary-input-file
-    open-binary-output-file
     close-port
     close-input-port
     close-output-port

--- a/goldfish/scheme/boot.scm
+++ b/goldfish/scheme/boot.scm
@@ -73,56 +73,59 @@
   ) ;define
 ) ;unless
 
-(define-macro (import . libs)
-  `(begin
-     (r7rs-import-library-filename (quote ,libs))
-     (varlet (curlet)
-       ,@(map (lambda (lib)
-                (case (car lib)
-                      ((only)
-                       `((lambda (e names)
-                           (apply inlet
-                             (map (lambda (name) (cons name (e name))) names)))
-                         (symbol->value (symbol (object->string (cadr (quote
-                                                                        ,lib)))))
-                         (cddr (quote ,lib))))
-                      ((except)
-                       `((lambda (e names)
-                           (apply inlet
-                             (map (lambda (entry)
-                                    (if (member (car entry) names)
-                                      (values)
-                                      entry))
-                               e)))
-                         (symbol->value (symbol (object->string (cadr (quote
-                                                                        ,lib)))))
-                         (cddr (quote ,lib))))
-                      ((prefix)
-                       `((lambda (e prefx)
-                           (apply inlet
-                             (map (lambda (entry)
-                                    (cons (string->symbol (string-append (symbol->string prefx)
-                                                            (symbol->string (car entry))))
-                                      (cdr entry)))
-                               e)))
-                         (symbol->value (symbol (object->string (cadr (quote
-                                                                        ,lib)))))
-                         (caddr (quote ,lib))))
-                      ((rename)
-                       `((lambda (e names)
-                           (apply inlet
-                             (map (lambda (entry)
-                                    (let ((info (assoc (car entry) names)))
-                                      (if info
-                                        (cons (cadr info) (cdr entry))
-                                        entry)))
-                               e)))
-                         (symbol->value (symbol (object->string (cadr (quote
-                                                                        ,lib)))))
-                         (cddr (quote ,lib))))
-                      (else `(let ((sym (symbol (object->string (quote ,lib)))))
-                               (if (not (defined? sym))
-                                 (format () "~A not loaded~%" sym)
-                                 (symbol->value sym))))))
-           libs)))
-) ;define-macro
+;; C 实现的 import（src/s7_r7rs_library.c）已注册时，此后备版本不生效
+(unless (defined? 'import)
+  (define-macro (import . libs)
+    `(begin
+       (r7rs-import-library-filename (quote ,libs))
+       (varlet (curlet)
+         ,@(map (lambda (lib)
+                  (case (car lib)
+                        ((only)
+                         `((lambda (e names)
+                             (apply inlet
+                               (map (lambda (name) (cons name (e name))) names)))
+                           (symbol->value (symbol (object->string (cadr (quote
+                                                                          ,lib)))))
+                           (cddr (quote ,lib))))
+                        ((except)
+                         `((lambda (e names)
+                             (apply inlet
+                               (map (lambda (entry)
+                                      (if (member (car entry) names)
+                                        (values)
+                                        entry))
+                                 e)))
+                           (symbol->value (symbol (object->string (cadr (quote
+                                                                          ,lib)))))
+                           (cddr (quote ,lib))))
+                        ((prefix)
+                         `((lambda (e prefx)
+                             (apply inlet
+                               (map (lambda (entry)
+                                      (cons (string->symbol (string-append (symbol->string prefx)
+                                                              (symbol->string (car entry))))
+                                        (cdr entry)))
+                                 e)))
+                           (symbol->value (symbol (object->string (cadr (quote
+                                                                          ,lib)))))
+                           (caddr (quote ,lib))))
+                        ((rename)
+                         `((lambda (e names)
+                             (apply inlet
+                               (map (lambda (entry)
+                                      (let ((info (assoc (car entry) names)))
+                                        (if info
+                                          (cons (cadr info) (cdr entry))
+                                          entry)))
+                                 e)))
+                           (symbol->value (symbol (object->string (cadr (quote
+                                                                          ,lib)))))
+                           (cddr (quote ,lib))))
+                        (else `(let ((sym (symbol (object->string (quote ,lib)))))
+                                 (if (not (defined? sym))
+                                   (format () "~A not loaded~%" sym)
+                                   (symbol->value sym))))))
+             libs)))
+  ) ;define-macro
+) ;unless

--- a/goldfish/scheme/boot.scm
+++ b/goldfish/scheme/boot.scm
@@ -25,23 +25,27 @@
   ) ;if
 ) ;define
 
-(define-macro (define-library libname . body)
-  `(define ,(symbol (object->string libname))
-     (with-let (sublet (unlet)
-                 (cons 'import import)
-                 (cons '*export* ())
-                 (cons 'export
-                   (define-macro (,(gensym) . names)
-                     `(set! *export* (append (quote ,names) *export*)))))
-       ,@body
-       (apply inlet
-         (map (lambda (entry)
-                (if (or (member (car entry) '(*export* export import))
-                      (and (pair? *export*) (not (member (car entry) *export*))))
-                  (values)
-                  entry))
-           (curlet)))))
-) ;define-macro
+;; C 实现的 define-library（src/s7_r7rs_library.c）已注册时，此后备版本不生效
+(unless (defined? 'define-library)
+  (define-macro (define-library libname . body)
+    `(define ,(symbol (object->string libname))
+       (with-let (sublet (unlet)
+                   (cons 'import import)
+                   (cons '*export* ())
+                   (cons 'export
+                     (define-macro (,(gensym) . names)
+                       `(set! *export* (append (quote ,names) *export*)))))
+         ,@body
+         (apply inlet
+           (map (lambda (entry)
+                  (if (or (member (car entry) '(*export* export import))
+                        (and (pair? *export*)
+                          (not (member (car entry) *export*))))
+                    (values)
+                    entry))
+             (curlet)))))
+  ) ;define-macro
+) ;unless
 
 (unless (defined? 'r7rs-import-library-filename)
   (define (r7rs-import-library-filename libs)

--- a/goldfish/srfi/srfi-125.scm
+++ b/goldfish/srfi/srfi-125.scm
@@ -16,14 +16,13 @@
 
 (define-library (srfi srfi-125)
   (import (srfi srfi-1) (srfi srfi-128) (liii base) (liii error))
-  (export make-hash-table hash-table alist->hash-table
-    hash-table? hash-table-contains? hash-table-empty? hash-table=?
-    hash-table-ref hash-table-ref/default hash-table-set!
-    hash-table-delete! hash-table-update!
-    hash-table-update!/default hash-table-clear! hash-table-size
-    hash-table-keys hash-table-values hash-table-entries hash-table-find
-    hash-table-count hash-table-fold hash-table-for-each hash-table-map->list
-    hash-table->alist hash-table-copy
+  (export make-hash-table hash-table alist->hash-table hash-table?
+    hash-table-contains? hash-table-empty? hash-table=? hash-table-ref
+    hash-table-ref/default hash-table-set! hash-table-delete! hash-table-update!
+    hash-table-update!/default hash-table-clear! hash-table-size hash-table-keys
+    hash-table-values hash-table-entries hash-table-find hash-table-count
+    hash-table-fold hash-table-for-each hash-table-map->list hash-table->alist
+    hash-table-copy
   ) ;export
   (begin
 

--- a/goldfish/srfi/srfi-125.scm
+++ b/goldfish/srfi/srfi-125.scm
@@ -16,11 +16,11 @@
 
 (define-library (srfi srfi-125)
   (import (srfi srfi-1) (srfi srfi-128) (liii base) (liii error))
-  (export make-hash-table hash-table hash-table-unfold alist->hash-table
+  (export make-hash-table hash-table alist->hash-table
     hash-table? hash-table-contains? hash-table-empty? hash-table=?
-    hash-table-mutable? hash-table-ref hash-table-ref/default hash-table-set!
-    hash-table-delete! hash-table-intern! hash-table-update!
-    hash-table-update!/default hash-table-pop! hash-table-clear! hash-table-size
+    hash-table-ref hash-table-ref/default hash-table-set!
+    hash-table-delete! hash-table-update!
+    hash-table-update!/default hash-table-clear! hash-table-size
     hash-table-keys hash-table-values hash-table-entries hash-table-find
     hash-table-count hash-table-fold hash-table-for-each hash-table-map->list
     hash-table->alist hash-table-copy

--- a/goldfish/srfi/srfi-224.scm
+++ b/goldfish/srfi/srfi-224.scm
@@ -42,7 +42,6 @@
     alist->fxmapping
     alist->fxmapping/combinator
     fxmapping-unfold
-    fxmapping-accumulate
     ;; Predicates
     fxmapping?
     fxmapping-contains?
@@ -59,13 +58,9 @@
     fxmapping-adjust
     fxmapping-delete
     fxmapping-delete-all
-    fxmapping-update
-    fxmapping-alter
     fxmapping-delete-min
-    fxmapping-update-min
     fxmapping-pop-min
     fxmapping-delete-max
-    fxmapping-update-max
     fxmapping-pop-max
     ;; The whole fxmapping
     fxmapping-size

--- a/src/goldfish.hpp
+++ b/src/goldfish.hpp
@@ -15,6 +15,7 @@
 //
 
 #include "s7.h"
+#include "s7_r7rs_library.h"
 #include <algorithm>
 #include <argh.h>
 #include <cctype>
@@ -711,6 +712,7 @@ glue_for_community_edition (s7_scheme* sc) {
   glue_liii_base64 (sc);
   glue_scheme_base (sc);
   glue_scheme_char (sc);
+  glue_r7rs_library (sc);
   glue_njson (sc);
 #ifdef GOLDFISH_ENABLE_HTTP
   glue_http (sc);

--- a/src/s7_r7rs_library.c
+++ b/src/s7_r7rs_library.c
@@ -25,6 +25,8 @@
 #include "s7_r7rs_library.h"
 
 #include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
 
 #define R7RS_LIBRARIES_NAME "*r7rs-libraries*"
 
@@ -102,6 +104,135 @@ g_library_unregister (s7_scheme* sc, s7_pointer args) {
   return s7_unspecified (sc);
 }
 
+/* -------- define-library -------- */
+
+static bool
+r7rs_decl_named (s7_pointer decl, const char* name) {
+  return (s7_is_pair (decl)) && (s7_is_symbol (s7_car (decl))) &&
+         (strcmp (s7_symbol_name (s7_car (decl)), name) == 0);
+}
+
+/* An export spec is either a symbol (external == internal) or (rename old new).
+ * On success stores the internal name in *internal and returns the external name;
+ * on a malformed spec an error is signalled. */
+static s7_pointer
+r7rs_export_spec_names (s7_scheme* sc, s7_pointer spec, s7_pointer* internal) {
+  if (s7_is_symbol (spec)) {
+    *internal= spec;
+    return spec;
+  }
+  if ((s7_is_pair (spec)) && (r7rs_decl_named (spec, "rename")) && (s7_list_length (sc, spec) == 3) &&
+      (s7_is_symbol (s7_cadr (spec))) && (s7_is_symbol (s7_caddr (spec)))) {
+    *internal= s7_cadr (spec);
+    return s7_caddr (spec);
+  }
+  return r7rs_library_error (sc, "syntax-error", "define-library: invalid export spec ~S", spec);
+}
+
+/* Find the binding entry (a (symbol . value) pair of s7_let_to_list) for sym
+ * among the own slots of env, or NULL if sym is not bound in env itself
+ * (outlets are deliberately not searched: only definitions and imports of the
+ * library body count). */
+static s7_pointer
+r7rs_entries_find (s7_pointer entries, s7_pointer sym) {
+  for (s7_pointer p= entries; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer entry= s7_car (p);
+    if (s7_car (entry) == sym) return entry;
+  }
+  return NULL;
+}
+
+static s7_pointer
+g_define_library (s7_scheme* sc, s7_pointer args) {
+  s7_gc_protect_via_stack (sc, args);
+  s7_pointer libname= s7_car (args);
+  if (!r7rs_library_name_valid (sc, libname))
+    return r7rs_library_error (sc, "wrong-type-arg",
+                               "define-library: invalid library name ~S (a proper list of symbols or non-negative "
+                               "integers expected)",
+                               libname);
+
+  /* the working environment: definitions and imports of the library body land here */
+  s7_pointer lib_env= s7_sublet (sc, s7_rootlet (sc), s7_nil (sc));
+  s7_gc_protect_via_stack (sc, lib_env);
+
+  /* pass 1: evaluate every declaration except export in lib_env.
+   * import uses the current (Scheme or C) import implementation via s7_eval;
+   * begin and any other form are evaluated directly. */
+  for (s7_pointer body= s7_cdr (args); s7_is_pair (body); body= s7_cdr (body)) {
+    s7_pointer decl= s7_car (body);
+    if (r7rs_decl_named (decl, "export")) continue;
+    s7_eval (sc, decl, lib_env);
+  }
+
+  /* the own slots of lib_env, as (symbol . value) entries */
+  s7_pointer entries= s7_let_to_list (sc, lib_env);
+  s7_gc_protect_via_stack (sc, entries);
+
+  /* pass 2: validate export specs before mutating any visible state.
+   * A name may come from the library body's own slots, or fall through to the
+   * rootlet (R7RS libraries such as (scheme base) re-export core bindings). */
+  for (s7_pointer body= s7_cdr (args); s7_is_pair (body); body= s7_cdr (body)) {
+    s7_pointer decl= s7_car (body);
+    if (!r7rs_decl_named (decl, "export")) continue;
+    for (s7_pointer specs= s7_cdr (decl); s7_is_pair (specs); specs= s7_cdr (specs)) {
+      s7_pointer internal= NULL;
+      r7rs_export_spec_names (sc, s7_car (specs), &internal);
+      if ((!r7rs_entries_find (entries, internal)) && (!s7_is_defined (sc, s7_symbol_name (internal))))
+        return r7rs_library_error (sc, "unbound-variable", "define-library: cannot export ~S: it is not defined in "
+                                   "the library body",
+                                   internal);
+    }
+  }
+
+  s7_pointer export_env= s7_inlet (sc, s7_nil (sc));
+  s7_gc_protect_via_stack (sc, export_env);
+
+  /* make the library reachable before populating it: the registry entry and the
+   * compatibility global symbol (used by the Scheme import implementation) */
+  s7_hash_table_set (sc, r7rs_library_registry (sc), libname, export_env);
+  char* name_str= s7_object_to_c_string (sc, libname);
+  s7_define (sc, s7_rootlet (sc), s7_make_symbol (sc, name_str), export_env);
+  free (name_str);
+
+  /* populate: with no export declaration every binding is exported */
+  bool export_all= true;
+  for (s7_pointer body= s7_cdr (args); s7_is_pair (body); body= s7_cdr (body))
+    if (r7rs_decl_named (s7_car (body), "export")) {
+      export_all= false;
+      break;
+    }
+  if (export_all) {
+    for (s7_pointer p= entries; s7_is_pair (p); p= s7_cdr (p)) {
+      s7_pointer entry= s7_car (p);
+      s7_varlet (sc, export_env, s7_car (entry), s7_cdr (entry));
+    }
+  }
+  else {
+    for (s7_pointer body= s7_cdr (args); s7_is_pair (body); body= s7_cdr (body)) {
+      s7_pointer decl= s7_car (body);
+      if (!r7rs_decl_named (decl, "export")) continue;
+      for (s7_pointer specs= s7_cdr (decl); s7_is_pair (specs); specs= s7_cdr (specs)) {
+        s7_pointer internal= NULL;
+        s7_pointer external= r7rs_export_spec_names (sc, s7_car (specs), &internal);
+        s7_pointer entry   = r7rs_entries_find (entries, internal);
+        /* pass 2 guarantees the name exists: in the library body's own slots,
+         * or via the fall-through to the rootlet */
+        s7_pointer value= entry ? s7_cdr (entry) : s7_let_ref (sc, lib_env, internal);
+        /* syntactic rootlet bindings (define* etc.) cannot be let slots in s7;
+         * skip them, matching the old Scheme implementation */
+        if (!s7_is_syntax (value)) s7_varlet (sc, export_env, external, value);
+      }
+    }
+  }
+
+  s7_gc_unprotect_via_stack (sc, export_env);
+  s7_gc_unprotect_via_stack (sc, entries);
+  s7_gc_unprotect_via_stack (sc, lib_env);
+  s7_gc_unprotect_via_stack (sc, args);
+  return s7_t (sc);
+}
+
 void
 glue_r7rs_library (s7_scheme* sc) {
   s7_define_variable (sc, R7RS_LIBRARIES_NAME, s7_make_hash_table (sc, 64));
@@ -115,4 +246,7 @@ glue_r7rs_library (s7_scheme* sc) {
                            "library named libname, replacing any previous registration");
   s7_define_safe_function (sc, "g_library-unregister!", g_library_unregister, 1, 0, false,
                            "(g_library-unregister! libname) removes the R7RS library named libname from the registry");
+  s7_define_macro (sc, "define-library", g_define_library, 1, 0, true,
+                   "(define-library libname decl ...) defines the R7RS library libname from the given declarations "
+                   "(export, import, begin, ...) and registers its exported environment");
 }

--- a/src/s7_r7rs_library.c
+++ b/src/s7_r7rs_library.c
@@ -1,0 +1,118 @@
+//
+// Copyright (C) 2026 The Goldfish Scheme Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+
+/* s7_r7rs_library.c - R7RS library registry for Goldfish Scheme
+ *
+ * The registry maps an R7RS library name (a proper list of symbols and
+ * non-negative integers, e.g. (liii base)) to the let environment holding
+ * the library's exported bindings.  It lives in the rootlet variable
+ * *r7rs-libraries* so that it is reachable by the garbage collector.
+ */
+
+#include "s7_r7rs_library.h"
+
+#include <stddef.h>
+
+#define R7RS_LIBRARIES_NAME "*r7rs-libraries*"
+
+static s7_pointer
+r7rs_library_error (s7_scheme* sc, const char* kind, const char* msg, s7_pointer arg) {
+  return s7_error (sc, s7_make_symbol (sc, kind), s7_list (sc, 2, s7_make_string (sc, msg), arg));
+}
+
+static s7_pointer
+r7rs_library_registry (s7_scheme* sc) {
+  return s7_name_to_value (sc, R7RS_LIBRARIES_NAME);
+}
+
+/* R7RS: a library name is a proper list whose elements are symbols or
+ * exact non-negative integers.  Returns true iff name is valid. */
+static bool
+r7rs_library_name_valid (s7_scheme* sc, s7_pointer name) {
+  if ((!s7_is_null (sc, name)) && (!s7_is_pair (name))) return false; /* not a list at all */
+  if (s7_list_length (sc, name) < 0) return false;                    /* improper or circular list */
+  for (s7_pointer p= name; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer elt= s7_car (p);
+    if (s7_is_symbol (elt)) continue;
+    if (s7_is_integer (elt) && s7_integer (elt) >= 0) continue;
+    return false;
+  }
+  return true;
+}
+
+static s7_pointer
+r7rs_library_check_name (s7_scheme* sc, const char* caller, s7_pointer name) {
+  if (!r7rs_library_name_valid (sc, name))
+    return r7rs_library_error (sc, "wrong-type-arg",
+                               "library name should be a proper list of symbols or non-negative integers, but got ~S",
+                               name);
+  return NULL;
+}
+
+static s7_pointer
+g_library_defined_p (s7_scheme* sc, s7_pointer args) {
+  s7_pointer name= s7_car (args);
+  s7_pointer err = r7rs_library_check_name (sc, "g_library-defined?", name);
+  if (err) return err;
+  return s7_make_boolean (sc, s7_is_let (s7_hash_table_ref (sc, r7rs_library_registry (sc), name)));
+}
+
+static s7_pointer
+g_library_ref (s7_scheme* sc, s7_pointer args) {
+  s7_pointer name= s7_car (args);
+  s7_pointer err = r7rs_library_check_name (sc, "g_library-ref", name);
+  if (err) return err;
+  s7_pointer env= s7_hash_table_ref (sc, r7rs_library_registry (sc), name);
+  return s7_is_let (env) ? env : s7_f (sc);
+}
+
+static s7_pointer
+g_library_register (s7_scheme* sc, s7_pointer args) {
+  s7_pointer name= s7_car (args);
+  s7_pointer err = r7rs_library_check_name (sc, "g_library-register!", name);
+  if (err) return err;
+  s7_pointer env= s7_cadr (args);
+  if (!s7_is_let (env))
+    return r7rs_library_error (sc, "wrong-type-arg", "library environment should be a let, but got ~S", env);
+  s7_hash_table_set (sc, r7rs_library_registry (sc), name, env);
+  return env;
+}
+
+static s7_pointer
+g_library_unregister (s7_scheme* sc, s7_pointer args) {
+  s7_pointer name= s7_car (args);
+  s7_pointer err = r7rs_library_check_name (sc, "g_library-unregister!", name);
+  if (err) return err;
+  /* s7 hash tables have no delete; storing #f marks the entry as absent
+   * (g_library-defined?/g_library-ref only accept let values). */
+  s7_hash_table_set (sc, r7rs_library_registry (sc), name, s7_f (sc));
+  return s7_unspecified (sc);
+}
+
+void
+glue_r7rs_library (s7_scheme* sc) {
+  s7_define_variable (sc, R7RS_LIBRARIES_NAME, s7_make_hash_table (sc, 64));
+  s7_define_safe_function (sc, "g_library-defined?", g_library_defined_p, 1, 0, false,
+                           "(g_library-defined? libname) returns #t if the R7RS library named libname is registered");
+  s7_define_safe_function (sc, "g_library-ref", g_library_ref, 1, 0, false,
+                           "(g_library-ref libname) returns the exported environment of the R7RS library named libname, "
+                           "or #f if it is not registered");
+  s7_define_safe_function (sc, "g_library-register!", g_library_register, 2, 0, false,
+                           "(g_library-register! libname env) registers env as the exported environment of the R7RS "
+                           "library named libname, replacing any previous registration");
+  s7_define_safe_function (sc, "g_library-unregister!", g_library_unregister, 1, 0, false,
+                           "(g_library-unregister! libname) removes the R7RS library named libname from the registry");
+}

--- a/src/s7_r7rs_library.c
+++ b/src/s7_r7rs_library.c
@@ -105,7 +105,363 @@ g_library_unregister (s7_scheme* sc, s7_pointer args) {
   return s7_unspecified (sc);
 }
 
-/* -------- define-library -------- */
+/* -------- define-library helpers (defined below) -------- */
+
+static bool       r7rs_decl_named (s7_pointer decl, const char* name);
+static s7_pointer r7rs_export_spec_names (s7_scheme* sc, s7_pointer spec, s7_pointer* internal);
+static s7_pointer r7rs_entries_find (s7_pointer entries, s7_pointer sym);
+static char*      r7rs_library_name_to_path (s7_scheme* sc, s7_pointer libname);
+
+/* -------- cond-expand (library declarations) -------- */
+
+/* is the library available: registered, or present as a file in some *load-path* directory? */
+static bool
+r7rs_library_available (s7_scheme* sc, s7_pointer libname) {
+  if (s7_is_let (s7_hash_table_ref (sc, r7rs_library_registry (sc), libname))) return true;
+  char*      relpath  = r7rs_library_name_to_path (sc, libname);
+  bool       found    = false;
+  s7_pointer load_path= s7_name_to_value (sc, "*load-path*");
+  for (s7_pointer p= load_path; (s7_is_pair (p)) && (!found); p= s7_cdr (p)) {
+    if (!s7_is_string (s7_car (p))) continue;
+    const char* dir= s7_string (s7_car (p));
+    size_t      n  = strlen (dir) + strlen (relpath) + 2;
+    char*       full= (char*) malloc (n);
+    snprintf (full, n, "%s/%s", dir, relpath);
+    FILE* fp= fopen (full, "r");
+    if (fp) {
+      fclose (fp);
+      found= true;
+    }
+    free (full);
+  }
+  free (relpath);
+  return found;
+}
+
+/* evaluate an R7RS feature requirement: a feature identifier, (library name),
+ * or (and/or/not ...) compositions */
+static bool
+r7rs_feature_satisfied (s7_scheme* sc, s7_pointer req) {
+  if (s7_is_symbol (req)) return s7_is_provided (sc, s7_symbol_name (req));
+  if (!s7_is_pair (req)) {
+    r7rs_library_error (sc, "syntax-error", "cond-expand: invalid feature requirement ~S", req);
+    return false;
+  }
+  s7_pointer head= s7_car (req);
+  if (!s7_is_symbol (head)) {
+    r7rs_library_error (sc, "syntax-error", "cond-expand: invalid feature requirement ~S", req);
+    return false;
+  }
+  const char* op= s7_symbol_name (head);
+  if (strcmp (op, "library") == 0) {
+    if ((s7_list_length (sc, req) != 2) || (!r7rs_library_name_valid (sc, s7_cadr (req)))) {
+      r7rs_library_error (sc, "syntax-error", "cond-expand: malformed (library ...) requirement ~S", req);
+      return false;
+    }
+    return r7rs_library_available (sc, s7_cadr (req));
+  }
+  if (strcmp (op, "and") == 0) {
+    for (s7_pointer p= s7_cdr (req); s7_is_pair (p); p= s7_cdr (p))
+      if (!r7rs_feature_satisfied (sc, s7_car (p))) return false;
+    return true;
+  }
+  if (strcmp (op, "or") == 0) {
+    for (s7_pointer p= s7_cdr (req); s7_is_pair (p); p= s7_cdr (p))
+      if (r7rs_feature_satisfied (sc, s7_car (p))) return true;
+    return false;
+  }
+  if (strcmp (op, "not") == 0) {
+    if (s7_list_length (sc, req) != 2) {
+      r7rs_library_error (sc, "syntax-error", "cond-expand: (not ...) takes exactly one requirement, got ~S", req);
+      return false;
+    }
+    return !r7rs_feature_satisfied (sc, s7_cadr (req));
+  }
+  r7rs_library_error (sc, "syntax-error", "cond-expand: unknown feature requirement ~S", req);
+  return false;
+}
+
+/* choose the body (a list of declarations) of the first matching clause of a
+ * cond-expand declaration; returns NULL (no allocation) if nothing matches */
+static s7_pointer
+r7rs_cond_expand_choose (s7_scheme* sc, s7_pointer clauses) {
+  for (s7_pointer p= clauses; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer clause= s7_car (p);
+    if (!s7_is_pair (clause)) {
+      r7rs_library_error (sc, "syntax-error", "cond-expand: clause is not a list: ~S", clause);
+      return NULL;
+    }
+    s7_pointer req= s7_car (clause);
+    if ((s7_is_symbol (req)) && (strcmp (s7_symbol_name (req), "else") == 0)) return s7_cdr (clause);
+    if (r7rs_feature_satisfied (sc, req)) return s7_cdr (clause);
+  }
+  return NULL;
+}
+
+/* R7RS cond-expand, replacing s7's built-in read-time expansion (which neither
+ * supports (library ...) requirements nor clauses with multiple body forms).
+ * Registered as a plain c-macro, so the reader no longer expands cond-expand
+ * forms and define-library bodies can process them as declarations. */
+static s7_pointer
+g_cond_expand_r7rs (s7_scheme* sc, s7_pointer args) {
+  s7_gc_protect_via_stack (sc, args);
+  s7_pointer chosen   = r7rs_cond_expand_choose (sc, args);
+  s7_pointer expansion=
+    chosen ? s7_cons (sc, s7_make_symbol (sc, "begin"), chosen) : s7_unspecified (sc);
+  s7_gc_unprotect_via_stack (sc, args);
+  return expansion;
+}
+
+/* -------- define-library passes -------- */
+
+enum { R7RS_PASS_EVAL, R7RS_PASS_VALIDATE, R7RS_PASS_POPULATE };
+
+typedef struct {
+  s7_pointer lib_env;
+  s7_pointer entries;
+  s7_pointer export_env;
+  bool       saw_export;
+} r7rs_define_library_ctx;
+
+static void r7rs_walk_library_decls (s7_scheme* sc, s7_pointer decls, int mode, r7rs_define_library_ctx* ctx);
+
+/* -------- include -------- */
+
+static bool
+r7rs_file_readable (const char* path) {
+  FILE* fp= fopen (path, "r");
+  if (!fp) return false;
+  fclose (fp);
+  return true;
+}
+
+static char*
+r7rs_str_dup (const char* s) {
+  size_t n= strlen (s) + 1;
+  char*  r= (char*) malloc (n);
+  memcpy (r, s, n);
+  return r;
+}
+
+/* resolve an include file: first relative to the directory of the file
+ * currently being loaded, then each *load-path* directory, then the name
+ * as-is.  Returns a malloc'd path, or NULL if not found. */
+static char*
+r7rs_find_include_file (s7_scheme* sc, const char* name) {
+  s7_pointer port= s7_current_input_port (sc);
+  const char* current= s7_port_filename (sc, port);
+  if (current) {
+    const char* sep= strrchr (current, '/');
+    if (!sep) sep= strrchr (current, '\\');
+    if (sep) {
+      size_t dir_len= (size_t) (sep - current);
+      char* candidate= (char*) malloc (dir_len + 1 + strlen (name) + 1);
+      memcpy (candidate, current, dir_len);
+      candidate[dir_len]= '/';
+      strcpy (candidate + dir_len + 1, name);
+      if (r7rs_file_readable (candidate)) return candidate;
+      free (candidate);
+    }
+  }
+  s7_pointer load_path= s7_name_to_value (sc, "*load-path*");
+  for (s7_pointer p= load_path; s7_is_pair (p); p= s7_cdr (p)) {
+    if (!s7_is_string (s7_car (p))) continue;
+    const char* dir= s7_string (s7_car (p));
+    size_t      n  = strlen (dir) + strlen (name) + 2;
+    char* candidate= (char*) malloc (n);
+    snprintf (candidate, n, "%s/%s", dir, name);
+    if (r7rs_file_readable (candidate)) return candidate;
+    free (candidate);
+  }
+  if (r7rs_file_readable (name)) return r7rs_str_dup (name);
+  return NULL;
+}
+
+/* read an entire file; returns a malloc'd NUL-terminated string, or NULL */
+static char*
+r7rs_read_file_text (const char* path) {
+  FILE* fp= fopen (path, "rb");
+  if (!fp) return NULL;
+  fseek (fp, 0, SEEK_END);
+  long size= ftell (fp);
+  if (size < 0) {
+    fclose (fp);
+    return NULL;
+  }
+  rewind (fp);
+  char* text= (char*) malloc ((size_t) size + 1);
+  size_t got= fread (text, 1, (size_t) size, fp);
+  fclose (fp);
+  text[got]= '\0';
+  return text;
+}
+
+/* validate the filename arguments of an include declaration */
+static s7_pointer
+r7rs_include_check_files (s7_scheme* sc, s7_pointer files) {
+  for (s7_pointer p= files; s7_is_pair (p); p= s7_cdr (p))
+    if (!s7_is_string (s7_car (p)))
+      return r7rs_library_error (sc, "wrong-type-arg", "include: filename should be a string, got ~S", s7_car (p));
+  return NULL;
+}
+
+/* (include "file" ...) / (include-ci "file" ...): the file contents are library
+ * body forms, as if wrapped in begin.  Note: the s7 reader has no case-folding
+ * mode, so include-ci currently behaves exactly like include. */
+static void
+r7rs_include_files (s7_scheme* sc, s7_pointer files, s7_pointer lib_env) {
+  s7_pointer err= r7rs_include_check_files (sc, files);
+  if (err) return;
+  for (s7_pointer p= files; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer name= s7_car (p);
+    char*      path= r7rs_find_include_file (sc, s7_string (name));
+    if (!path) {
+      r7rs_library_error (sc, "io-error", "include: cannot find file ~S", name);
+      return;
+    }
+    char* text= r7rs_read_file_text (path);
+    free (path);
+    if (!text) {
+      r7rs_library_error (sc, "io-error", "include: cannot read file ~S", name);
+      return;
+    }
+    s7_pointer port= s7_open_input_string (sc, text); /* the port references text */
+    s7_gc_protect_via_stack (sc, port);
+    s7_pointer eof= s7_eof_object (sc);
+    s7_pointer form;
+    while ((form= s7_read (sc, port)) != eof)
+      s7_eval (sc, form, lib_env);
+    s7_gc_unprotect_via_stack (sc, port);
+    free (text);
+  }
+}
+
+/* (include-library-declarations "file" ...): the file contents are library
+ * declarations, spliced into the declaration stream */
+static void
+r7rs_include_library_declarations (s7_scheme* sc, s7_pointer files, int mode, r7rs_define_library_ctx* ctx) {
+  s7_pointer err= r7rs_include_check_files (sc, files);
+  if (err) return;
+  for (s7_pointer p= files; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer name= s7_car (p);
+    char*      path= r7rs_find_include_file (sc, s7_string (name));
+    if (!path) {
+      r7rs_library_error (sc, "io-error", "include-library-declarations: cannot find file ~S", name);
+      return;
+    }
+    char* text= r7rs_read_file_text (path);
+    free (path);
+    if (!text) {
+      r7rs_library_error (sc, "io-error", "include-library-declarations: cannot read file ~S", name);
+      return;
+    }
+    s7_pointer port= s7_open_input_string (sc, text); /* the port references text */
+    s7_gc_protect_via_stack (sc, port);
+    s7_pointer eof  = s7_eof_object (sc);
+    s7_pointer forms= s7_nil (sc);
+    s7_gc_protect_via_stack (sc, forms);
+    s7_pointer form;
+    while ((form= s7_read (sc, port)) != eof) {
+      s7_gc_protect_via_stack (sc, form);
+      forms= s7_cons (sc, form, forms); /* reversed */
+      s7_gc_unprotect_via_stack (sc, form);
+      s7_gc_unprotect_via_stack (sc, forms);
+      s7_gc_protect_via_stack (sc, forms);
+    }
+    /* reverse in place (no allocation, so no GC risk): restore source order */
+    s7_pointer rev= s7_nil (sc);
+    for (s7_pointer q= forms; s7_is_pair (q);) {
+      s7_pointer next= s7_cdr (q);
+      s7_set_cdr (q, rev);
+      rev= q;
+      q  = next;
+    }
+    /* the last cons cell (old head) is still on the protect stack and anchors
+     * the whole chain, which now starts at rev */
+    r7rs_walk_library_decls (sc, rev, mode, ctx);
+    s7_gc_unprotect_via_stack (sc, forms);
+    s7_gc_unprotect_via_stack (sc, port);
+    free (text);
+  }
+}
+
+/* pass 2 helper: every export spec must be well-formed and name a binding of the
+ * library body, or a binding that falls through to the rootlet */
+static void
+r7rs_validate_export_decl (s7_scheme* sc, s7_pointer decl, s7_pointer entries) {
+  for (s7_pointer specs= s7_cdr (decl); s7_is_pair (specs); specs= s7_cdr (specs)) {
+    s7_pointer internal= NULL;
+    r7rs_export_spec_names (sc, s7_car (specs), &internal);
+    if ((!r7rs_entries_find (entries, internal)) && (!s7_is_defined (sc, s7_symbol_name (internal))))
+      r7rs_library_error (sc, "unbound-variable", "define-library: cannot export ~S: it is not defined in "
+                          "the library body",
+                          internal);
+  }
+}
+
+/* pass 3 helper: materialize the exported bindings into export_env */
+static void
+r7rs_populate_export_decl (s7_scheme* sc, s7_pointer decl, s7_pointer entries, s7_pointer export_env, s7_pointer lib_env) {
+  for (s7_pointer specs= s7_cdr (decl); s7_is_pair (specs); specs= s7_cdr (specs)) {
+    s7_pointer internal= NULL;
+    s7_pointer external= r7rs_export_spec_names (sc, s7_car (specs), &internal);
+    s7_pointer entry   = r7rs_entries_find (entries, internal);
+    /* only the library body's own bindings are materialized in the export
+     * environment.  Names that fall through to the rootlet (pass 2 allows
+     * them, e.g. (scheme base) re-exporting eqv?) stay virtual: the export
+     * environment's outlet chain resolves them, exactly like the old
+     * Scheme implementation.  Copying hundreds of rootlet bindings into
+     * every export environment (and from there into every importer) would
+     * be a measurable slowdown. */
+    if (entry) s7_varlet (sc, export_env, external, s7_cdr (entry));
+    else
+      if (external != internal) {
+        /* a renamed rootlet re-export (export (rename eqv? same?)): the new
+         * name does not exist in the rootlet, so it must be materialized */
+        s7_pointer value= s7_let_ref (sc, lib_env, internal);
+        /* syntactic rootlet bindings (define* etc.) cannot be let slots in s7;
+         * skip them, matching the old Scheme implementation */
+        if (!s7_is_syntax (value)) s7_varlet (sc, export_env, external, value);
+      }
+  }
+}
+
+static void
+r7rs_walk_library_decls (s7_scheme* sc, s7_pointer decls, int mode, r7rs_define_library_ctx* ctx) {
+  for (s7_pointer p= decls; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer decl= s7_car (p);
+    if (r7rs_decl_named (decl, "cond-expand")) {
+      s7_pointer chosen= r7rs_cond_expand_choose (sc, s7_cdr (decl));
+      if (chosen) r7rs_walk_library_decls (sc, chosen, mode, ctx);
+      continue;
+    }
+    /* include-library-declarations splices declarations: handle in every pass */
+    if (r7rs_decl_named (decl, "include-library-declarations")) {
+      r7rs_include_library_declarations (sc, s7_cdr (decl), mode, ctx);
+      continue;
+    }
+    /* include/include-ci splice body forms: only the eval pass cares */
+    if ((r7rs_decl_named (decl, "include")) || (r7rs_decl_named (decl, "include-ci"))) {
+      if (mode == R7RS_PASS_EVAL) r7rs_include_files (sc, s7_cdr (decl), ctx->lib_env);
+      continue;
+    }
+    switch (mode) {
+    case R7RS_PASS_EVAL:
+      if (!r7rs_decl_named (decl, "export")) s7_eval (sc, decl, ctx->lib_env);
+      break;
+    case R7RS_PASS_VALIDATE:
+      if (r7rs_decl_named (decl, "export")) {
+        ctx->saw_export= true;
+        r7rs_validate_export_decl (sc, decl, ctx->entries);
+      }
+      break;
+    case R7RS_PASS_POPULATE:
+      if (r7rs_decl_named (decl, "export"))
+        r7rs_populate_export_decl (sc, decl, ctx->entries, ctx->export_env, ctx->lib_env);
+      break;
+    }
+  }
+}
 
 static bool
 r7rs_decl_named (s7_pointer decl, const char* name) {
@@ -153,94 +509,46 @@ g_define_library (s7_scheme* sc, s7_pointer args) {
                                "integers expected)",
                                libname);
 
-  /* the working environment: definitions and imports of the library body land here */
-  s7_pointer lib_env= s7_sublet (sc, s7_rootlet (sc), s7_nil (sc));
-  s7_gc_protect_via_stack (sc, lib_env);
+  r7rs_define_library_ctx ctx;
+  ctx.saw_export= false;
 
-  /* pass 1: evaluate every declaration except export in lib_env.
-   * import uses the current (Scheme or C) import implementation via s7_eval;
-   * begin and any other form are evaluated directly. */
-  for (s7_pointer body= s7_cdr (args); s7_is_pair (body); body= s7_cdr (body)) {
-    s7_pointer decl= s7_car (body);
-    if (r7rs_decl_named (decl, "export")) continue;
-    s7_eval (sc, decl, lib_env);
-  }
+  /* the working environment: definitions and imports of the library body land here */
+  ctx.lib_env= s7_sublet (sc, s7_rootlet (sc), s7_nil (sc));
+  s7_gc_protect_via_stack (sc, ctx.lib_env);
+
+  /* pass 1: evaluate every declaration except export in lib_env
+   * (cond-expand clauses are resolved and recursed into by the walker) */
+  r7rs_walk_library_decls (sc, s7_cdr (args), R7RS_PASS_EVAL, &ctx);
 
   /* the own slots of lib_env, as (symbol . value) entries */
-  s7_pointer entries= s7_let_to_list (sc, lib_env);
-  s7_gc_protect_via_stack (sc, entries);
+  ctx.entries= s7_let_to_list (sc, ctx.lib_env);
+  s7_gc_protect_via_stack (sc, ctx.entries);
 
-  /* pass 2: validate export specs before mutating any visible state.
-   * A name may come from the library body's own slots, or fall through to the
-   * rootlet (R7RS libraries such as (scheme base) re-export core bindings). */
-  for (s7_pointer body= s7_cdr (args); s7_is_pair (body); body= s7_cdr (body)) {
-    s7_pointer decl= s7_car (body);
-    if (!r7rs_decl_named (decl, "export")) continue;
-    for (s7_pointer specs= s7_cdr (decl); s7_is_pair (specs); specs= s7_cdr (specs)) {
-      s7_pointer internal= NULL;
-      r7rs_export_spec_names (sc, s7_car (specs), &internal);
-      if ((!r7rs_entries_find (entries, internal)) && (!s7_is_defined (sc, s7_symbol_name (internal))))
-        return r7rs_library_error (sc, "unbound-variable", "define-library: cannot export ~S: it is not defined in "
-                                   "the library body",
-                                   internal);
-    }
-  }
+  /* pass 2: validate export specs before mutating any visible state */
+  r7rs_walk_library_decls (sc, s7_cdr (args), R7RS_PASS_VALIDATE, &ctx);
 
-  s7_pointer export_env= s7_inlet (sc, s7_nil (sc));
-  s7_gc_protect_via_stack (sc, export_env);
+  ctx.export_env= s7_inlet (sc, s7_nil (sc));
+  s7_gc_protect_via_stack (sc, ctx.export_env);
 
   /* make the library reachable before populating it: the registry entry and the
    * compatibility global symbol (used by the Scheme import implementation) */
-  s7_hash_table_set (sc, r7rs_library_registry (sc), libname, export_env);
+  s7_hash_table_set (sc, r7rs_library_registry (sc), libname, ctx.export_env);
   char* name_str= s7_object_to_c_string (sc, libname);
-  s7_define (sc, s7_rootlet (sc), s7_make_symbol (sc, name_str), export_env);
+  s7_define (sc, s7_rootlet (sc), s7_make_symbol (sc, name_str), ctx.export_env);
   free (name_str);
 
   /* populate: with no export declaration every binding is exported */
-  bool export_all= true;
-  for (s7_pointer body= s7_cdr (args); s7_is_pair (body); body= s7_cdr (body))
-    if (r7rs_decl_named (s7_car (body), "export")) {
-      export_all= false;
-      break;
-    }
-  if (export_all) {
-    for (s7_pointer p= entries; s7_is_pair (p); p= s7_cdr (p)) {
+  if (!ctx.saw_export) {
+    for (s7_pointer p= ctx.entries; s7_is_pair (p); p= s7_cdr (p)) {
       s7_pointer entry= s7_car (p);
-      s7_varlet (sc, export_env, s7_car (entry), s7_cdr (entry));
+      s7_varlet (sc, ctx.export_env, s7_car (entry), s7_cdr (entry));
     }
   }
-  else {
-    for (s7_pointer body= s7_cdr (args); s7_is_pair (body); body= s7_cdr (body)) {
-      s7_pointer decl= s7_car (body);
-      if (!r7rs_decl_named (decl, "export")) continue;
-      for (s7_pointer specs= s7_cdr (decl); s7_is_pair (specs); specs= s7_cdr (specs)) {
-        s7_pointer internal= NULL;
-        s7_pointer external= r7rs_export_spec_names (sc, s7_car (specs), &internal);
-        s7_pointer entry   = r7rs_entries_find (entries, internal);
-        /* only the library body's own bindings are materialized in the export
-         * environment.  Names that fall through to the rootlet (pass 2 allows
-         * them, e.g. (scheme base) re-exporting eqv?) stay virtual: the export
-         * environment's outlet chain resolves them, exactly like the old
-         * Scheme implementation.  Copying hundreds of rootlet bindings into
-         * every export environment (and from there into every importer) would
-         * be a measurable slowdown. */
-        if (entry) s7_varlet (sc, export_env, external, s7_cdr (entry));
-        else
-          if (external != internal) {
-            /* a renamed rootlet re-export (export (rename eqv? same?)): the new
-             * name does not exist in the rootlet, so it must be materialized */
-            s7_pointer value= s7_let_ref (sc, lib_env, internal);
-            /* syntactic rootlet bindings (define* etc.) cannot be let slots in s7;
-             * skip them, matching the old Scheme implementation */
-            if (!s7_is_syntax (value)) s7_varlet (sc, export_env, external, value);
-          }
-      }
-    }
-  }
+  else r7rs_walk_library_decls (sc, s7_cdr (args), R7RS_PASS_POPULATE, &ctx);
 
-  s7_gc_unprotect_via_stack (sc, export_env);
-  s7_gc_unprotect_via_stack (sc, entries);
-  s7_gc_unprotect_via_stack (sc, lib_env);
+  s7_gc_unprotect_via_stack (sc, ctx.export_env);
+  s7_gc_unprotect_via_stack (sc, ctx.entries);
+  s7_gc_unprotect_via_stack (sc, ctx.lib_env);
   s7_gc_unprotect_via_stack (sc, args);
   return s7_t (sc);
 }
@@ -470,4 +778,7 @@ glue_r7rs_library (s7_scheme* sc) {
   s7_define_macro (sc, "import", g_import, 0, 0, true,
                    "(import import-set ...) imports the bindings denoted by each import set (a library name, "
                    "optionally modified by only/except/prefix/rename) into the current environment");
+  s7_define_macro (sc, "cond-expand", g_cond_expand_r7rs, 0, 0, true,
+                   "(cond-expand clause ...) chooses the first clause whose feature requirement (a feature "
+                   "identifier, (library name), or an and/or/not composition) is satisfied");
 }

--- a/src/s7_r7rs_library.c
+++ b/src/s7_r7rs_library.c
@@ -25,6 +25,7 @@
 #include "s7_r7rs_library.h"
 
 #include <stddef.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -216,12 +217,23 @@ g_define_library (s7_scheme* sc, s7_pointer args) {
         s7_pointer internal= NULL;
         s7_pointer external= r7rs_export_spec_names (sc, s7_car (specs), &internal);
         s7_pointer entry   = r7rs_entries_find (entries, internal);
-        /* pass 2 guarantees the name exists: in the library body's own slots,
-         * or via the fall-through to the rootlet */
-        s7_pointer value= entry ? s7_cdr (entry) : s7_let_ref (sc, lib_env, internal);
-        /* syntactic rootlet bindings (define* etc.) cannot be let slots in s7;
-         * skip them, matching the old Scheme implementation */
-        if (!s7_is_syntax (value)) s7_varlet (sc, export_env, external, value);
+        /* only the library body's own bindings are materialized in the export
+         * environment.  Names that fall through to the rootlet (pass 2 allows
+         * them, e.g. (scheme base) re-exporting eqv?) stay virtual: the export
+         * environment's outlet chain resolves them, exactly like the old
+         * Scheme implementation.  Copying hundreds of rootlet bindings into
+         * every export environment (and from there into every importer) would
+         * be a measurable slowdown. */
+        if (entry) s7_varlet (sc, export_env, external, s7_cdr (entry));
+        else
+          if (external != internal) {
+            /* a renamed rootlet re-export (export (rename eqv? same?)): the new
+             * name does not exist in the rootlet, so it must be materialized */
+            s7_pointer value= s7_let_ref (sc, lib_env, internal);
+            /* syntactic rootlet bindings (define* etc.) cannot be let slots in s7;
+             * skip them, matching the old Scheme implementation */
+            if (!s7_is_syntax (value)) s7_varlet (sc, export_env, external, value);
+          }
       }
     }
   }
@@ -231,6 +243,212 @@ g_define_library (s7_scheme* sc, s7_pointer args) {
   s7_gc_unprotect_via_stack (sc, lib_env);
   s7_gc_unprotect_via_stack (sc, args);
   return s7_t (sc);
+}
+
+/* -------- import -------- */
+
+/* map a library name (liii base) to the file path "liii/base.scm" */
+static char*
+r7rs_library_name_to_path (s7_scheme* sc, s7_pointer libname) {
+  size_t len= 1; /* NUL */
+  for (s7_pointer p= libname; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer elt= s7_car (p);
+    len+= (s7_is_symbol (elt) ? strlen (s7_symbol_name (elt)) : 24) + 1; /* '/' or ".scm" */
+  }
+  char* path= (char*) malloc (len + 4);
+  char* w   = path;
+  for (s7_pointer p= libname; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer elt= s7_car (p);
+    if (w != path) *w++= '/';
+    if (s7_is_symbol (elt)) {
+      size_t n= strlen (s7_symbol_name (elt));
+      memcpy (w, s7_symbol_name (elt), n);
+      w+= n;
+    }
+    else w+= sprintf (w, "%lld", (long long) s7_integer (elt));
+  }
+  memcpy (w, ".scm", 5); /* with NUL */
+  return path;
+}
+
+/* return the exported environment of libname, loading its file on first use */
+static s7_pointer
+r7rs_library_env (s7_scheme* sc, s7_pointer libname) {
+  s7_pointer env= s7_hash_table_ref (sc, r7rs_library_registry (sc), libname);
+  if (s7_is_let (env)) return env;
+  char* path= r7rs_library_name_to_path (sc, libname);
+  s7_load (sc, path); /* errors if the file cannot be found */
+  free (path);
+  env= s7_hash_table_ref (sc, r7rs_library_registry (sc), libname);
+  if (!s7_is_let (env))
+    return r7rs_library_error (sc, "unbound-variable", "import: loading did not define the library ~S", libname);
+  return env;
+}
+
+static s7_pointer r7rs_import_set_env (s7_scheme* sc, s7_pointer iset);
+
+/* is sym a member of the symbol list names? */
+static bool
+r7rs_symbol_member (s7_pointer names, s7_pointer sym) {
+  for (s7_pointer p= names; s7_is_pair (p); p= s7_cdr (p))
+    if (s7_car (p) == sym) return true;
+  return false;
+}
+
+static s7_pointer
+r7rs_import_check_names (s7_scheme* sc, s7_pointer names) {
+  for (s7_pointer p= names; s7_is_pair (p); p= s7_cdr (p))
+    if (!s7_is_symbol (s7_car (p)))
+      return r7rs_library_error (sc, "wrong-type-arg", "import: expected an identifier, got ~S", s7_car (p));
+  return NULL;
+}
+
+/* (only import-set identifier ...) */
+static s7_pointer
+r7rs_import_only (s7_scheme* sc, s7_pointer iset) {
+  s7_pointer rest= s7_cdr (iset);
+  if (!s7_is_pair (rest))
+    return r7rs_library_error (sc, "syntax-error", "import: (only ...) needs an import set, got ~S", iset);
+  s7_pointer err= r7rs_import_check_names (sc, s7_cdr (rest));
+  if (err) return err;
+  s7_pointer sub= r7rs_import_set_env (sc, s7_car (rest));
+  s7_gc_protect_via_stack (sc, sub);
+  s7_pointer env= s7_inlet (sc, s7_nil (sc));
+  s7_gc_protect_via_stack (sc, env);
+  for (s7_pointer names= s7_cdr (rest); s7_is_pair (names); names= s7_cdr (names)) {
+    s7_pointer name= s7_car (names);
+    s7_varlet (sc, env, name, s7_let_ref (sc, sub, name)); /* let-ref errors if name is missing */
+  }
+  s7_gc_unprotect_via_stack (sc, env);
+  s7_gc_unprotect_via_stack (sc, sub);
+  return env;
+}
+
+/* (except import-set identifier ...) */
+static s7_pointer
+r7rs_import_except (s7_scheme* sc, s7_pointer iset) {
+  s7_pointer rest= s7_cdr (iset);
+  if (!s7_is_pair (rest))
+    return r7rs_library_error (sc, "syntax-error", "import: (except ...) needs an import set, got ~S", iset);
+  s7_pointer err= r7rs_import_check_names (sc, s7_cdr (rest));
+  if (err) return err;
+  s7_pointer sub= r7rs_import_set_env (sc, s7_car (rest));
+  s7_gc_protect_via_stack (sc, sub);
+  s7_pointer env= s7_inlet (sc, s7_nil (sc));
+  s7_gc_protect_via_stack (sc, env);
+  s7_pointer entries= s7_let_to_list (sc, sub);
+  s7_gc_protect_via_stack (sc, entries);
+  s7_pointer names= s7_cdr (rest);
+  for (s7_pointer p= entries; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer entry= s7_car (p);
+    if (!r7rs_symbol_member (names, s7_car (entry))) s7_varlet (sc, env, s7_car (entry), s7_cdr (entry));
+  }
+  s7_gc_unprotect_via_stack (sc, entries);
+  s7_gc_unprotect_via_stack (sc, env);
+  s7_gc_unprotect_via_stack (sc, sub);
+  return env;
+}
+
+/* (prefix import-set prefix-identifier) */
+static s7_pointer
+r7rs_import_prefix (s7_scheme* sc, s7_pointer iset) {
+  if ((s7_list_length (sc, iset) != 3) || (!s7_is_symbol (s7_caddr (iset))))
+    return r7rs_library_error (sc, "syntax-error",
+                               "import: (prefix ...) needs an import set and a prefix identifier, got ~S", iset);
+  s7_pointer sub= r7rs_import_set_env (sc, s7_cadr (iset));
+  s7_gc_protect_via_stack (sc, sub);
+  s7_pointer env= s7_inlet (sc, s7_nil (sc));
+  s7_gc_protect_via_stack (sc, env);
+  s7_pointer entries= s7_let_to_list (sc, sub);
+  s7_gc_protect_via_stack (sc, entries);
+  const char* pre= s7_symbol_name (s7_caddr (iset));
+  size_t      pre_len= strlen (pre);
+  for (s7_pointer p= entries; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer  entry= s7_car (p);
+    const char* name = s7_symbol_name (s7_car (entry));
+    size_t      name_len= strlen (name);
+    char*       buf= (char*) malloc (pre_len + name_len + 1);
+    memcpy (buf, pre, pre_len);
+    memcpy (buf + pre_len, name, name_len + 1);
+    s7_varlet (sc, env, s7_make_symbol (sc, buf), s7_cdr (entry));
+    free (buf);
+  }
+  s7_gc_unprotect_via_stack (sc, entries);
+  s7_gc_unprotect_via_stack (sc, env);
+  s7_gc_unprotect_via_stack (sc, sub);
+  return env;
+}
+
+/* (rename import-set (old new) ...) */
+static s7_pointer
+r7rs_import_rename (s7_scheme* sc, s7_pointer iset) {
+  s7_pointer rest= s7_cdr (iset);
+  if (!s7_is_pair (rest))
+    return r7rs_library_error (sc, "syntax-error", "import: (rename ...) needs an import set, got ~S", iset);
+  for (s7_pointer specs= s7_cdr (rest); s7_is_pair (specs); specs= s7_cdr (specs)) {
+    s7_pointer spec= s7_car (specs);
+    if ((s7_list_length (sc, spec) != 2) || (!s7_is_symbol (s7_car (spec))) || (!s7_is_symbol (s7_cadr (spec))))
+      return r7rs_library_error (sc, "syntax-error", "import: rename expects (old new) pairs, got ~S", spec);
+  }
+  s7_pointer sub= r7rs_import_set_env (sc, s7_car (rest));
+  s7_gc_protect_via_stack (sc, sub);
+  s7_pointer env= s7_inlet (sc, s7_nil (sc));
+  s7_gc_protect_via_stack (sc, env);
+  s7_pointer entries= s7_let_to_list (sc, sub);
+  s7_gc_protect_via_stack (sc, entries);
+  s7_pointer specs= s7_cdr (rest);
+  for (s7_pointer p= entries; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer entry= s7_car (p);
+    s7_pointer name = s7_car (entry);
+    for (s7_pointer q= specs; s7_is_pair (q); q= s7_cdr (q)) {
+      s7_pointer spec= s7_car (q);
+      if (s7_car (spec) == name) {
+        name= s7_cadr (spec);
+        break;
+      }
+    }
+    s7_varlet (sc, env, name, s7_cdr (entry));
+  }
+  s7_gc_unprotect_via_stack (sc, entries);
+  s7_gc_unprotect_via_stack (sc, env);
+  s7_gc_unprotect_via_stack (sc, sub);
+  return env;
+}
+
+/* resolve an import set to the environment of bindings it denotes */
+static s7_pointer
+r7rs_import_set_env (s7_scheme* sc, s7_pointer iset) {
+  if (r7rs_decl_named (iset, "only")) return r7rs_import_only (sc, iset);
+  if (r7rs_decl_named (iset, "except")) return r7rs_import_except (sc, iset);
+  if (r7rs_decl_named (iset, "prefix")) return r7rs_import_prefix (sc, iset);
+  if (r7rs_decl_named (iset, "rename")) return r7rs_import_rename (sc, iset);
+  /* plain library name */
+  if (!r7rs_library_name_valid (sc, iset))
+    return r7rs_library_error (sc, "wrong-type-arg", "import: invalid import set ~S", iset);
+  return r7rs_library_env (sc, iset);
+}
+
+static s7_pointer
+g_import (s7_scheme* sc, s7_pointer args) {
+  s7_gc_protect_via_stack (sc, args);
+  /* s7 applies a c-macro without changing sc->curlet, so the current let is
+   * exactly the environment in which the import form appears. */
+  s7_pointer target= s7_curlet (sc);
+  for (s7_pointer sets= args; s7_is_pair (sets); sets= s7_cdr (sets)) {
+    s7_pointer env= r7rs_import_set_env (sc, s7_car (sets));
+    s7_gc_protect_via_stack (sc, env);
+    s7_pointer entries= s7_let_to_list (sc, env);
+    s7_gc_protect_via_stack (sc, entries);
+    /* varlet prepends slots, so bindings of later import sets shadow earlier ones */
+    for (s7_pointer p= entries; s7_is_pair (p); p= s7_cdr (p)) {
+      s7_pointer entry= s7_car (p);
+      s7_varlet (sc, target, s7_car (entry), s7_cdr (entry));
+    }
+    s7_gc_unprotect_via_stack (sc, entries);
+    s7_gc_unprotect_via_stack (sc, env);
+  }
+  s7_gc_unprotect_via_stack (sc, args);
+  return s7_t (sc); /* the "expansion" #t evaluates to itself */
 }
 
 void
@@ -249,4 +467,7 @@ glue_r7rs_library (s7_scheme* sc) {
   s7_define_macro (sc, "define-library", g_define_library, 1, 0, true,
                    "(define-library libname decl ...) defines the R7RS library libname from the given declarations "
                    "(export, import, begin, ...) and registers its exported environment");
+  s7_define_macro (sc, "import", g_import, 0, 0, true,
+                   "(import import-set ...) imports the bindings denoted by each import set (a library name, "
+                   "optionally modified by only/except/prefix/rename) into the current environment");
 }

--- a/src/s7_r7rs_library.h
+++ b/src/s7_r7rs_library.h
@@ -1,0 +1,32 @@
+//
+// Copyright (C) 2026 The Goldfish Scheme Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#ifndef S7_R7RS_LIBRARY_H
+#define S7_R7RS_LIBRARY_H
+
+#include "s7.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void glue_r7rs_library (s7_scheme* sc);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* S7_R7RS_LIBRARY_H */

--- a/tests/scheme/boot-test.scm
+++ b/tests/scheme/boot-test.scm
@@ -168,4 +168,58 @@
   (define-library "not-a-list" (export x))
 ) ;check-catch
 
+;; [0112_3] C 实现的 import：嵌套修饰符（旧 Scheme 实现不支持）
+(let* ((probe-root (path-join (path-temp-dir)
+                     (string-append "goldfish-import-nest-" (number->string (getpid)))
+                   ) ;path-join
+       ) ;probe-root
+       (probe-liii (path-join probe-root "liii"))
+       (probe-file (path-join probe-liii "nestprobe.scm"))
+       (old-load-path *load-path*)
+      ) ;
+  (mkdir (path->string probe-root))
+  (mkdir (path->string probe-liii))
+  (path-write-text probe-file
+    (string-append "(define *nestprobe-load-count*\n"
+      "  (if (defined? '*nestprobe-load-count*) (+ *nestprobe-load-count* 1) 1))\n"
+      "(define-library (liii nestprobe)\n"
+      "  (export nest-a nest-b nest-c nest-d)\n"
+      "  (begin (define nest-a 1) (define nest-b 2) (define nest-c 3) (define nest-d 4)))\n"
+    ) ;string-append
+  ) ;path-write-text
+  (dynamic-wind (lambda ()
+                  (set! *load-path* (append *load-path* (list (path->string probe-root))))
+                ) ;lambda
+    (lambda ()
+      ;; only 嵌套 except
+      (import (only (except (liii nestprobe) nest-d) nest-a nest-b))
+      (check nest-a => 1)
+      (check nest-b => 2)
+      (check (defined? 'nest-c) => #f)
+      (check (defined? 'nest-d) => #f)
+      ;; 嵌套修饰符不绕过加载缓存：文件只 load 一次
+      (check *nestprobe-load-count* => 1)
+      ;; prefix 嵌套 only
+      (import (prefix (only (liii nestprobe) nest-a) pre-))
+      (check pre-nest-a => 1)
+      ;; rename 嵌套 except
+      (import (rename (except (liii nestprobe) nest-a nest-b nest-d) (nest-c renamed-c)))
+      (check renamed-c => 3)
+      (check *nestprobe-load-count* => 1)
+    ) ;lambda
+    (lambda ()
+      (set! *load-path* old-load-path)
+      (path-unlink probe-file #t)
+      (path-rmdir (path->string probe-liii))
+      (path-rmdir (path->string probe-root))
+    ) ;lambda
+  ) ;dynamic-wind
+) ;let*
+
+;; 非法 import set：报错
+(check-catch 'wrong-type-arg (import "not-a-library-name"))
+(check-catch 'wrong-type-arg (import 42))
+;; 修饰符结构不完整：报错
+(check-catch 'syntax-error (import (only)))
+
 (check-report "\n\nCheck report of boot-test.scm => ")

--- a/tests/scheme/boot-test.scm
+++ b/tests/scheme/boot-test.scm
@@ -93,4 +93,79 @@
 (check-catch 'wrong-type-arg (g_library-register! '(a -1) (inlet)))
 (check-catch 'wrong-type-arg (g_library-register! '(a) 42))
 
+;; [0112_2] C 实现的 define-library
+(define-library (goldfish test-lib-1)
+  (export greet answer)
+  (begin
+    (define (greet) "hello")
+    (define answer 42)
+    (define hidden 99)
+  ) ;begin
+) ;define-library
+
+(check (g_library-defined? '(goldfish test-lib-1)) => #t)
+(let ((env (g_library-ref '(goldfish test-lib-1))))
+  (check (procedure? (env 'greet)) => #t)
+  (check ((env 'greet)) => "hello")
+  (check (env 'answer) => 42)
+  ;; 未导出的名字不在导出环境中
+  (check (defined? 'hidden env) => #f)
+) ;let
+
+;; 与 Scheme 版 import 的互操作：C 定义的库可以被 import 引入
+(import (goldfish test-lib-1))
+(check (greet) => "hello")
+(check answer => 42)
+;; 加载缓存约定：库名对应的全局符号已定义，import 不会重复 load
+(check (defined? (symbol (object->string '(goldfish test-lib-1)))) => #t)
+
+;; 无 export 子句：库内所有绑定都被导出
+(define-library (goldfish test-lib-2)
+  (begin
+    (define pub-1 1)
+    (define pub-2 2)
+  ) ;begin
+) ;define-library
+(let ((env (g_library-ref '(goldfish test-lib-2))))
+  (check (env 'pub-1) => 1)
+  (check (env 'pub-2) => 2)
+) ;let
+
+;; export 支持 (rename old new)
+(define-library (goldfish test-lib-3)
+  (export (rename internal external))
+  (begin (define internal 7))
+) ;define-library
+(let ((env (g_library-ref '(goldfish test-lib-3))))
+  (check (env 'external) => 7)
+  (check (defined? 'internal env) => #f)
+) ;let
+
+;; 库体内 import：引入的绑定对 begin 中的代码可见
+(define-library (goldfish test-lib-4)
+  (export double-car)
+  (import (scheme base))
+  (begin (define (double-car x) (* 2 (car x))))
+) ;define-library
+(check (((g_library-ref '(goldfish test-lib-4)) 'double-car) '(3)) => 6)
+
+;; 库体内 import 的名字可以被再导出
+(define-library (goldfish test-lib-5)
+  (export car)
+  (import (only (scheme base) car))
+) ;define-library
+(check (((g_library-ref '(goldfish test-lib-5)) 'car) '(10 20)) => 10)
+
+;; 导出未定义的名字：报错
+(check-catch 'unbound-variable
+  (define-library (goldfish test-lib-bad)
+    (export missing-name)
+  ) ;define-library
+) ;check-catch
+
+;; 非法库名：报错
+(check-catch 'wrong-type-arg
+  (define-library "not-a-list" (export x))
+) ;check-catch
+
 (check-report "\n\nCheck report of boot-test.scm => ")

--- a/tests/scheme/boot-test.scm
+++ b/tests/scheme/boot-test.scm
@@ -97,7 +97,9 @@
 (define-library (goldfish test-lib-1)
   (export greet answer)
   (begin
-    (define (greet) "hello")
+    (define (greet)
+      "hello"
+    ) ;define
     (define answer 42)
     (define hidden 99)
   ) ;begin
@@ -134,7 +136,9 @@
 ;; export 支持 (rename old new)
 (define-library (goldfish test-lib-3)
   (export (rename internal external))
-  (begin (define internal 7))
+  (begin
+    (define internal 7)
+  ) ;begin
 ) ;define-library
 (let ((env (g_library-ref '(goldfish test-lib-3))))
   (check (env 'external) => 7)
@@ -145,7 +149,11 @@
 (define-library (goldfish test-lib-4)
   (export double-car)
   (import (scheme base))
-  (begin (define (double-car x) (* 2 (car x))))
+  (begin
+    (define (double-car x)
+      (* 2 (car x))
+    ) ;define
+  ) ;begin
 ) ;define-library
 (check (((g_library-ref '(goldfish test-lib-4)) 'double-car) '(3)) => 6)
 
@@ -164,9 +172,7 @@
 ) ;check-catch
 
 ;; 非法库名：报错
-(check-catch 'wrong-type-arg
-  (define-library "not-a-list" (export x))
-) ;check-catch
+(check-catch 'wrong-type-arg (define-library "not-a-list" (export x)))
 
 ;; [0112_3] C 实现的 import：嵌套修饰符（旧 Scheme 实现不支持）
 (let* ((probe-root (path-join (path-temp-dir)
@@ -203,7 +209,8 @@
       (import (prefix (only (liii nestprobe) nest-a) pre-))
       (check pre-nest-a => 1)
       ;; rename 嵌套 except
-      (import (rename (except (liii nestprobe) nest-a nest-b nest-d) (nest-c renamed-c)))
+      (import (rename (except (liii nestprobe) nest-a nest-b nest-d) (nest-c renamed-c))
+      ) ;import
       (check renamed-c => 3)
       (check *nestprobe-load-count* => 1)
     ) ;lambda
@@ -221,5 +228,171 @@
 (check-catch 'wrong-type-arg (import 42))
 ;; 修饰符结构不完整：报错
 (check-catch 'syntax-error (import (only)))
+
+;; [0112_4] define-library 支持 cond-expand 声明
+;; 特性条件：r7rs 特性已注册
+(define-library (goldfish test-lib-ce1)
+  (export ce1-value)
+  (cond-expand (r7rs (begin (define ce1-value 'from-r7rs)))
+               (else (begin (define ce1-value 'from-else)))
+  ) ;cond-expand
+) ;define-library
+(check ((g_library-ref '(goldfish test-lib-ce1)) 'ce1-value) => 'from-r7rs)
+
+;; else 分支
+(define-library (goldfish test-lib-ce2)
+  (export ce2-value)
+  (cond-expand (no-such-feature-xyz (begin (define ce2-value 1)))
+               (else (begin (define ce2-value 2)))
+  ) ;cond-expand
+) ;define-library
+(check ((g_library-ref '(goldfish test-lib-ce2)) 'ce2-value) => 2)
+
+;; and/or/not 组合
+(define-library (goldfish test-lib-ce3)
+  (export ce3-value)
+  (cond-expand ((and r7rs (not no-such-feature-xyz)) (begin (define ce3-value 'and-ok)))
+               (else (begin (define ce3-value 'bad)))
+  ) ;cond-expand
+) ;define-library
+(check ((g_library-ref '(goldfish test-lib-ce3)) 'ce3-value) => 'and-ok)
+
+(define-library (goldfish test-lib-ce3b)
+  (export ce3b-value)
+  (cond-expand ((or no-such-feature-xyz (and r7rs no-such-feature-abc))
+                (begin
+                  (define ce3b-value 'bad)
+                ) ;begin
+               ) ;
+               (else (begin (define ce3b-value 'or-ok)))
+  ) ;cond-expand
+) ;define-library
+(check ((g_library-ref '(goldfish test-lib-ce3b)) 'ce3b-value) => 'or-ok)
+
+;; (library ...) 条件：可加载的库
+(define-library (goldfish test-lib-ce4)
+  (export ce4-value)
+  (cond-expand ((library (liii base)) (begin (define ce4-value 'has-base)))
+               (else (begin (define ce4-value 'no-base)))
+  ) ;cond-expand
+) ;define-library
+(check ((g_library-ref '(goldfish test-lib-ce4)) 'ce4-value) => 'has-base)
+
+;; (library ...) 条件：不存在的库
+(define-library (goldfish test-lib-ce5)
+  (export ce5-value)
+  (cond-expand ((library (no-such lib-xyz)) (begin (define ce5-value 'bad)))
+               (else (begin (define ce5-value 'good)))
+  ) ;cond-expand
+) ;define-library
+(check ((g_library-ref '(goldfish test-lib-ce5)) 'ce5-value) => 'good)
+
+;; cond-expand 中的 export 子句
+(define-library (goldfish test-lib-ce6)
+  (cond-expand (r7rs (export ce6-func))
+               (else)
+  ) ;cond-expand
+  (begin
+    (define (ce6-func)
+      6
+    ) ;define
+  ) ;begin
+) ;define-library
+(check (((g_library-ref '(goldfish test-lib-ce6)) 'ce6-func)) => 6)
+
+;; cond-expand 中的 import 子句
+(define-library (goldfish test-lib-ce7)
+  (export ce7-car)
+  (cond-expand (r7rs (import (only (scheme base) car)))
+               (else)
+  ) ;cond-expand
+  (begin
+    (define (ce7-car x)
+      (car x)
+    ) ;define
+  ) ;begin
+) ;define-library
+(check (((g_library-ref '(goldfish test-lib-ce7)) 'ce7-car) '(9 8)) => 9)
+
+;; cond-expand 嵌套
+(define-library (goldfish test-lib-ce8)
+  (export ce8-value)
+  (cond-expand (r7rs (cond-expand (no-such-feature-xyz (begin (define ce8-value 'bad)))
+                                  (else (begin (define ce8-value 'nested-ok)))
+                     ) ;cond-expand
+               ) ;r7rs
+               (else (begin (define ce8-value 'bad2)))
+  ) ;cond-expand
+) ;define-library
+(check ((g_library-ref '(goldfish test-lib-ce8)) 'ce8-value) => 'nested-ok)
+
+;; 表达式级 cond-expand（C 版，同样支持 (library ...) 条件）
+(check (cond-expand (r7rs 'r7rs-ok) (else 'bad)) => 'r7rs-ok)
+(check (cond-expand (no-such-feature-xyz 'bad) (else 'else-ok)) => 'else-ok)
+(check (cond-expand ((library (liii base)) 'lib-ok) (else 'bad)) => 'lib-ok)
+(check (cond-expand ((and r7rs (not no-such-feature-xyz)) 'and-ok)
+                    (else 'bad)
+       ) ;cond-expand
+  =>
+  'and-ok
+) ;check
+(check (cond-expand ((or no-such-feature-xyz r7rs) 'or-ok)
+                    (else 'bad)
+       ) ;cond-expand
+  =>
+  'or-ok
+) ;check
+
+;; [0112_5] define-library 支持 include / include-ci / include-library-declarations
+(let* ((probe-root (path-join (path-temp-dir)
+                     (string-append "goldfish-include-" (number->string (getpid)))
+                   ) ;path-join
+       ) ;probe-root
+       (probe-liii (path-join probe-root "liii"))
+       (old-load-path *load-path*)
+      ) ;
+  (mkdir (path->string probe-root))
+  (mkdir (path->string probe-liii))
+  ;; 实现文件与声明文件都放在库文件旁边（include 按库文件所在目录解析）
+  (path-write-text (path-join probe-liii "incimpl.scm")
+    "(define (inc-func) 100)\n(define (inc-ci-func) 7)\n(define inc-hidden 1)\n"
+  ) ;path-write-text
+  (path-write-text (path-join probe-liii "incdecls.scm")
+    "(export inc-func inc-ci-func)\n"
+  ) ;path-write-text
+  (path-write-text (path-join probe-liii "inclib.scm")
+    (string-append "(define-library (liii inclib)\n"
+      "  (include-library-declarations \"incdecls.scm\")\n"
+      "  (import (scheme base))\n" "  (include \"incimpl.scm\")\n"
+      "  (cond-expand (r7rs (include-ci \"incimpl.scm\")) (else)))\n"
+    ) ;string-append
+  ) ;path-write-text
+  (dynamic-wind (lambda ()
+                  (set! *load-path* (append *load-path* (list (path->string probe-root))))
+                ) ;lambda
+    (lambda ()
+      (import (liii inclib))
+      (check (inc-func) => 100)
+      (check (inc-ci-func) => 7)
+      ;; 未被 include-library-declarations 导出的名字不可见
+      (check (defined? 'inc-hidden) => #f)
+    ) ;lambda
+    (lambda ()
+      (set! *load-path* old-load-path)
+      (path-unlink (path-join probe-liii "incimpl.scm") #t)
+      (path-unlink (path-join probe-liii "incdecls.scm") #t)
+      (path-unlink (path-join probe-liii "inclib.scm") #t)
+      (path-rmdir (path->string probe-liii))
+      (path-rmdir (path->string probe-root))
+    ) ;lambda
+  ) ;dynamic-wind
+) ;let*
+
+;; include 找不到文件：报错
+(check-catch 'io-error
+  (define-library (goldfish test-lib-incbad)
+    (include "no-such-file-xyz.scm")
+  ) ;define-library
+) ;check-catch
 
 (check-report "\n\nCheck report of boot-test.scm => ")

--- a/tests/scheme/boot-test.scm
+++ b/tests/scheme/boot-test.scm
@@ -42,10 +42,8 @@
   (path-write-text probe-file
     (string-append "(define *cacheprobe-load-count*\n"
       "  (if (defined? '*cacheprobe-load-count*) (+ *cacheprobe-load-count* 1) 1))\n"
-      "(define-library (liii cacheprobe)\n"
-      "  (export probe-func)\n"
-      "  (import (scheme base))\n"
-      "  (begin (define (probe-func) 42)))\n"
+      "(define-library (liii cacheprobe)\n" "  (export probe-func)\n"
+      "  (import (scheme base))\n" "  (begin (define (probe-func) 42)))\n"
     ) ;string-append
   ) ;path-write-text
   (dynamic-wind (lambda ()
@@ -67,5 +65,32 @@
     ) ;lambda
   ) ;dynamic-wind
 ) ;let*
+
+;; [0112_1] C 实现的 R7RS 库注册表基础设施
+(let ((probe-env (inlet 'probe-x 1 'probe-y 2)))
+  (check (g_library-defined? '(goldfish test-probe)) => #f)
+  (check (g_library-ref '(goldfish test-probe)) => #f)
+  (g_library-register! '(goldfish test-probe) probe-env)
+  (check (g_library-defined? '(goldfish test-probe)) => #t)
+  (check (eq? (g_library-ref '(goldfish test-probe)) probe-env) => #t)
+  (check ((g_library-ref '(goldfish test-probe)) 'probe-x) => 1)
+  ;; 重复注册：覆盖
+  (let ((env2 (inlet 'probe-z 3)))
+    (g_library-register! '(goldfish test-probe) env2)
+    (check (eq? (g_library-ref '(goldfish test-probe)) env2) => #t)
+    (check ((g_library-ref '(goldfish test-probe)) 'probe-z) => 3)
+  ) ;let
+  ;; 卸载
+  (g_library-unregister! '(goldfish test-probe))
+  (check (g_library-defined? '(goldfish test-probe)) => #f)
+  (check (g_library-ref '(goldfish test-probe)) => #f)
+) ;let
+
+;; 库名必须是 proper list，元素为 symbol 或非负整数（R7RS）
+(check-catch 'wrong-type-arg (g_library-defined? "not-a-list"))
+(check-catch 'wrong-type-arg (g_library-defined? '(a . b)))
+(check-catch 'wrong-type-arg (g_library-register! '(a 1.5) (inlet)))
+(check-catch 'wrong-type-arg (g_library-register! '(a -1) (inlet)))
+(check-catch 'wrong-type-arg (g_library-register! '(a) 42))
 
 (check-report "\n\nCheck report of boot-test.scm => ")

--- a/xmake.lua
+++ b/xmake.lua
@@ -128,6 +128,7 @@ target ("goldfish") do
     add_files ("src/s7_liii_list.c", {languages = "c11"})
     add_files ("src/s7_liii_vector.c", {languages = "c11"})
     add_files ("src/s7_module.c", {languages = "c11"})
+    add_files ("src/s7_r7rs_library.c", {languages = "c11"})
     add_files ("src/s7_scheme_inexact.c", {languages = "c11"})
     add_files ("src/s7_scheme_base.c", {languages = "c11"})
     add_files ("src/s7_scheme_symbol.c", {languages = "c11"})


### PR DESCRIPTION
## 概述

将 boot.scm 中基于 define-macro 的 define-library / import 迁移到 C 实现（新增 src/s7_r7rs_library.c/h，不改动 s7.c），boot.scm 的 Scheme 版保留为后备（`unless (defined? ...)` 包裹）。详见 devel/0112.md。

## 变更内容

1. **C 侧库注册表**：`*r7rs-libraries*` hash table + `g_library-register!/defined?/ref/unregister!` 原语
2. **C 版 define-library**：export（含 `(rename old new)`）、import、begin、cond-expand、include / include-ci / include-library-declarations 声明全覆盖
3. **C 版 import**：only/except/prefix/rename 修饰符**支持任意嵌套**；注册表加载缓存保证任何修饰形式只 load 一次；库名支持整数组件（`(srfi 1)`）
4. **C 版 cond-expand**：替换 s7 内置读时 expansion，新增 `(library ...)` 条件支持
5. **清理幽灵导出**：导出但未实现的名字现在按 R7RS 报 unbound-variable；修正了 6 个库文件的导出列表（如 `(scheme base)` 误导出属于 `(scheme file)` 的 open-binary-input-file）

## 兼容性修复（旧实现的缺陷）

- 旧实现不支持嵌套修饰符，`(only (except ...) ...)` 会报错或重复 load
- 旧实现在 cond-expand 子句含多个声明形式时展开错误

## 测试与性能

- 全量测试 1493/1493 通过；boot-test.scm 69 项（新增约 45 项用例）
- 单进程加载全部 102 个库：60ms → 47ms（约 22% 提升）；进程启动时间不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)