### PR TITLE
[0113] list-sort! 实现替换为 S7 内置 sort! 并添加 bench

### DIFF
--- a/bench/list-sort-bang.scm
+++ b/bench/list-sort-bang.scm
@@ -1,0 +1,118 @@
+;; list-sort! 性能基准测试
+;; 对比旧 Scheme 快速排序实现（已修正丢弃 pivot 的 bug，以便公平对比）
+;; 与新实现（基于 S7 内置 sort!，C qsort）
+
+(import (liii timeit) (scheme base) (liii sort) (liii list))
+
+;; 旧 Scheme 实现（srfi-132 中的快速排序，修正了丢弃 pivot 的 bug）
+
+(define (list-sort!-scheme less-p lst)
+  (define (partition! lst pivot less-p)
+    (let loop
+      ((lst lst) (less '()) (greater '()))
+      (cond ((null? lst) (values (reverse less) (reverse greater)))
+            ((less-p (car lst) pivot) (loop (cdr lst) (cons (car lst) less) greater))
+            (else (loop (cdr lst) less (cons (car lst) greater)))
+      ) ;cond
+    ) ;let
+  ) ;define
+  (if (or (null? lst) (null? (cdr lst)))
+    lst
+    (let* ((pivot (car lst)))
+      (call-with-values (lambda () (partition! (cdr lst) pivot less-p))
+        (lambda (less greater)
+          (let ((sorted-less (list-sort!-scheme less-p less))
+                (sorted-greater (list-sort!-scheme less-p greater))
+               ) ;
+            (if (null? sorted-less)
+              (cons pivot sorted-greater)
+              (begin
+                (set-cdr! (last-pair sorted-less) (cons pivot sorted-greater))
+                sorted-less
+              ) ;begin
+            ) ;if
+          ) ;let
+        ) ;lambda
+      ) ;call-with-values
+    ) ;let*
+  ) ;if
+) ;define
+
+(define (bench name stmt number)
+  (let ((elapsed (timeit stmt '() number)))
+    (display name)
+    (display ": ")
+    (display elapsed)
+    (display " 秒 (")
+    (display number)
+    (display " 次)\n")
+  ) ;let
+) ;define
+
+;; 确定性伪随机列表（线性同余生成器），保证两次实现面对相同数据
+
+(define (make-random-list n)
+  (let loop
+    ((i n) (seed 12345) (acc '()))
+    (if (= i 0)
+      acc
+      (let ((next (modulo (+ (* seed 1103515245) 12345) 2147483648)))
+        (loop (- i 1) next (cons (modulo next 100000) acc))
+      ) ;let
+    ) ;if
+  ) ;let
+) ;define
+
+(define data-random-1000 (make-random-list 1000))
+
+(define data-random-10000 (make-random-list 10000))
+
+(define data-sorted-1000 (iota 1000))
+
+(define data-reverse-1000 (reverse (iota 1000)))
+
+(define (run-benchmarks)
+  (display "=== list-sort! 性能测试 ===\n\n")
+
+  ;; 随机数据（1000 元素）
+  (bench "Scheme 随机列表(1000)   "
+    (lambda () (list-sort!-scheme < (append data-random-1000 '())))
+    100
+  ) ;bench
+  (bench "sort!  随机列表(1000)   "
+    (lambda () (list-sort! < (append data-random-1000 '())))
+    100
+  ) ;bench
+
+  ;; 随机数据（10000 元素）
+  (bench "Scheme 随机列表(10000)  "
+    (lambda () (list-sort!-scheme < (append data-random-10000 '())))
+    10
+  ) ;bench
+  (bench "sort!  随机列表(10000)  "
+    (lambda () (list-sort! < (append data-random-10000 '())))
+    10
+  ) ;bench
+
+  ;; 已排序数据（快速排序最坏情况之一：pivot 恒为最小值）
+  (bench "Scheme 有序列表(1000)   "
+    (lambda () (list-sort!-scheme < (append data-sorted-1000 '())))
+    100
+  ) ;bench
+  (bench "sort!  有序列表(1000)   "
+    (lambda () (list-sort! < (append data-sorted-1000 '())))
+    100
+  ) ;bench
+
+  ;; 逆序数据
+  (bench "Scheme 逆序列表(1000)   "
+    (lambda () (list-sort!-scheme < (append data-reverse-1000 '())))
+    100
+  ) ;bench
+  (bench "sort!  逆序列表(1000)   "
+    (lambda () (list-sort! < (append data-reverse-1000 '())))
+    100
+  ) ;bench
+) ;define
+
+(run-benchmarks)

--- a/devel/0113.md
+++ b/devel/0113.md
@@ -2,7 +2,10 @@
 
 ## 任务相关的代码文件
 - goldfish/liii/base.scm
+- goldfish/srfi/srfi-132.scm
 - tests/liii/base/sort-bang-test.scm（新增）
+- tests/liii/sort/list-sort-bang-test.scm
+- bench/list-sort-bang.scm（新增）
 
 ## 如何测试
 ```bash
@@ -11,15 +14,55 @@ xmake b goldfish
 
 # 2. 格式化
 bin/gf fmt goldfish/liii/base.scm
+bin/gf fmt goldfish/srfi/srfi-132.scm
 bin/gf fmt tests/liii/base/sort-bang-test.scm
+bin/gf fmt tests/liii/sort/list-sort-bang-test.scm
+bin/gf fmt bench/list-sort-bang.scm
 
 # 3. 运行测试
 bin/gf tests/liii/base/sort-bang-test.scm
+bin/gf tests/liii/sort/list-sort-bang-test.scm
 
-# 4. 重建文档索引并查看文档
+# 4. 运行性能基准
+bin/gf bench/list-sort-bang.scm
+
+# 5. 重建文档索引并查看文档
 bin/gf doc --build-json
 bin/gf doc "sort!"
+bin/gf doc "list-sort!"
 ```
+
+## 2026-08-14 list-sort! 实现替换为 S7 内置 sort!，并添加 bench
+### What
+1. `goldfish/srfi/srfi-132.scm` 的 `list-sort!` 改为基于 S7 内置 `sort!`
+   的薄封装：`(define (list-sort! less-p lis) (sort! lis less-p))`
+2. 新增 `bench/list-sort-bang.scm`：对比旧 Scheme 快速排序实现
+   （已修正丢 pivot 的 bug 以便公平对比）与新实现的性能
+3. 完善 `tests/liii/sort/list-sort-bang-test.scm`：从 9 个仅检查
+   list-sorted? 的弱断言扩充为 19 个用例，覆盖精确内容、eq? 同一性、
+   别名可见、重复元素、自定义比较器、大列表和错误处理
+4. 同步更新 `tests/liii/base/sort-bang-test.scm` 中已过时的
+   "与 list-sort! 的区别"段落
+
+### Why
+1. 旧实现有 bug：当小于 pivot 的部分为空时返回 sorted-greater，
+   把 pivot 丢掉了（如 `(list-sort! < (list 1 2 3 4 5))` 返回 `(5)`）。
+   旧测试只用 list-sorted? 检查结果，丢元素后的截断列表依然有序，
+   所以 bug 一直未被发现——这也是本次加强测试的直接原因
+2. 性能：新实现基于 C qsort，随机 1000 元素快约 12 倍；
+   有序/逆序输入下旧快速排序退化为 O(n^2)（4.35 秒 vs 0.004 秒，
+   100 次），新实现快约 1000 倍
+3. 语义更好：sort! 只重写各 pair 的 car，列表骨架不变，
+   返回值与输入 eq?，所有别名都能观察到排序结果
+
+### How
+- `sort!` 是 S7 内置函数，在 define-library 的 begin 中直接可用，
+  无需额外 import（与 reverse! 同样模式）
+- bench 中旧实现修正了丢 pivot 的 bug（sorted-less 为空时返回
+  `(cons pivot sorted-greater)`），否则对比不公平（旧实现丢元素，
+  做的功更少）
+- bench 使用确定性线性同余生成器构造伪随机数据，
+  保证两种实现面对相同输入
 
 ## 2026-08-14 在 (liii base) 导出 sort! 并补充文档和测试
 ### What

--- a/goldfish/srfi/srfi-132.scm
+++ b/goldfish/srfi/srfi-132.scm
@@ -106,45 +106,12 @@
       ) ;if
     ) ;define
 
-    (define (list-sort! less-p lst)
-      ;; 辅助函数：将列表分成小于和大于 pivot 的部分
-      (define (partition! lst pivot less-p)
-        (let loop
-          ((lst lst) (less '()) (greater '()))
-          (cond ((null? lst) (values (reverse less) (reverse greater)))
-                ;; 返回小于和大于部分
-                ((less-p (car lst) pivot) (loop (cdr lst) (cons (car lst) less) greater))
-                (else (loop (cdr lst) less (cons (car lst) greater)))
-          ) ;cond
-        ) ;let
-      ) ;define
-      ;; 排序函数：原地排序
-      (if (or (null? lst) (null? (cdr lst)))
-        ;; 如果列表为空或只有一个元素，已经排序好
-        lst
-        (let* ((pivot (car lst)))
-          (call-with-values (lambda () (partition! (cdr lst) pivot less-p))
-            ;; 调用 partition 并返回小于和大于部分
-            (lambda (less greater)
-              ;; 对小于和大于部分递归排序
-              (let ((sorted-less (list-sort! less-p less))
-                    (sorted-greater (list-sort! less-p greater))
-                   ) ;
-                ;; 如果 sorted-less 是空，直接返回 sorted-greater
-                (if (null? sorted-less)
-                  sorted-greater
-                  (begin
-                    ;; 原地连接两个部分和 pivot
-                    (set-cdr! (last-pair sorted-less) (cons pivot sorted-greater))
-                    sorted-less
-                    ;; 返回排序后的列表
-                  ) ;begin
-                ) ;if
-              ) ;let
-            ) ;lambda
-          ) ;call-with-values
-        ) ;let*
-      ) ;if
+    ;; list-sort! 复用 S7 内置的 sort!：基于 C qsort 的原地排序，
+    ;; 只重写各 pair 的 car，列表骨架不变，返回值与输入 eq?。
+    ;; 注意参数顺序相反：list-sort! 是 (list-sort! less-p lis)，
+    ;; 内置 sort! 是 (sort! seq less?)。
+    (define (list-sort! less-p lis)
+      (sort! lis less-p)
     ) ;define
 
     (define list-stable-sort!

--- a/tests/liii/base/sort-bang-test.scm
+++ b/tests/liii/base/sort-bang-test.scm
@@ -37,9 +37,11 @@
 ;;
 ;; 与 list-sort! 的区别
 ;; -------------------
-;; sort!       保证返回与输入同一个对象，只改 car 不动列表骨架；
-;; list-sort!  允许用 set-cdr! 重接链表，调用后必须使用返回值，
-;;             不能再依赖原列表变量的结构。
+;; (liii sort) 的 list-sort! 是基于 sort! 的薄封装，两者原地排序的
+;; 语义一致（只改 car 不动列表骨架，返回值与输入 eq?），区别在于：
+;; sort!       支持列表、向量和字符串，参数顺序是 (sort! seq less?)；
+;; list-sort!  只支持列表，参数顺序是 (list-sort! less? lst)，
+;;             比较函数在前（SRFI-132 约定）。
 ;;
 ;; 相关函数
 ;; --------
@@ -88,8 +90,12 @@
 (check (sort! (string #\b #\a #\c) char>?) => "cba")
 
 ;; 自定义比较函数：按字符串长度排序
-(check (sort! (list "ccc" "a" "bb") (lambda (x y) (< (string-length x) (string-length y))))
-  => '("a" "bb" "ccc"))
+(check (sort! (list "ccc" "a" "bb")
+         (lambda (x y) (< (string-length x) (string-length y)))
+       ) ;sort!
+  =>
+  '("a" "bb" "ccc")
+) ;check
 
 ;; 错误处理：非序列参数
 (check-catch 'wrong-type-arg (sort! 42 <))

--- a/tests/liii/sort/list-sort-bang-test.scm
+++ b/tests/liii/sort/list-sort-bang-test.scm
@@ -1,20 +1,18 @@
-(import (liii check) (liii sort))
-
+(import (liii check) (liii sort) (liii list))
 
 (check-set-mode! 'report-failed)
 
-
 ;; list-sort!
-;; 对列表进行破坏性快速排序。
+;; 对列表进行原地排序（破坏性操作），返回排序后的列表本身。
 ;;
 ;; 语法
 ;; ----
-;; (list-sort! cmp lst)
+;; (list-sort! less? lst)
 ;;
 ;; 参数
 ;; ----
-;; cmp : procedure
-;; 比较函数，接受两个参数，返回布尔值。
+;; less? : procedure
+;; 比较函数，接受两个元素，当第一个元素应排在前面时返回 #t。
 ;;
 ;; lst : list
 ;; 要排序的列表。
@@ -22,33 +20,83 @@
 ;; 返回值
 ;; ----
 ;; list
-;; 排序后的列表（原地修改）。
+;; 排序后的列表，与输入 lst 是同一个对象（eq? 为 #t）。
 ;;
-;; 注意
+;; 说明
 ;; ----
-;; 这是一个破坏性操作，原列表会被修改。
+;; 1. 本实现基于 S7 内置的 sort!：只重写各 pair 的 car，
+;;    列表骨架（cdr 链）保持不变，因此所有指向该列表的别名
+;;    都能观察到排序结果
+;; 2. 不稳定排序：比较结果相等的元素，排序后的相对顺序不保证
+;;    与原来一致；需要稳定排序时请使用 list-stable-sort!
+;; 3. 与内置 sort! 的参数顺序不同：
+;;    list-sort! 是 (list-sort! less? lst)，比较函数在前；
+;;    内置 sort! 是 (sort! seq less?)，序列在前
 ;;
 ;; 示例
 ;; ----
-;; (list-sort! < '(1 5 1 0 -1 9 2 4 3)) => 排序后的列表
+;; (list-sort! < (list 1 5 1 0 -1 9 2 4 3)) => '(-1 0 1 1 2 3 4 5 9)
 ;;
 ;; 错误处理
 ;; ----
-;; 无
+;; 当 lst 不是列表时抛出 wrong-type-arg 错误。
 
-
-(check-true (list-sorted? < (list-sort! < '(1 5 1 0 -1 9 2 4 3))))
-(check-true (list-sorted? < (list-sort! < '(9 7 5 3 2 8 6 4 1))))
-(check-true (list-sorted? < (list-sort! < '())))
-(check-true (list-sorted? < (list-sort! < '(42))))
-(check-true (list-sorted? < (list-sort! < '(1 2 3 4 5))))
-(check-true (list-sorted? < (list-sort! < '(3 1 4 1 5 9 2 6 5 3 5))))
-(check-true (list-sorted? < (list-sort! < '(0 -1 2 -2 3 1))))
-(check-true (list-sorted? < (list-sort! < '(5 -3 0 2 1 -1 4))))
-
+;; 基本升序排序：精确内容断言
+(check (list-sort! < (list 3 1 4 1 5 9 2 6 5)) => '(1 1 2 3 4 5 5 6 9))
+(check (list-sort! < (list 1 5 1 0 -1 9 2 4 3)) => '(-1 0 1 1 2 3 4 5 9))
 
 ;; 降序排序
-(check-true (list-sorted? > (list-sort! > '(1 5 1 0 -1 9 2 4 3))))
+(check (list-sort! > (list 1 5 1 0 -1 9 2 4 3)) => '(9 5 4 3 2 1 1 0 -1))
 
+;; 边界情况：空列表与单元素
+(check (list-sort! < '()) => '())
+(check (list-sort! < (list 42)) => '(42))
+
+;; 已排序与逆序输入
+(check (list-sort! < (list 1 2 3 4 5)) => '(1 2 3 4 5))
+(check (list-sort! < (list 5 4 3 2 1)) => '(1 2 3 4 5))
+
+;; 重复元素与全相同元素
+(check (list-sort! < (list 3 1 4 1 5 9 2 6 5 3 5)) => '(1 1 2 3 3 4 5 5 5 6 9))
+(check (list-sort! < (list 7 7 7 7)) => '(7 7 7 7))
+
+;; 含负数
+(check (list-sort! < (list 0 -1 2 -2 3 1)) => '(-2 -1 0 1 2 3))
+(check (list-sort! < (list 5 -3 0 2 1 -1 4)) => '(-3 -1 0 1 2 4 5))
+
+;; 字符串列表
+(check (list-sort! string<? (list "pear" "apple" "banana"))
+  =>
+  '("apple" "banana" "pear")
+) ;check
+
+;; 自定义比较函数：按字符串长度排序
+(check (list-sort! (lambda (x y) (< (string-length x) (string-length y)))
+         (list "ccc" "a" "bb")
+       ) ;list-sort!
+  =>
+  '("a" "bb" "ccc")
+) ;check
+
+;; 返回值与输入是同一个对象
+(let ((xs (list 3 1 2)))
+  (check-true (eq? xs (list-sort! < xs)))
+  (check xs => '(1 2 3))
+) ;let
+
+;; 列表骨架不变：别名可见排序结果
+(let ((xs (list 3 1 2)))
+  (let ((alias xs))
+    (list-sort! < xs)
+    (check alias => '(1 2 3))
+  ) ;let
+) ;let
+
+;; 较大列表：验证排序正确性
+(check-true (list-sorted? < (list-sort! < (reverse (iota 1000)))))
+(check (list-sort! < (reverse (iota 10))) => (iota 10))
+
+;; 错误处理：非列表参数
+(check-catch 'wrong-type-arg (list-sort! < 42))
 
 (check-report)


### PR DESCRIPTION
## What
1. `goldfish/srfi/srfi-132.scm` 的 `list-sort!` 改为基于 S7 内置 `sort!` 的薄封装：`(define (list-sort! less-p lis) (sort! lis less-p))`
2. 新增 `bench/list-sort-bang.scm`：对比旧 Scheme 快速排序实现（已修正丢 pivot 的 bug 以便公平对比）与新实现的性能
3. 完善 `tests/liii/sort/list-sort-bang-test.scm`：从 9 个仅检查 list-sorted? 的弱断言扩充为 19 个用例（精确内容、eq? 同一性、别名可见、重复元素、自定义比较器、大列表、错误处理）
4. 同步更新 `tests/liii/base/sort-bang-test.scm` 中已过时的"与 list-sort! 的区别"段落

## Why
1. **旧实现有 bug**：当小于 pivot 的部分为空时会把 pivot 丢掉，如 `(list-sort! < (list 1 2 3 4 5))` 返回 `(5)`。旧测试只用 list-sorted? 检查，截断后的列表依然有序，bug 未被发现
2. **性能**：新实现基于 C qsort，随机 1000 元素快约 13 倍；有序/逆序输入下旧快排退化为 O(n²)（4.35 秒 vs 0.004 秒 / 100 次），快约 1000 倍
3. **语义更好**：sort! 只重写各 pair 的 car，列表骨架不变，返回值与输入 eq?，所有别名都能观察到排序结果

## 性能对比（bin/gf bench/list-sort-bang.scm）
| 场景 | Scheme 旧实现 | sort! 新实现 | 提升 |
|---|---|---|---|
| 随机 1000 ×100 次 | 0.144 s | 0.011 s | ~13x |
| 随机 10000 ×10 次 | 0.227 s | 0.017 s | ~14x |
| 有序 1000 ×100 次 | 4.35 s | 0.004 s | ~1000x |
| 逆序 1000 ×100 次 | 4.25 s | 0.004 s | ~1000x |

## 测试
- `tests/liii/sort/` 全部 11 个测试文件通过
- `tests/liii/base/sort-bang-test.scm` 通过（17 个用例）
- `tests/liii/trie/trie-to-list-test.scm`（list-sort! 调用方）通过

详细记录见 `devel/0113.md`