### PR TITLE
[0114] count 替换为 C 实现 g_count，提升性能并支持 SRFI-1 多列表语义

### DIFF
--- a/bench/count.scm
+++ b/bench/count.scm
@@ -1,0 +1,74 @@
+;;
+;; Copyright (C) 2026 The Goldfish Scheme Authors
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+;; the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+
+;; count 性能基准测试
+;; 对比旧 Scheme 实现（srfi-1.scm 中的递归循环）与新的 C 实现
+;; （src/s7_liii_list.c 的 g_count）
+;;
+;; 旧实现只遍历第一个列表（多列表形式被忽略），
+;; 因此本基准只对比单列表形式。
+
+(import (liii timeit) (liii list) (scheme base))
+
+(define (bench name stmt number)
+  (let ((elapsed (timeit stmt '() number)))
+    (display name)
+    (display ": ")
+    (display elapsed)
+    (display " 秒 (")
+    (display number)
+    (display " 次)\n")
+  ) ;let
+) ;define
+
+;; 旧 Scheme 实现（迁移到 C 之前的版本）
+
+(define (count-old pred list1)
+  (let lp
+    ((lis list1) (i 0))
+    (if (null-list? lis) i (lp (cdr lis) (if (pred (car lis)) (+ i 1) i)))
+  ) ;let
+) ;define
+
+(define (run-benchmarks)
+  (display "=== count 性能测试（旧 Scheme 实现 vs 新 C 实现）===\n\n")
+
+  (define (compare name pred lst number)
+    (display name)
+    (display "\n")
+    (bench "  旧 Scheme 实现" (lambda () (count-old pred lst)) number)
+    (bench "  新 C 实现     " (lambda () (count pred lst)) number)
+    (newline)
+  ) ;define
+
+  (compare "空列表" even? '() 100000)
+  (compare "小列表（1K 元素，偶数计数）" even? (iota 1000) 1000)
+  (compare "中列表（10K 元素，偶数计数）" even? (iota 10000) 100)
+  (compare "大列表（100K 元素，偶数计数）" even? (iota 100000) 10)
+  (compare "中列表（复杂谓词）"
+    (lambda (x) (and (> x 1000) (even? (length (list x)))))
+    (iota 10000)
+    100
+  ) ;compare
+
+  (display "多列表形式（仅新 C 实现支持，展示用途）\n")
+  (bench "  新 C 实现（双列表 =）"
+    (lambda () (count = (iota 10000) (map (lambda (x) (- x 1)) (iota 10000))))
+    10
+  ) ;bench
+) ;define
+
+(run-benchmarks)

--- a/devel/0114.md
+++ b/devel/0114.md
@@ -1,0 +1,75 @@
+# [0114] count 换成 C 语言实现，提升性能
+
+## 任务相关的代码文件
+- src/s7_liii_list.c（新增 g_count）
+- src/s7_liii_list.h（新增 g_count 声明）
+- src/s7.c（注册 g_count）
+- goldfish/srfi/srfi-1.scm（count 改为 g_count 薄封装）
+- tests/liii/list/count-test.scm（扩充测试）
+- bench/count.scm（新增）
+
+## 如何测试
+```bash
+# 1. 构建
+xmake b goldfish
+
+# 2. 格式化
+bin/gf fmt goldfish/srfi/srfi-1.scm
+bin/gf fmt tests/liii/list/count-test.scm
+bin/gf fmt bench/count.scm
+
+# 3. 运行测试
+bin/gf tests/liii/list/count-test.scm
+
+# 4. 运行性能基准
+bin/gf bench/count.scm
+
+# 5. 重建文档索引并查看文档
+bin/gf doc --build-json
+bin/gf doc count
+```
+
+## 2026-08-14 count 实现替换为 C 语言（g_count）
+### What
+1. `src/s7_liii_list.c` 新增 `g_count`，`src/s7.c` 注册
+   （`(g_count pred clist1 clist2 ...)`，2 必需参数 + rest，
+   签名为 circular signature `[integer procedure list...]`）
+2. `goldfish/srfi/srfi-1.scm` 的 `count` 从 Scheme 递归循环
+   改为 `(define count g_count)` 薄封装
+3. `tests/liii/list/count-test.scm` 从 1 个用例扩充为 26 个：
+   覆盖单列表、多列表（以最短列表为准）、谓词返回任意非 #f 值、
+   谓词执行期间分配内存（GC 压力）、非过程谓词、非列表参数、
+   点列表（单/多列表形式）等错误处理
+4. 新增 `bench/count.scm` 对比新旧实现性能
+5. 执行 `bin/gf doc --build-json` 重建索引后，
+   `bin/gf doc count` 可查看文档
+
+### Why
+旧 Scheme 实现每次迭代有函数调用、`(+ i 1)` 装箱分配和
+分支开销；改为 C 实现后循环体用 `s7_int` 计数，消除了
+这些开销。基准结果（bench/count.scm）：
+
+| 用例 | 旧实现 | 新实现 | 提升 |
+|---|---|---|---|
+| 空列表（10万次） | 0.0121 秒 | 0.0044 秒 | ~2.8x |
+| 1K 元素 × 1000 次 | 0.0458 秒 | 0.0051 秒 | ~9.0x |
+| 10K 元素 × 100 次 | 0.0570 秒 | 0.0048 秒 | ~11.9x |
+| 100K 元素 × 10 次 | 0.0750 秒 | 0.0058 秒 | ~13.0x |
+| 10K 元素复杂谓词 × 100 次 | 0.0973 秒 | 0.0519 秒 | ~1.9x |
+
+另外，旧实现 `(define (count pred list1 . lists))` 直接忽略了
+多列表参数（不符合 SRFI-1 语义），新实现按 SRFI-1 语义
+同步遍历多个列表、在最短列表处停止，属于行为修正。
+
+### How
+- 单列表走快路径，复用 `g_any` 的 GC anchor 模式：
+  pred 和列表放进自建保护 pair，`s7i_set_plist_1` 构造调用参数
+- 多列表先做一遍 properness 预检查（此阶段无 Scheme 回调，
+  无 GC 顾虑），然后以 anchor（pred + call-args 槽 + 每个列表
+  一个"当前位置"单元格）在保护栈上做同步推进；每轮用
+  `s7_cons` 现造调用参数表，每个新 pair 在 `s7_cons` 之后
+  立即链入 anchor 的槽位，保证 GC 可达
+- 注意 anchor 结构中 call-args 槽必须放在位置单元格链之外
+  （开发中发现若槽在链内，构造中的参数列表会被当成列表元素
+  再次处理，导致传参错乱）
+- 注册时 pred 非过程、列表非正规列表分别抛出 `wrong-type-arg`

--- a/goldfish/srfi/srfi-1.scm
+++ b/goldfish/srfi/srfi-1.scm
@@ -142,12 +142,7 @@
       (car (last-pair l))
     ) ;define
 
-    (define (count pred list1 . lists)
-      (let lp
-        ((lis list1) (i 0))
-        (if (null-list? lis) i (lp (cdr lis) (if (pred (car lis)) (+ i 1) i)))
-      ) ;let
-    ) ;define
+    (define count g_count)
 
     (define (zip . lists)
       (apply map list lists)

--- a/src/s7.c
+++ b/src/s7.c
@@ -85753,6 +85753,10 @@ is #t, the string is also sent to the current-output-port."
   #define Q_every s7_make_signature(sc, 3, sc->is_boolean_symbol, sc->is_procedure_symbol, sc->is_list_symbol)
   s7_define_semisafe_typed_function(sc, "g_every", g_every, 2, 0, false, H_every, Q_every);
 
+  #define H_count "(g_count pred clist1 clist2 ...) returns the number of element tuples for which (pred elem1 elem2 ...) is not #f, stopping at the end of the shortest list"
+  #define Q_count s7_make_circular_signature(sc, 2, 3, sc->is_integer_symbol, sc->is_procedure_symbol, sc->is_list_symbol)
+  s7_define_semisafe_typed_function(sc, "g_count", g_count, 2, 0, true, H_count, Q_count);
+
   #define H_fold "(g_fold f init lst) folds f over the elements of lst: (f elem acc)"
   #define Q_fold s7_make_signature(sc, 4, sc->T, sc->is_procedure_symbol, sc->T, sc->is_list_symbol)
   s7_define_semisafe_typed_function(sc, "g_fold", g_fold, 3, 0, false, H_fold, Q_fold);

--- a/src/s7_liii_list.c
+++ b/src/s7_liii_list.c
@@ -636,6 +636,95 @@ s7_pointer g_every(s7_scheme *sc, s7_pointer args)
   return(s7_t(sc));
 }
 
+/* -------------------------------- count -------------------------------- */
+
+s7_pointer g_count(s7_scheme *sc, s7_pointer args)
+{
+  /* (count pred clist1 clist2 ...) applies pred to one element of each list
+   * per iteration and returns the number of true results; the walk stops at
+   * the end of the shortest list */
+  s7_pointer pred = s7_car(args);
+  if (!s7_is_procedure(pred))
+    return(s7_wrong_type_arg_error(sc, "count", 1, pred, "a procedure"));
+
+  s7_pointer rest = s7_cdr(args);   /* (clist1 clist2 ...) */
+
+  if (s7_is_null(sc, s7_cdr(rest)))
+    {
+      /* single-list case: same GC pattern as g_any -- keep pred and lst
+       * anchored in our own protected pair while pred runs */
+      s7_pointer lst = s7_car(rest);
+      s7_pointer keep = s7_cons(sc, pred, s7_cons(sc, lst, s7_nil(sc)));
+      s7_gc_protect_via_stack(sc, keep);
+      s7_pointer p = lst;
+      s7_int i = 0;
+      while (s7_is_pair(p))
+        {
+          if (s7i_is_true(sc, s7_apply_function(sc, s7_car(keep), s7i_set_plist_1(sc, s7_car(p)))))
+            i++;
+          p = s7_cdr(p);
+        }
+      s7_gc_unprotect_via_stack(sc, keep);
+      if (!s7_is_null(sc, p))
+        return(s7_wrong_type_arg_error(sc, "count", 2, lst, "a proper list"));
+      return(s7_make_integer(sc, i));
+    }
+
+  /* multi-list case: check properness up front (no Scheme callbacks here, so
+   * no GC concerns), then walk all lists in lockstep */
+  for (s7_pointer lp = rest; s7_is_pair(lp); lp = s7_cdr(lp))
+    if (!s7_is_proper_list(sc, s7_car(lp)))
+      return(s7_wrong_type_arg_error(sc, "count", 2, s7_car(lp), "a proper list"));
+
+  /* keep pred, a slot for the current call args, and one "current position"
+   * cell per list (in argument order) in our own protected cells: the args
+   * cells may be recycled by the evaluator while pred runs; the slot sits at
+   * cadr so the position-cell walk below starts after it */
+  s7_pointer anchor = s7_cons(sc, pred, s7_cons(sc, s7_cons(sc, s7_nil(sc), s7_nil(sc)), s7_nil(sc)));
+  s7_gc_protect_via_stack(sc, anchor);
+  s7_pointer tail = s7_cdr(anchor);   /* (call-args-slot) */
+  for (s7_pointer lp = rest; s7_is_pair(lp); lp = s7_cdr(lp))
+    {
+      s7_set_cdr(tail, s7_cons(sc, s7_car(lp), s7_nil(sc)));
+      tail = s7_cdr(tail);
+    }
+  s7_pointer args_slot = s7_car(s7_cdr(anchor));
+
+  s7_int i = 0;
+  while (true)
+    {
+      /* build the call args from the current heads, linking each new pair
+       * into args_slot right after s7_cons so the growing list stays
+       * GC-reachable; advance the position cells in the same pass */
+      s7_set_car(args_slot, s7_nil(sc));
+      s7_pointer prev = NULL;
+      bool shortest_ended = false;
+      for (s7_pointer cell = s7_cdr(s7_cdr(anchor)); s7_is_pair(cell); cell = s7_cdr(cell))
+        {
+          s7_pointer cur = s7_car(cell);
+          if (!s7_is_pair(cur))
+            {
+              /* pre-checked above, so the shortest list just ended */
+              shortest_ended = true;
+              break;
+            }
+          s7_pointer node = s7_cons(sc, s7_car(cur), s7_nil(sc));
+          if (prev == NULL)
+            s7_set_car(args_slot, node);
+          else
+            s7_set_cdr(prev, node);
+          prev = node;
+          s7_set_car(cell, s7_cdr(cur));
+        }
+      if (shortest_ended)
+        break;
+      if (s7i_is_true(sc, s7_apply_function(sc, s7_car(anchor), s7_car(args_slot))))
+        i++;
+    }
+  s7_gc_unprotect_via_stack(sc, anchor);
+  return(s7_make_integer(sc, i));
+}
+
 /* -------------------------------- fold / fold-right -------------------------------- */
 
 s7_pointer g_fold(s7_scheme *sc, s7_pointer args)

--- a/src/s7_liii_list.h
+++ b/src/s7_liii_list.h
@@ -61,6 +61,7 @@ s7_pointer g_filter(s7_scheme *sc, s7_pointer args);
 s7_pointer g_find(s7_scheme *sc, s7_pointer args);
 s7_pointer g_any(s7_scheme *sc, s7_pointer args);
 s7_pointer g_every(s7_scheme *sc, s7_pointer args);
+s7_pointer g_count(s7_scheme *sc, s7_pointer args);
 s7_pointer g_fold(s7_scheme *sc, s7_pointer args);
 s7_pointer g_fold_right(s7_scheme *sc, s7_pointer args);
 s7_pointer g_take(s7_scheme *sc, s7_pointer args);

--- a/tests/liii/list/count-test.scm
+++ b/tests/liii/list/count-test.scm
@@ -8,27 +8,87 @@
 ;;
 ;; 语法
 ;; ----
-;; (count pred clist)
+;; (count pred clist1 clist2 ...)
 ;;
 ;; 参数
 ;; ----
 ;; pred : procedure?
-;; 谓词函数，接受单个参数并返回布尔值。
+;; 谓词函数，接受与列表个数相同的参数。
 ;;
-;; clist : list?
-;; 要计数的列表。
+;; clist1, clist2, ... : list?
+;; 要计数的列表，必须是正规列表。
 ;;
 ;; 返回值
 ;; ------
 ;; integer?
-;; 返回列表中满足谓词条件的元素数量。
+;; 返回使 (pred e1 e2 ...) 为真的元素元组个数；
+;; 多列表形式在 最短 的列表结束时停止计数。
+;;
+;; 实现说明
+;; --------
+;; C 实现（src/s7_liii_list.c 的 g_count），多列表形式按 SRFI-1
+;; 语义逐个列表同步取元素。
 ;;
 ;; 示例
 ;; ----
 ;; (count even? '(3 1 4 1 5 9 2 5 6)) => 3
+;; (count = '(1 2 4 4 4) '(3 4 4 4 3)) => 2
 
+
+;; 单列表
 
 (check (count even? '(3 1 4 1 5 9 2 5 6)) => 3)
+(check (count even? '()) => 0)
+(check (count even? '(1 3 5)) => 0)
+(check (count even? '(2 4 6)) => 3)
+(check (count (lambda (x) (> x 0)) '(1 2 3)) => 3)
+(check (count (lambda (x) (< x 0)) '(1 2 3)) => 0)
+(check (integer? (count even? '(1 2))) => #t)
+
+
+;; 谓词返回任意非 #f 值都计数，并非只计 #t
+
+(check (count (lambda (x) (and (even? x) x)) '(1 2 3 4)) => 2)
+(check (count (lambda (x) (if (odd? x) 'yes #f)) '(1 2 3)) => 2)
+
+
+;; 多列表：pred 每次取各列表同位置的元素，以最短列表为准
+
+(check (count = '(1 2 3 4 5) '(3 4 5 6 7)) => 0)
+(check (count = '(1 2 4 4 4) '(3 4 4 4 3)) => 2)
+(check (count = '(1 2 3) '(3 2 1)) => 1)
+(check (count = '(1 2 3) '(1 2)) => 2)
+(check (count = '(1 2) '(1 2 3)) => 2)
+(check (count = '() '(1 2 3)) => 0)
+(check (count < '(1 2 3 4) '(2 3 4 5)) => 4)
+(check (count (lambda (a b c) (= (+ a b) c)) '(1 2 3) '(1 2 3) '(2 4 6)) => 3)
+(check (count (lambda (a b) #t) '(a b) '(x y)) => 2)
+
+
+;; 谓词执行期间分配内存（GC 压力下 anchor 保护 pred 和列表）
+
+(check (count (lambda (x) (even? (car (list x)))) (iota 100)) => 50)
+(check (count (lambda (a b) (= (length (list a b)) (+ a b) 2)) '(1 2 3) '(1 2 3))
+  =>
+  1
+) ;check
+
+
+;; 非法参数
+
+;; pred 不是过程
+(check-catch 'wrong-type-arg (count 3 '(1 2)))
+
+;; 非列表参数
+(check-catch 'wrong-type-arg (count even? 3))
+
+;; 点列表：count 总是遍历完整列表，到达非正规尾部即报错
+(check-catch 'wrong-type-arg (count even? '(1 2 . 3)))
+(check-catch 'wrong-type-arg (count even? '(2 4 . 6)))
+
+;; 多列表形式中的点列表和非列表参数
+(check-catch 'wrong-type-arg (count = '(1 2 3) '(1 2 . 3)))
+(check-catch 'wrong-type-arg (count = '(1 2 3) 3))
 
 
 (check-report)


### PR DESCRIPTION
## 概述

将 `(liii list)` / `(srfi srfi-1)` 的 `count` 从 Scheme 递归循环替换为 C 语言实现（`g_count`，位于 `src/s7_liii_list.c`），提升性能。

## 改动

- `src/s7_liii_list.c` / `src/s7_liii_list.h` / `src/s7.c`：新增并注册 `g_count`（2 必需参数 + rest，circular signature）
- `goldfish/srfi/srfi-1.scm`：`count` 改为 `(define count g_count)` 薄封装
- `tests/liii/list/count-test.scm`：从 1 个用例扩充为 26 个，覆盖单列表、多列表（以最短列表为准）、GC 压力、错误处理
- `bench/count.scm`（新增）、`devel/0114.md`（新增）

## 性能（bench/count.scm）

| 用例 | 旧实现 | 新实现 | 提升 |
|---|---|---|---|
| 1K 元素 × 1000 次 | 0.046s | 0.005s | ~9x |
| 100K 元素 × 10 次 | 0.075s | 0.006s | ~13x |
| 10K 元素复杂谓词 × 100 次 | 0.097s | 0.052s | ~1.9x |

## 行为修正

旧实现 `(count pred list1 . lists)` 直接忽略多出来的列表参数，不符合 SRFI-1 语义。新实现按 SRFI-1 语义同步遍历多个列表、在最短列表处停止计数。

## 测试

```bash
xmake b goldfish
bin/gf tests/liii/list/count-test.scm   # 26 correct, 0 failed
bin/gf bench/count.scm
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)