### PR TITLE
[0115] list-index 替换为 C 实现 g_list_index，提升性能并支持 SRFI-1 多列表语义

### DIFF
--- a/bench/list-index.scm
+++ b/bench/list-index.scm
@@ -1,0 +1,87 @@
+;;
+;; Copyright (C) 2026 The Goldfish Scheme Authors
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+;; the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+
+;; list-index 性能基准测试
+;; 对比旧 Scheme 实现（srfi-1.scm 中的递归循环）与新的 C 实现
+;; （src/s7_liii_list.c 的 g_list_index）
+;;
+;; 旧实现只遍历第一个列表（多列表形式不被接受），
+;; 因此本基准只对比单列表形式。
+
+(import (liii timeit) (liii list) (scheme base))
+
+(define (bench name stmt number)
+  (let ((elapsed (timeit stmt '() number)))
+    (display name)
+    (display ": ")
+    (display elapsed)
+    (display " 秒 (")
+    (display number)
+    (display " 次)\n")
+  ) ;let
+) ;define
+
+;; 旧 Scheme 实现（迁移到 C 之前的版本）
+
+(define (list-index-old pred l)
+  (let loop
+    ((index 0) (l l))
+    (if (null? l) #f (if (pred (car l)) index (loop (+ index 1) (cdr l))))
+  ) ;let
+) ;define
+
+(define (run-benchmarks)
+  (display "=== list-index 性能测试（旧 Scheme 实现 vs 新 C 实现）===\n\n"
+  ) ;display
+
+  (define (compare name pred lst number)
+    (display name)
+    (display "\n")
+    (bench "  旧 Scheme 实现" (lambda () (list-index-old pred lst)) number)
+    (bench "  新 C 实现     " (lambda () (list-index pred lst)) number)
+    (newline)
+  ) ;define
+
+  ;; 命中位置在列表头部
+  (compare "头部命中（1K 元素）" even? (iota 1000) 1000)
+  ;; 命中位置在列表尾部附近
+  (compare "尾部命中（1K 元素，找第一个 >998）"
+    (lambda (x) (> x 998))
+    (iota 1000)
+    1000
+  ) ;compare
+  ;; 未命中，需要遍历完整列表
+  (compare "未命中（10K 元素）" (lambda (x) (> x 10000)) (iota 10000) 100)
+  (compare "未命中（100K 元素）"
+    (lambda (x) (> x 100000))
+    (iota 100000)
+    10
+  ) ;compare
+  ;; 谓词本身开销较大时
+  (compare "中列表（复杂谓词）"
+    (lambda (x) (and (> x 1000) (even? (length (list x)))))
+    (iota 10000)
+    100
+  ) ;compare
+
+  (display "多列表形式（仅新 C 实现支持，展示用途）\n")
+  (bench "  新 C 实现（双列表 =）"
+    (lambda () (list-index = (iota 10000) (map (lambda (x) (- x 1)) (iota 10000))))
+    10
+  ) ;bench
+) ;define
+
+(run-benchmarks)

--- a/devel/0115.md
+++ b/devel/0115.md
@@ -1,0 +1,82 @@
+# [0115] list-index 换成 C 语言实现，提升性能
+
+## 任务相关的代码文件
+- src/s7_liii_list.c（新增 g_list_index）
+- src/s7_liii_list.h（新增 g_list_index 声明）
+- src/s7.c（注册 g_list_index）
+- goldfish/srfi/srfi-1.scm（list-index 改为 g_list_index 薄封装）
+- tests/liii/list/list-index-test.scm（扩充测试）
+- bench/list-index.scm（新增）
+
+## 如何测试
+```bash
+# 1. 构建
+xmake b goldfish
+
+# 2. 格式化
+bin/gf fmt goldfish/srfi/srfi-1.scm
+bin/gf fmt tests/liii/list/list-index-test.scm
+bin/gf fmt bench/list-index.scm
+
+# 3. 运行测试
+bin/gf tests/liii/list/list-index-test.scm
+
+# 4. 运行性能基准
+bin/gf bench/list-index.scm
+
+# 5. 重建文档索引并查看文档
+bin/gf doc --build-json
+bin/gf doc list-index
+```
+
+## 2026-08-14 list-index 实现替换为 C 语言（g_list_index）
+### What
+1. `src/s7_liii_list.c` 新增 `g_list_index`，`src/s7.c` 注册
+   （`(g_list_index pred clist1 clist2 ...)`，2 必需参数 + rest，
+   签名为 circular signature `[T procedure list...]`，返回 integer 或 #f）
+2. `goldfish/srfi/srfi-1.scm` 的 `list-index` 从 Scheme 递归循环
+   改为 `(define list-index g_list_index)` 薄封装
+3. `tests/liii/list/list-index-test.scm` 从 3 个用例扩充为 27 个：
+   覆盖单列表、多列表（以最短列表为准）、谓词返回任意非 #f 值、
+   谓词执行期间分配内存（GC 压力）、非过程谓词、非列表参数、
+   点列表（单/多列表形式）等错误处理
+4. 新增 `bench/list-index.scm` 对比新旧实现性能
+5. 执行 `bin/gf doc --build-json` 重建索引后，
+   `bin/gf doc list-index` 可查看文档
+
+### Why
+旧 Scheme 实现每次迭代有函数调用和 `(+ index 1)` 装箱分配开销；
+改为 C 实现后循环体用 `s7_int` 计数，消除了这些开销。
+基准结果（bench/list-index.scm）：
+
+| 用例 | 旧实现 | 新实现 | 提升 |
+|---|---|---|---|
+| 头部命中（1K 元素 × 1000 次） | 0.0000589 秒 | 0.0000370 秒 | ~1.6x |
+| 尾部命中（1K 元素 × 1000 次） | 0.0383 秒 | 0.0373 秒 | ~1.0x |
+| 未命中（10K 元素 × 100 次） | 0.0436 秒 | 0.0336 秒 | ~1.3x |
+| 未命中（100K 元素 × 10 次） | 0.0787 秒 | 0.0339 秒 | ~2.3x |
+| 10K 元素复杂谓词 × 100 次 | 0.0586 秒 | 0.0466 秒 | ~1.3x |
+
+提升幅度与谓词类型相关：命中早、谓词是 C 内置（如 even?）时收益
+明显；谓词是 Scheme lambda 时，`s7_apply_function` 调用谓词本身
+的开销占主导，循环体优化收益相对有限。
+
+另外，旧实现 `(define (list-index pred l))` 不接受多列表参数
+（不符合 SRFI-1 语义），新实现按 SRFI-1 语义同步遍历多个列表、
+在最短列表处停止，属于行为修正。
+
+### How
+- 实现完全沿用 [0114] g_count 的模式：
+  - 单列表走快路径，复用 GC anchor 模式（pred 和列表放进自建
+    保护 pair，`s7i_set_plist_1` 构造调用参数）
+  - 多列表先做一遍 properness 预检查，然后以 anchor（pred +
+    call-args 槽 + 每个列表一个"当前位置"单元格）在保护栈上
+    做同步推进
+- 与 g_count 的差异：
+  - 谓词命中即返回当前索引（提前退出，无需遍历完整列表）
+  - 单列表路径的正规性检查是惰性的：命中点在点列表尾部之前
+    则正常返回，遍历到非正规尾部仍未命中才报 wrong-type-arg
+    （g_count 必须数完整个列表，总能到达尾部）
+- 开发过程中发现 `bin/gf fmt` 对超长行中 `(1 2 3)` 这类点列表
+  之外的普通引号列表会做竖向折行（形如 `'(1\n2\n3)`），测试中
+  通过把长谓词提取到 define 规避

--- a/goldfish/srfi/srfi-1.scm
+++ b/goldfish/srfi/srfi-1.scm
@@ -247,12 +247,7 @@
       (if (null? l) '() (if (pred (car l)) (drop-while pred (cdr l)) l))
     ) ;define
 
-    (define (list-index pred l)
-      (let loop
-        ((index 0) (l l))
-        (if (null? l) #f (if (pred (car l)) index (loop (+ index 1) (cdr l))))
-      ) ;let
-    ) ;define
+    (define list-index g_list_index)
 
     (define any g_any)
 

--- a/src/s7.c
+++ b/src/s7.c
@@ -85757,6 +85757,10 @@ is #t, the string is also sent to the current-output-port."
   #define Q_count s7_make_circular_signature(sc, 2, 3, sc->is_integer_symbol, sc->is_procedure_symbol, sc->is_list_symbol)
   s7_define_semisafe_typed_function(sc, "g_count", g_count, 2, 0, true, H_count, Q_count);
 
+  #define H_list_index "(g_list_index pred clist1 clist2 ...) returns the index of the first element tuple for which (pred elem1 elem2 ...) is not #f, or #f if there is none, stopping at the end of the shortest list"
+  #define Q_list_index s7_make_circular_signature(sc, 2, 3, sc->T, sc->is_procedure_symbol, sc->is_list_symbol)
+  s7_define_semisafe_typed_function(sc, "g_list_index", g_list_index, 2, 0, true, H_list_index, Q_list_index);
+
   #define H_fold "(g_fold f init lst) folds f over the elements of lst: (f elem acc)"
   #define Q_fold s7_make_signature(sc, 4, sc->T, sc->is_procedure_symbol, sc->T, sc->is_list_symbol)
   s7_define_semisafe_typed_function(sc, "g_fold", g_fold, 3, 0, false, H_fold, Q_fold);

--- a/src/s7_liii_list.c
+++ b/src/s7_liii_list.c
@@ -725,6 +725,102 @@ s7_pointer g_count(s7_scheme *sc, s7_pointer args)
   return(s7_make_integer(sc, i));
 }
 
+/* ------------------------------ list-index ------------------------------ */
+
+s7_pointer g_list_index(s7_scheme *sc, s7_pointer args)
+{
+  /* (list-index pred clist1 clist2 ...) applies pred to one element of each
+   * list per iteration and returns the index of the first true result, or #f;
+   * the walk stops at the end of the shortest list */
+  s7_pointer pred = s7_car(args);
+  if (!s7_is_procedure(pred))
+    return(s7_wrong_type_arg_error(sc, "list-index", 1, pred, "a procedure"));
+
+  s7_pointer rest = s7_cdr(args);   /* (clist1 clist2 ...) */
+
+  if (s7_is_null(sc, s7_cdr(rest)))
+    {
+      /* single-list case: same GC pattern as g_count -- keep pred and lst
+       * anchored in our own protected pair while pred runs; properness is
+       * checked lazily, so an early match returns without touching the tail */
+      s7_pointer lst = s7_car(rest);
+      s7_pointer keep = s7_cons(sc, pred, s7_cons(sc, lst, s7_nil(sc)));
+      s7_gc_protect_via_stack(sc, keep);
+      s7_pointer p = lst;
+      s7_int i = 0;
+      while (s7_is_pair(p))
+        {
+          if (s7i_is_true(sc, s7_apply_function(sc, s7_car(keep), s7i_set_plist_1(sc, s7_car(p)))))
+            {
+              s7_gc_unprotect_via_stack(sc, keep);
+              return(s7_make_integer(sc, i));
+            }
+          i++;
+          p = s7_cdr(p);
+        }
+      s7_gc_unprotect_via_stack(sc, keep);
+      if (!s7_is_null(sc, p))
+        return(s7_wrong_type_arg_error(sc, "list-index", 2, lst, "a proper list"));
+      return(s7_f(sc));
+    }
+
+  /* multi-list case: check properness up front (no Scheme callbacks here, so
+   * no GC concerns), then walk all lists in lockstep */
+  for (s7_pointer lp = rest; s7_is_pair(lp); lp = s7_cdr(lp))
+    if (!s7_is_proper_list(sc, s7_car(lp)))
+      return(s7_wrong_type_arg_error(sc, "list-index", 2, s7_car(lp), "a proper list"));
+
+  /* same anchor layout as g_count: pred, a slot for the current call args,
+   * then one "current position" cell per list in argument order */
+  s7_pointer anchor = s7_cons(sc, pred, s7_cons(sc, s7_cons(sc, s7_nil(sc), s7_nil(sc)), s7_nil(sc)));
+  s7_gc_protect_via_stack(sc, anchor);
+  s7_pointer tail = s7_cdr(anchor);   /* (call-args-slot) */
+  for (s7_pointer lp = rest; s7_is_pair(lp); lp = s7_cdr(lp))
+    {
+      s7_set_cdr(tail, s7_cons(sc, s7_car(lp), s7_nil(sc)));
+      tail = s7_cdr(tail);
+    }
+  s7_pointer args_slot = s7_car(s7_cdr(anchor));
+
+  s7_int i = 0;
+  while (true)
+    {
+      /* build the call args from the current heads, linking each new pair
+       * into args_slot right after s7_cons so the growing list stays
+       * GC-reachable; advance the position cells in the same pass */
+      s7_set_car(args_slot, s7_nil(sc));
+      s7_pointer prev = NULL;
+      bool shortest_ended = false;
+      for (s7_pointer cell = s7_cdr(s7_cdr(anchor)); s7_is_pair(cell); cell = s7_cdr(cell))
+        {
+          s7_pointer cur = s7_car(cell);
+          if (!s7_is_pair(cur))
+            {
+              /* pre-checked above, so the shortest list just ended */
+              shortest_ended = true;
+              break;
+            }
+          s7_pointer node = s7_cons(sc, s7_car(cur), s7_nil(sc));
+          if (prev == NULL)
+            s7_set_car(args_slot, node);
+          else
+            s7_set_cdr(prev, node);
+          prev = node;
+          s7_set_car(cell, s7_cdr(cur));
+        }
+      if (shortest_ended)
+        break;
+      if (s7i_is_true(sc, s7_apply_function(sc, s7_car(anchor), s7_car(args_slot))))
+        {
+          s7_gc_unprotect_via_stack(sc, anchor);
+          return(s7_make_integer(sc, i));
+        }
+      i++;
+    }
+  s7_gc_unprotect_via_stack(sc, anchor);
+  return(s7_f(sc));
+}
+
 /* -------------------------------- fold / fold-right -------------------------------- */
 
 s7_pointer g_fold(s7_scheme *sc, s7_pointer args)

--- a/src/s7_liii_list.h
+++ b/src/s7_liii_list.h
@@ -62,6 +62,7 @@ s7_pointer g_find(s7_scheme *sc, s7_pointer args);
 s7_pointer g_any(s7_scheme *sc, s7_pointer args);
 s7_pointer g_every(s7_scheme *sc, s7_pointer args);
 s7_pointer g_count(s7_scheme *sc, s7_pointer args);
+s7_pointer g_list_index(s7_scheme *sc, s7_pointer args);
 s7_pointer g_fold(s7_scheme *sc, s7_pointer args);
 s7_pointer g_fold_right(s7_scheme *sc, s7_pointer args);
 s7_pointer g_take(s7_scheme *sc, s7_pointer args);

--- a/tests/liii/list/list-index-test.scm
+++ b/tests/liii/list/list-index-test.scm
@@ -8,31 +8,90 @@
 ;;
 ;; 语法
 ;; ----
-;; (list-index pred clist)
+;; (list-index pred clist1 clist2 ...)
 ;;
 ;; 参数
 ;; ----
 ;; pred : procedure?
-;; 谓词函数，接受单个参数并返回布尔值。
+;; 谓词函数，接受与列表个数相同的参数。
 ;;
-;; clist : list?
-;; 要查找的列表。
+;; clist1, clist2, ... : list?
+;; 要查找的列表，必须是正规列表。
 ;;
 ;; 返回值
 ;; ------
 ;; integer? 或 #f
-;; 返回第一个满足谓词条件的元素的索引（从0开始），如果没有找到则返回#f。
+;; 返回第一个使 (pred e1 e2 ...) 为非 #f 的元素元组索引（从 0 开始）；
+;; 没有找到则返回 #f；多列表形式在 最短 的列表结束时停止查找。
+;;
+;; 实现说明
+;; --------
+;; C 实现（src/s7_liii_list.c 的 g_list_index），多列表形式按 SRFI-1
+;; 语义逐个列表同步取元素。
 ;;
 ;; 示例
 ;; ----
 ;; (list-index even? '(3 1 4 1 5 9)) => 2
-;; (list-index even? '()) => #f
-;; (list-index even? '(1 3 5 7 9)) => #f
+;; (list-index = '(1 2 4 4 4) '(3 4 4 4 3)) => 2
 
+
+;; 单列表
 
 (check (list-index even? '(3 1 4 1 5 9)) => 2)
 (check (list-index even? '()) => #f)
 (check (list-index even? '(1 3 5 7 9)) => #f)
+(check (list-index even? '(2 4 6)) => 0)
+(check (list-index (lambda (x) (> x 0)) '(1 2 3)) => 0)
+(check (list-index (lambda (x) (< x 0)) '(1 2 3)) => #f)
+(check (list-index (lambda (x) (> x 2)) '(1 2 3)) => 2)
+(check (integer? (list-index even? '(2))) => #t)
+
+
+;; 谓词返回任意非 #f 值都算命中，并非只认 #t
+
+(check (list-index (lambda (x) (and (even? x) x)) '(1 2 3 4)) => 1)
+(check (list-index (lambda (x) (if (odd? x) 'yes #f)) '(2 4 5)) => 2)
+
+
+;; 多列表：pred 每次取各列表同位置的元素，以最短列表为准
+
+(check (list-index = '(1 2 4 4 4) '(3 4 4 4 3)) => 2)
+(check (list-index = '(1 2 3) '(3 2 1)) => 1)
+(check (list-index = '(1 2 3) '(1 2)) => 0)
+(check (list-index = '(2 1 3) '(1 2)) => #f)
+(check (list-index = '() '(1 2 3)) => #f)
+(check (list-index < '(1 2 3 4) '(2 3 4 5)) => 0)
+(check (list-index > '(1 2 3 4) '(2 3 4 5)) => #f)
+(check (list-index (lambda (a b c) (= (+ a b) c)) '(1 2 3) '(1 2 3) '(1 4 6))
+  =>
+  1
+) ;check
+(check (list-index (lambda (a b) #f) '(a b) '(x y)) => #f)
+
+
+;; 谓词执行期间分配内存（GC 压力下 anchor 保护 pred 和列表）
+
+(check (list-index (lambda (x) (even? (car (list x)))) (iota 100)) => 0)
+
+(define %li-pred2 (lambda (a b) (= (length (list a b)) (+ a b) 2)))
+(check (list-index %li-pred2 '(1 2 3) '(1 2 3)) => 0)
+
+
+;; 非法参数
+
+;; pred 不是过程
+(check-catch 'wrong-type-arg (list-index 3 '(1 2)))
+
+;; 非列表参数
+(check-catch 'wrong-type-arg (list-index even? 3))
+
+;; 点列表：遍历到非正规尾部仍未命中即报错；命中点在尾部之前则正常返回
+(check-catch 'wrong-type-arg (list-index odd? '(2 4 . 6)))
+(check (list-index even? '(2 4 . 6)) => 0)
+
+;; 多列表形式中的点列表和非列表参数（预先做正规性检查）
+(check-catch 'wrong-type-arg (list-index = '(1 2 3) '(1 2 . 3)))
+(check-catch 'wrong-type-arg (list-index = '(1 2 3) 3))
 
 
 (check-report)


### PR DESCRIPTION
## 概述

沿用 [0114] g_count 的模式，将 `list-index` 的实现从 Scheme 递归循环替换为 C 实现 `g_list_index`，并补齐 SRFI-1 多列表语义。

## 改动内容

- `src/s7_liii_list.c` 新增 `g_list_index`（单列表快路径 + 多列表锁步推进，复用 g_count 的 GC anchor 模式），`src/s7.c` 注册，`src/s7_liii_list.h` 声明
- `goldfish/srfi/srfi-1.scm`：`list-index` 改为 `(define list-index g_list_index)` 薄封装
- `tests/liii/list/list-index-test.scm`：3 → 27 个用例，覆盖单/多列表、谓词返回非 #f 值、GC 压力、非法参数、点列表等
- 新增 `bench/list-index.scm` 和 `devel/0115.md`

## 行为修正

旧实现 `(define (list-index pred l))` 不接受多列表参数，不符合 SRFI-1 语义。新实现按 SRFI-1 语义同步遍历多个列表、在最短列表处停止。

单列表路径的点列表检查是惰性的：命中点在尾部之前则正常返回（如 `(list-index even? '(2 4 . 6)) => 0`），遍历到非正规尾部仍未命中才报 `wrong-type-arg`。

## 性能（bench/list-index.scm）

| 用例 | 旧实现 | 新实现 | 提升 |
|---|---|---|---|
| 头部命中（1K × 1000 次） | 0.0000589 秒 | 0.0000370 秒 | ~1.6x |
| 尾部命中（1K × 1000 次） | 0.0383 秒 | 0.0373 秒 | ~1.0x |
| 未命中（10K × 100 次） | 0.0436 秒 | 0.0336 秒 | ~1.3x |
| 未命中（100K × 10 次） | 0.0787 秒 | 0.0339 秒 | ~2.3x |
| 复杂谓词（10K × 100 次） | 0.0586 秒 | 0.0466 秒 | ~1.3x |

## 测试

- `bin/gf tests/liii/list/list-index-test.scm`：27/27 通过
- `tests/liii/list/` 全部测试文件回归通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)