### PR TITLE
[0907] 修改 bump version 提交信息与输入提示

### DIFF
--- a/.github/workflows/ci_bump_version.yml
+++ b/.github/workflows/ci_bump_version.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: '新版本号'
+        description: '新版本号 (如 v18.11.24)'
         required: true
 
 jobs:
@@ -26,35 +26,37 @@ jobs:
         run: |
           echo "NEW_VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
           echo "NEW_VERSION_DATE=$(date +'%Y/%m/%d')" >> $GITHUB_ENV
+          VERSION="${{ github.event.inputs.version }}"
+          echo "NEW_VERSION_WITHOUT_V=${VERSION#v}" >> $GITHUB_ENV
 
       - name: Validate version format
         run: |
           VERSION="${{ github.event.inputs.version }}"
-          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "版本格式错误，应为 17.11.35 格式"
+          if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "版本格式错误，应为 v18.11.24 格式"
             exit 1
           fi
 
       - name: Update version in files
         run: |
           # Update xmake.lua
-          sed -i "s/^set_version (\"[^\"]*\")/set_version (\"${{ env.NEW_VERSION }}\")/" xmake.lua
+          sed -i "s/^set_version (\"[^\"]*\")/set_version (\"${{ env.NEW_VERSION_WITHOUT_V }}\")/" xmake.lua
 
           # Update src/goldfish.hpp
-          sed -i "s/#define GOLDFISH_VERSION \"[^\"]*\"/#define GOLDFISH_VERSION \"${{ env.NEW_VERSION }}\"/" src/goldfish.hpp
+          sed -i "s/#define GOLDFISH_VERSION \"[^\"]*\"/#define GOLDFISH_VERSION \"${{ env.NEW_VERSION_WITHOUT_V }}\"/" src/goldfish.hpp
           
           # Update README.md
-          sed -i -E "s/Goldfish Scheme [0-9]+\.[0-9]+\.[0-9]+/Goldfish Scheme ${{ env.NEW_VERSION }}/g" README.md
+          sed -i -E "s/Goldfish Scheme [0-9]+\.[0-9]+\.[0-9]+/Goldfish Scheme ${{ env.NEW_VERSION_WITHOUT_V }}/g" README.md
           
           # Update README_ZH.md
-          sed -i -E "s/Goldfish Scheme [0-9]+\.[0-9]+\.[0-9]+/Goldfish Scheme ${{ env.NEW_VERSION }}/g" README_ZH.md
+          sed -i -E "s/Goldfish Scheme [0-9]+\.[0-9]+\.[0-9]+/Goldfish Scheme ${{ env.NEW_VERSION_WITHOUT_V }}/g" README_ZH.md
           
           # Update pkgs/goldfish.nix
-          sed -i "s/version = \"[^\"]*\"/version = \"${{ env.NEW_VERSION }}\"/" pkgs/goldfish.nix
+          sed -i "s/version = \"[^\"]*\"/version = \"${{ env.NEW_VERSION_WITHOUT_V }}\"/" pkgs/goldfish.nix
 
       - name: Update devel/200_1.md
         run: |
-          header="## ${{ env.NEW_VERSION_DATE }}   Goldfish Scheme v${{ env.NEW_VERSION }}"
+          header="## ${{ env.NEW_VERSION_DATE }}   Goldfish Scheme ${{ env.NEW_VERSION }}"
           sed -i "3i$header" devel/200_1.md
 
       - name: Git commit and tag
@@ -63,9 +65,9 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           git add .
-          git commit -m "[200_1] Bump version to ${{ env.NEW_VERSION }}"
+          git commit -m "[200_1] bump to Goldfish Scheme ${{ env.NEW_VERSION }}"
           # 打 Tag (带 v 前缀)
-          git tag v${{ env.NEW_VERSION }}
+          git tag ${{ env.NEW_VERSION }}
           
           git push origin ${{ github.ref_name }}
-          git push origin v${{ env.NEW_VERSION }}
+          git push origin ${{ env.NEW_VERSION }}

--- a/devel/0907.md
+++ b/devel/0907.md
@@ -1,0 +1,30 @@
+# [0907] 修改 bump version 提交信息与输入提示
+
+## 任务相关的代码文件
+- .github/workflows/ci_bump_version.yml
+
+## 如何测试
+本次改动仅涉及 bump version 工作流（workflow_dispatch），无编译/单元测试。验证方式为手动触发工作流：
+
+1. 在 Gitee 的 Actions 页面手动触发 `Bump Version` 工作流
+2. 输入 `v18.11.24` 形式的版本号（带 v）
+3. 确认触发后：
+   - 提交信息为 `[200_1] bump to Goldfish Scheme v18.11.24`
+   - tag 为 `v18.11.24`
+   - `xmake.lua` / `src/goldfish.hpp` / README / `pkgs/goldfish.nix` 内版本号仍为不带 v 的 `18.11.24`（安装包名 `goldfish-scheme-...-v18.11.24` 保持不变）
+
+## 2026/08/14 修改 bump version 提交信息与输入提示
+
+### What
+1. 输入框描述增加版本号示例提示：`新版本号` -> `新版本号 (如 v18.11.24)`
+2. 版本号统一带 `v` 前缀：用户输入 `v18.11.24`，校验正则由 `^[0-9]+\.[0-9]+\.[0-9]+$` 改为 `^v[0-9]+\.[0-9]+\.[0-9]+$`
+3. 提交信息由 `[200_1] Bump version to 18.11.24` 改为 `[200_1] bump to Goldfish Scheme v18.11.24`（小写 bump to、增加产品名、版本号加 v 前缀）
+4. 写回文件的版本号去掉 `v`（新增 `NEW_VERSION_WITHOUT_V`），保持安装包名不变
+
+### Why
+参考 Mogan 仓库的 bump version 规范，统一提交信息格式（产品名 + v 前缀），并在输入框提供版本号示例提示，降低误输入概率。
+
+### How
+- 输入框要求带 `v` 输入，在「Set new version to env」步骤中用 `${VERSION#v}` 去掉 `v` 得到 `NEW_VERSION_WITHOUT_V`
+- 提交信息与 tag 使用带 `v` 的 `NEW_VERSION`；写入文件（`xmake.lua`、`goldfish.hpp`、README、`goldfish.nix`）使用不带 `v` 的 `NEW_VERSION_WITHOUT_V`
+- 因 `NEW_VERSION` 已含 `v`，原 `git tag v$NEW_VERSION` 改为 `git tag $NEW_VERSION`，`devel/200_1.md` 标题的 `v$NEW_VERSION` 也改为 `$NEW_VERSION`，避免出现 `vv`


### PR DESCRIPTION
## 概述
修改 bump version 工作流（`.github/workflows/ci_bump_version.yml`），对齐 Mogan 仓库的规范。

## 改动
1. 提交信息由 `[200_1] Bump version to 18.11.24` 改为 `[200_1] bump to Goldfish Scheme v18.11.24`（小写 bump to + 产品名 + v 前缀）
2. 输入框描述增加版本号示例提示：`新版本号 (如 v18.11.24)`
3. 版本号统一带 `v` 前缀：输入 `v18.11.24`，校验正则改为 `^v[0-9]+\.[0-9]+\.[0-9]+$`
4. 写回文件的版本号去掉 `v`（新增 `NEW_VERSION_WITHOUT_V`），保持安装包名 `goldfish-scheme-...-v18.11.24` 不变

## 测试
本次改动仅涉及 workflow_dispatch 工作流，无编译/单元测试，通过手动触发 Bump Version 工作流验证。

详见 `devel/0907.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)