### PR TITLE
[0908] 修复 bin/pr 脚本的远程地址（Gitee → GitHub）

### DIFF
--- a/bin/pr
+++ b/bin/pr
@@ -2,7 +2,7 @@
 
 var num = $args[0]
 
-var remote      = git@gitee.com:XmacsLabs/goldfish.git
+var remote      = git@github.com:MoganLab/goldfish.git
 var remoteRef   = pull/$num/head
 var localBranch = pr_$num
 

--- a/devel/0908.md
+++ b/devel/0908.md
@@ -1,0 +1,22 @@
+# [0908] 修复 bin/pr 脚本的远程地址（Gitee → GitHub）
+
+## 任务相关的代码文件
+- bin/pr
+
+## 如何测试
+```bash
+# 拉取一个已存在的 PR（示例：#918），应从 GitHub fetch 成功并切换到 pr_918 分支
+bin/pr 918
+```
+
+## 2026-08-14 修复 bin/pr 脚本的远程地址
+### What
+1. `bin/pr` 的 remote 地址由 `git@gitee.com:XmacsLabs/goldfish.git` 改为 `git@github.com:MoganLab/goldfish.git`，与仓库当前的 `origin` 保持一致
+
+### Why
+项目已从 Gitee 迁移到 GitHub（`origin` 为 `github.com/MoganLab/goldfish`），但 `bin/pr` 脚本仍写死旧的 Gitee 地址，导致：
+1. 拉取 PR 时访问的是 Gitee 上无关的同号 PR
+2. SSH 密钥只注册在 GitHub，访问 Gitee 时被 `Permission denied (publickey)` 拒绝
+
+### How
+仅修改 remote 地址字符串一行，脚本其余逻辑（删除同名本地分支 → 重新 fetch → 切换）保持不变。


### PR DESCRIPTION
## 概述
修复 `bin/pr` 脚本的远程地址，由旧的 Gitee 改为当前使用的 GitHub，与仓库 `origin` 保持一致。

## 改动
- `bin/pr`：remote 地址 `git@gitee.com:XmacsLabs/goldfish.git` → `git@github.com:MoganLab/goldfish.git`
- `devel/0908.md`：任务文档

## 背景
项目已从 Gitee 迁移到 GitHub（`origin` 为 `github.com/MoganLab/goldfish`），但 `bin/pr` 仍写死旧的 Gitee 地址，导致拉取 PR 时访问 Gitee 上无关的同号 PR，且因 SSH 密钥只注册在 GitHub 而被 `Permission denied (publickey)` 拒绝。

## 测试
```bash
bin/pr 918   # 从 GitHub 成功 fetch 并切换到 pr_918 分支
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)