### PR TITLE
[0113] 在 (liii base) 导出 sort! 并补充文档和测试

### DIFF
--- a/devel/0113.md
+++ b/devel/0113.md
@@ -1,0 +1,44 @@
+# [0113] 在 (liii base) 导出 sort! 并补充文档和测试
+
+## 任务相关的代码文件
+- goldfish/liii/base.scm
+- tests/liii/base/sort-bang-test.scm（新增）
+
+## 如何测试
+```bash
+# 1. 构建
+xmake b goldfish
+
+# 2. 格式化
+bin/gf fmt goldfish/liii/base.scm
+bin/gf fmt tests/liii/base/sort-bang-test.scm
+
+# 3. 运行测试
+bin/gf tests/liii/base/sort-bang-test.scm
+
+# 4. 重建文档索引并查看文档
+bin/gf doc --build-json
+bin/gf doc "sort!"
+```
+
+## 2026-08-14 在 (liii base) 导出 sort! 并补充文档和测试
+### What
+1. `goldfish/liii/base.scm` 的 export 列表新增 `sort!`（S7 内置函数，
+   与 `reverse!` 同样模式，无需在 begin 中定义）
+2. 新增 `tests/liii/base/sort-bang-test.scm`：17 个测试用例，覆盖
+   列表/向量/字符串排序、原地修改语义（返回值 eq? 原对象、别名可见）、
+   边界情况和错误处理；文件头部包含完整文档注释
+3. 执行 `bin/gf doc --build-json` 重建索引后，`bin/gf doc "sort!"` 可查看文档
+
+### Why
+`sort!` 是 S7 内置的原地排序函数，支持列表、向量和字符串，
+此前未在 (liii base) 中导出，也没有文档和测试。
+
+### How
+- 文档中重点说明了 `sort!` 与 (liii sort) 中 `list-sort!` 的区别：
+  1. 参数顺序相反：`(sort! seq less?)` 序列在前，
+     `(list-sort! less? lst)` 比较函数在前
+  2. 破坏方式不同：`sort!` 只重写各 pair 的 car（骨架不变，
+     返回值与输入 eq?），`list-sort!` 允许 set-cdr! 重接链表
+  3. `sort!` 是不稳定排序（基于 C qsort），需要稳定排序时应使用
+     `list-stable-sort!` / `vector-stable-sort!`

--- a/goldfish/liii/base.scm
+++ b/goldfish/liii/base.scm
@@ -5,7 +5,7 @@
     string->keyword symbol->keyword keyword->symbol loose-car loose-cdr compose
     identity any? typed-lambda make-hook hook-functions with-output-to-string
     with-input-from-string call-with-input-string call-with-output-string
-    reverse! format
+    reverse! sort! format
   ) ;export
   (begin
 

--- a/tests/liii/base/sort-bang-test.scm
+++ b/tests/liii/base/sort-bang-test.scm
@@ -1,0 +1,98 @@
+(import (liii check) (liii base))
+
+(check-set-mode! 'report-failed)
+
+;; sort!
+;; 对序列进行原地排序，返回排序后的序列本身（S7 内置函数）。
+;;
+;; 语法
+;; ----
+;; (sort! seq less?)
+;;
+;; 参数
+;; ----
+;; seq : list? 或 vector? 或 string?
+;;     要排序的序列。
+;;
+;; less? : procedure
+;;     比较函数，接受两个元素，当第一个元素应排在前面时返回 #t。
+;;
+;; 返回值
+;; ------
+;; list? 或 vector? 或 string?
+;;     排序后的序列，与输入 seq 是同一个对象（eq? 为 #t）。
+;;
+;; 说明
+;; ----
+;; 1. 原地排序：对列表只重写各 pair 的 car，列表骨架（cdr 链）保持不变，
+;;    因此所有指向该列表的别名都能观察到排序结果
+;; 2. 不稳定排序：比较结果相等的元素，排序后的相对顺序不保证与原来一致；
+;;    需要稳定排序时请使用 (liii sort) 的 list-stable-sort! 或 vector-stable-sort!
+;; 3. 支持列表、向量和字符串；字符串按字符排序，比较函数常用 char<?
+;; 4. 与 (liii sort) 的 list-sort! 参数顺序不同：
+;;    内置 sort! 是 (sort! seq less?)，序列在前；
+;;    SRFI-132 的 list-sort! 是 (list-sort! less? lst)，比较函数在前
+;; 5. 比较函数必须一致（不能对相同的两个元素返回矛盾的结果），
+;;    否则可能触发死循环检测而报错
+;;
+;; 与 list-sort! 的区别
+;; -------------------
+;; sort!       保证返回与输入同一个对象，只改 car 不动列表骨架；
+;; list-sort!  允许用 set-cdr! 重接链表，调用后必须使用返回值，
+;;             不能再依赖原列表变量的结构。
+;;
+;; 相关函数
+;; --------
+;; list-sort!        - (liii sort) 中的列表排序，比较函数在前
+;; list-stable-sort! - (liii sort) 中的稳定列表排序
+;; vector-sort!      - (liii sort) 中的向量排序
+;;
+;; 错误处理
+;; --------
+;; 当 seq 不是序列时抛出 wrong-type-arg 错误；
+;; 当 less? 不是可接受两个参数的函数时抛出错误。
+
+;; 列表排序：升序与降序
+(check (sort! (list 3 1 2) <) => '(1 2 3))
+(check (sort! (list 3 1 4 1 5 9 2 6) <) => '(1 1 2 3 4 5 6 9))
+(check (sort! (list 1 2 3) >) => '(3 2 1))
+
+;; 边界情况
+(check (sort! '() <) => '())
+(check (sort! (list 42) <) => '(42))
+
+;; 返回值与输入是同一个对象
+(let ((xs (list 3 1 2)))
+  (check-true (eq? xs (sort! xs <)))
+  (check xs => '(1 2 3))
+) ;let
+
+;; 列表骨架不变：别名可见排序结果
+(let ((xs (list 3 1 2)))
+  (let ((alias xs))
+    (sort! xs <)
+    (check alias => '(1 2 3))
+  ) ;let
+) ;let
+
+;; 向量排序
+(check (sort! (vector 3 1 2) <) => #(1 2 3))
+(check (sort! (vector 5 4 3 2 1) >) => #(5 4 3 2 1))
+(let ((v (vector 3 1 2)))
+  (check-true (eq? v (sort! v <)))
+  (check v => #(1 2 3))
+) ;let
+
+;; 字符串排序（按字符）
+(check (sort! (string #\c #\b #\a) char<?) => "abc")
+(check (sort! (string #\b #\a #\c) char>?) => "cba")
+
+;; 自定义比较函数：按字符串长度排序
+(check (sort! (list "ccc" "a" "bb") (lambda (x y) (< (string-length x) (string-length y))))
+  => '("a" "bb" "ccc"))
+
+;; 错误处理：非序列参数
+(check-catch 'wrong-type-arg (sort! 42 <))
+(check-catch 'wrong-type-arg (sort! #t <))
+
+(check-report)


### PR DESCRIPTION
## 概述
在 `(liii base)` 中导出 S7 内置的 `sort!` 函数，并补充文档和单元测试，使 `bin/gf doc "sort!"` 可以查看文档。

## 改动
- `goldfish/liii/base.scm`：export 列表新增 `sort!`（与 `reverse!` 同模式，无需在 begin 中定义）
- `tests/liii/base/sort-bang-test.scm`：新增，17 个测试用例 + 完整文档注释
- `devel/0113.md`：任务文档

## 文档重点说明
- `sort!` 是**不稳定**原地排序（基于 C qsort），需要稳定排序时应使用 `list-stable-sort!` / `vector-stable-sort!`
- 与 `(liii sort)` 的 `list-sort!` 参数顺序相反：`(sort! seq less?)` 序列在前
- `sort!` 只重写各 pair 的 car，列表骨架不变，返回值与输入 `eq?`

## 测试
```bash
bin/gf tests/liii/base/sort-bang-test.scm   # 17 correct, 0 failed
bin/gf doc --build-json && bin/gf doc "sort!"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)