### PR TITLE
[0117] 修复 append 构建长列表时列表结构损坏的 bug

### DIFF
--- a/bench/append.scm
+++ b/bench/append.scm
@@ -1,0 +1,78 @@
+;;
+;; Copyright (C) 2026 The Goldfish Scheme Authors
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+;; the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+
+;; append 性能基准测试
+;; 对比 s7_append GC 保护修复（temp7 保护第二个参数）前后的性能
+
+(import (liii timeit) (liii list) (scheme base))
+
+(define (bench name stmt number)
+  (let ((elapsed (timeit stmt '() number)))
+    (display name)
+    (display ": ")
+    (display elapsed)
+    (display " 秒 (")
+    (display number)
+    (display " 次)\n")
+  ) ;let
+) ;define
+
+(define (run-benchmarks)
+  (display "=== append 性能测试 ===\n\n")
+
+  ;; 短列表（两参数优化路径 s7_append）
+  (bench "短列表 (append '(1 2 3) '(4 5 6))"
+    (lambda () (append '(1 2 3) '(4 5 6)))
+    1000000
+  ) ;bench
+
+  ;; 中等列表（两参数优化路径 s7_append）
+  (let ((a (iota 100)) (b (iota 100)))
+    (bench "中列表 (append (iota 100) (iota 100))"
+      (lambda () (append a b))
+      10000
+    ) ;bench
+  ) ;let
+
+  ;; 长列表（两参数优化路径 s7_append，复制循环中触发 GC）
+  (let ((a (iota 1000)) (b (iota 1000)))
+    (bench "长列表 (append (iota 1000) (iota 1000))"
+      (lambda () (append a b))
+      1000
+    ) ;bench
+  ) ;let
+
+  ;; 多列表（g_append -> g_list_append 路径）
+  (let ((a (iota 10)) (b (iota 10)) (c (iota 10)))
+    (bench "多列表 (append a b c)，各 10 元素"
+      (lambda () (append a b c))
+      100000
+    ) ;bench
+  ) ;let
+
+  ;; 循环构建列表（gf doc 模糊匹配的实际使用场景）
+  (bench "循环构建 300 元素列表"
+    (lambda ()
+      (let loop
+        ((i 0) (acc '()))
+        (if (= i 300) acc (loop (+ i 1) (append acc (list (number->string i)))))
+      ) ;let
+    ) ;lambda
+    100
+  ) ;bench
+) ;define
+
+(run-benchmarks)

--- a/devel/0117.md
+++ b/devel/0117.md
@@ -1,0 +1,76 @@
+# [0117] 修复 append 构建长列表时列表结构损坏的 bug
+
+## 任务相关的代码文件
+- src/s7.c（s7_append 增加对第二个参数的 GC 保护）
+- tests/scheme/base/append-test.scm（新增长列表回归测试）
+- bench/append.scm（新增性能基准）
+
+## 如何测试
+```bash
+# 1. 构建
+xmake b goldfish
+
+# 2. 格式化
+bin/gf fmt tests/scheme/base/append-test.scm
+bin/gf fmt bench/append.scm
+
+# 3. 运行测试
+bin/gf tests/scheme/base/append-test.scm
+
+# 4. 运行完整回归
+bin/gf test --all
+
+# 5. 运行性能基准
+bin/gf bench/append.scm
+```
+
+## 2026-08-14 修复 s7_append 第二个参数缺少 GC 保护
+
+### What
+1. `src/s7.c` 的 `s7_append` 在复制循环期间用 `sc->temp7`
+   保护第二个参数 `b`（循环结束后立即释放）
+2. `tests/scheme/base/append-test.scm` 新增回归测试：
+   循环调用 `(append visible (list ...))` 构建 1000 元素列表，
+   以及用户报告的 `member` + `append` 去重构建场景
+3. 新增 `bench/append.scm` 性能基准
+
+修复前复现（约 500+ 元素时触发）：
+```
+;append first argument, ("0" "1" "2" ...), is a pair but should be a proper list
+```
+修复后 `bin/gf test --all` 1495 个测试全部通过。
+
+### Why
+`gf doc "string-spli"` 模糊匹配崩溃：其 `visible-function-names` 用
+`append` 循环构建长列表，函数数量超过阈值时列表被损坏。
+
+两参数 `append` 走优化路径 `g_append_2` -> `s7_append`
+（`append_chooser` 在参数为 2 时选用）。`s7_append` 的复制循环中
+`list_1` 可能触发 GC，但此时只有第一个参数 `a`（temp9）和
+正在构建的新列表 `q`（temp6）受到 GC 保护，第二个参数 `b` 没有。
+`b` 被清扫回收后，循环末尾的 `set_cdr(np, b)` 把空闲 cell
+链入新列表，产生 dotted/环形列表。插桩确认损坏列表的尾部是
+`<free cell!>`（`length` 返回负值）。
+
+多参数路径 `g_append` -> `g_list_append` 用
+`gc_protect_via_stack` 保护了整个 args，不受影响
+（apply 路径回归测试验证通过）。
+
+### How
+在复制循环开始前设置 `sc->temp7 = b`（temp7 在 GC 标记根集合中，
+且 `s7_append` 内无其他使用者），循环结束后复位为 `sc->unused`。
+错误分支（`wrong_type_error_nr`）在复位之后，不受影响。
+
+### 性能基准（bench/append.scm，修复前 -> 修复后）
+
+| 用例 | 修复前 | 修复后（三轮最优） |
+|---|---|---|
+| 短列表 '(1 2 3) + '(4 5 6) × 100 万次 | 0.0296 秒 | 0.0302 秒 |
+| 中列表 iota 100 + iota 100 × 1 万次 | 0.00325 秒 | 0.00282 秒 |
+| 长列表 iota 1000 + iota 1000 × 1000 次 | 0.00372 秒 | 0.00309 秒 |
+| 多列表 (append a b c) × 10 万次 | 0.0106 秒 | 0.0114 秒 |
+| 循环构建 300 元素 × 100 次 | 0.0169 秒 | 0.0160 秒 |
+
+修复每次调用仅增加两次指针赋值（约 1-2 ns），
+相对单次 append 约 30 ns 的开销影响 <5%，实测差异在系统噪声范围内，
+无性能退化。

--- a/src/s7.c
+++ b/src/s7.c
@@ -38028,6 +38028,7 @@ s7_pointer s7_append(s7_scheme *sc, s7_pointer a, s7_pointer b)
       if ((!is_pair(b)) && (!is_null(b)))
 	return(g_list_append(sc, list_2(sc, a, b)));
       sc->temp9 = a; /* tempx? */
+      sc->temp7 = b; /* GC protect b across the copy loop below (it is not otherwise protected here) */
       q = list_1(sc, car(a));
       begin_temp(sc->temp6, q);
       p = cdr(a);
@@ -38039,6 +38040,7 @@ s7_pointer s7_append(s7_scheme *sc, s7_pointer a, s7_pointer b)
 	  set_cdr(np, list_1(sc, car(p)));
 	}
       end_temp(sc->temp6);
+      sc->temp7 = sc->unused;
       if (!is_null(p))
 	wrong_type_error_nr(sc, sc->append_symbol, 1, a, a_proper_list_string);
       sc->temp9 = sc->unused;

--- a/tests/scheme/base/append-test.scm
+++ b/tests/scheme/base/append-test.scm
@@ -223,4 +223,41 @@
 (check (length (append '(1 2) '(3 4) '(5 6) '(7 8))) => 8)
 (check (list-ref (append '(1 2 3) '(4 5 6)) 5) => 6)
 (check (list-ref (append '(1) '(2 3 4)) 3) => 4)
+;; 长列表循环构建测试（回归测试：append 构建长列表时不得损坏列表结构）
+;; s7_append 的复制循环会触发 GC，若第二个参数未受 GC 保护会被回收，
+;; 导致新列表尾部链入空闲 cell（dotted tail: <free cell!>）
+
+(define (append-loop-build n)
+  (let loop
+    ((i 0) (visible '()))
+    (if (= i n) visible (loop (+ i 1) (append visible (list (number->string i)))))
+  ) ;let
+) ;define
+(let ((visible (append-loop-build 1000)))
+  (check (proper-list? visible) => #t)
+  (check (length visible) => 1000)
+  (check (car visible) => "0")
+  (check (list-ref visible 999) => "999")
+) ;let
+;; 用户的原始复现场景：member + append 循环去重构建长列表
+(let loop
+  ((entries (map (lambda (i) (cons (number->string i) (list "lib"))) (iota 1000)))
+   (visible '())
+  ) ;
+  (if (null? entries)
+    (begin
+      (check (proper-list? visible) => #t)
+      (check (length visible) => 1000)
+      (check (list-ref visible 999) => "999")
+    ) ;begin
+    (let* ((entry (car entries)) (function-name (car entry)))
+      (loop (cdr entries)
+        (if (not (member function-name visible))
+          (append visible (list function-name))
+          visible
+        ) ;if
+      ) ;loop
+    ) ;let*
+  ) ;if
+) ;let
 (check-report)


### PR DESCRIPTION
## 问题

\`gf doc "string-spli"\` 模糊匹配崩溃，报错：

\`\`\`
;append first argument, ("0" "1" "2" ...), is a pair but should be a proper list
\`\`\`

任何用 \`append\` 循环构建长列表（约 500+ 元素）的代码都会触发。

## 根因

两参数 \`append\` 走优化路径 \`g_append_2\` → \`s7_append\`。其复制循环中 \`list_1\` 分配 cell 时会触发 GC，但只有第一个参数 \`a\`（\`temp9\`）和正在构建的新列表 \`q\`（\`temp6\`）受 GC 保护，**第二个参数 \`b\` 没有保护**。长列表复制时 GC 触发，\`b\` 被清扫回收，循环末尾 \`set_cdr(np, b)\` 把空闲 cell 链进新列表，产生 dotted/环形列表（插桩确认尾部为 \`<free cell!>\`，\`length\` 返回负值）。

多参数路径 \`g_append\` → \`g_list_append\` 用 \`gc_protect_via_stack\` 保护了整个 args，不受影响（apply 路径回归验证通过）。

## 修复

\`s7_append\` 复制循环期间用 \`sc->temp7\` 保护 \`b\`（仅两行赋值）。

## 测试

- \`tests/scheme/base/append-test.scm\` 新增长列表回归测试（1000 元素循环构建 + 用户原始 member+append 去重场景）
- \`bin/gf test --all\`：1495 个测试全部通过
- \`gf doc "string-spli"\` 模糊匹配恢复正常

## 性能（bench/append.scm，修复前 → 修复后）

| 用例 | 修复前 | 修复后（最优） |
|---|---|---|
| 短列表 × 100万次 | 0.0296s | 0.0302s |
| 中列表(100) × 1万次 | 0.00325s | 0.00282s |
| 长列表(1000) × 1000次 | 0.00372s | 0.00309s |
| 循环构建300元素 × 100次 | 0.0169s | 0.0160s |

修复每次调用仅多两次指针赋值（~1-2ns，单次 append 约 30ns），实测差异在系统噪声范围内，无性能退化。

详见 devel/0117.md。

🤖 Generated with [Claude Code](https://claude.com/claude-code)