### PR TITLE
[0116] define-record-type 替换为 C 实现 g_define_record_type，提升宏展开性能

### DIFF
--- a/bench/define-record-type.scm
+++ b/bench/define-record-type.scm
@@ -1,0 +1,126 @@
+;;
+;; Copyright (C) 2026 The Goldfish Scheme Authors
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+;; the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+
+;; define-record-type 性能基准测试
+;; 对比旧 Scheme 宏（define-macro，已从 base.scm 移除，此处原样保留）
+;; 与新的 C 宏（src/s7_liii_record.c 的 g_define_record_type）
+;;
+;; 两个版本生成的展开式完全相同（let 表示），因此运行时操作
+;; （构造/谓词/访问/修改）性能一致，差异只在宏展开耗时
+;; —— 每个使用 define-record-type 的库在加载时都要支付一次展开开销。
+
+(import (liii timeit) (scheme base) (scheme let))
+
+(define (bench name stmt number)
+  (let ((elapsed (timeit stmt '() number)))
+    (display name)
+    (display ": ")
+    (display elapsed)
+    (display " 秒 (")
+    (display number)
+    (display " 次)\n")
+  ) ;let
+) ;define
+
+;; 旧 Scheme 实现（从 goldfish/scheme/base.scm 原样保留，用于性能对比）
+(define-macro (define-record-type-old type make ? . fields)
+  (let ((obj (gensym))
+        (typ (gensym))
+        (args (map (lambda (field)
+                     (values (list 'quote (car field))
+                       (let ((par (memq (car field) (cdr make))))
+                         (and (pair? par) (car par))
+                       ) ;let
+                     ) ;values
+                   ) ;lambda
+                fields
+              ) ;map
+        ) ;args
+       ) ;
+    `(begin
+       (define (,? ,obj)
+         (and (let? ,obj) (eq? (let-ref ,obj (quote ,typ)) (quote ,type))))
+       (define ,make (inlet (quote ,typ) (quote ,type) ,@args))
+       ,@(map (lambda (field)
+                (when (pair? field)
+                  (if (null? (cdr field))
+                    (values)
+                    (if (null? (cddr field))
+                      `(define (,(cadr field) ,obj)
+                         (let-ref ,obj (quote ,(car field))))
+                      `(begin
+                         (define (,(cadr field) ,obj)
+                           (let-ref ,obj (quote ,(car field))))
+                         (define (,(caddr field) ,obj val)
+                           (let-set! ,obj (quote ,(car field)) val)))))))
+           fields)
+       (quote ,type))
+  ) ;let
+) ;define-macro
+
+;; 一个典型的记录类型定义（4 个字段，含访问器和修改器）
+
+(define (run-benchmarks)
+  (display "=== define-record-type 宏展开性能（旧 Scheme 宏 vs 新 C 宏）===\n\n"
+  ) ;display
+  (bench "旧 Scheme 宏展开"
+    (lambda ()
+      (macroexpand (define-record-type-old :person
+                     (make-person name age)
+                     person?
+                     (name get-name set-name!)
+                     (age get-age set-age!)
+                     (email get-email)
+                     (phone get-phone)
+                   ) ;define-record-type-old
+      ) ;macroexpand
+    ) ;lambda
+    10000
+  ) ;bench
+  (bench "新 C 宏展开     "
+    (lambda ()
+      (macroexpand (define-record-type :person
+                     (make-person name age)
+                     person?
+                     (name get-name set-name!)
+                     (age get-age set-age!)
+                     (email get-email)
+                     (phone get-phone)
+                   ) ;define-record-type
+      ) ;macroexpand
+    ) ;lambda
+    10000
+  ) ;bench
+  (newline)
+
+  ;; 两个版本展开式相同，运行时性能一致（展示用，各定义一个类型）
+  (display "=== 运行时操作（两版展开式相同，性能一致）===\n\n")
+  (eval '(define-record-type-old :pare/old
+           (kons/old x y)
+           pare/old?
+           (x kar/old)
+           (y kdr/old))
+  ) ;eval
+  (eval '(define-record-type :pare (kons x y) pare? (x kar) (y kdr)))
+  (bench "构造（旧展开式）" (lambda () (kons/old 1 2)) 100000)
+  (bench "构造（新展开式）" (lambda () (kons 1 2)) 100000)
+  (let ((old-obj (kons/old 1 2)) (new-obj (kons 1 2)))
+    (bench "访问（旧展开式）" (lambda () (kar/old old-obj)) 100000)
+    (bench "访问（新展开式）" (lambda () (kar new-obj)) 100000)
+  ) ;let
+) ;define
+
+(run-benchmarks)

--- a/devel/0116.md
+++ b/devel/0116.md
@@ -1,0 +1,78 @@
+# [0116] 用 C 语言实现 define-record-type，提升宏展开性能
+
+## 任务相关的代码文件
+- src/s7_liii_record.c（新增，g_define_record_type 宏 + glue_liii_record）
+- src/s7_liii_record.h（新增）
+- src/goldfish.hpp（include + 注册 glue_liii_record）
+- xmake.lua（新增 src/s7_liii_record.c）
+- goldfish/scheme/base.scm（删除旧 define-macro 实现）
+- tests/scheme/base/define-record-type-test.scm（扩充测试）
+- bench/define-record-type.scm（新增，保留旧 Scheme 宏做性能对比）
+
+## 如何测试
+```bash
+# 1. 构建
+xmake b goldfish
+
+# 2. 格式化
+bin/gf fmt tests/scheme/base/define-record-type-test.scm
+bin/gf fmt bench/define-record-type.scm
+clang-format --style=file -i src/s7_liii_record.c src/s7_liii_record.h
+
+# 3. 运行测试
+bin/gf tests/scheme/base/define-record-type-test.scm
+
+# 4. 运行性能基准
+bin/gf bench/define-record-type.scm
+
+# 5. 重建文档索引并查看文档
+bin/gf doc --build-json
+bin/gf doc define-record-type
+```
+
+## 2026-08-14 define-record-type 实现替换为 C 语言（g_define_record_type）
+### What
+1. `src/s7_liii_record.c` 新增 `g_define_record_type`，通过
+   `s7_define_macro` 注册为 `define-record-type`（3 必需参数 + rest），
+   在 `goldfish.hpp` 的 `glue_for_community_edition` 中注册
+2. `goldfish/scheme/base.scm` 删除旧 `define-macro` 实现；
+   `(scheme base)` 的导出经 rootlet 虚解析（与 `when`/`unless` 相同机制）
+3. `tests/scheme/base/define-record-type-test.scm` 从 13 个用例扩充为 42 个：
+   构造器参数乱序、缺省字段为 #f、空构造器、跨类型谓词、
+   谓词作用于非记录值、访问器/修改器错误处理、参数个数错误、
+   局部作用域定义、嵌套记录、同名类型重复定义等
+4. 新增 `bench/define-record-type.scm`：原样保留旧 Scheme 宏，
+   对比新旧宏的展开耗时
+5. 全量测试 1495 个文件通过（仅 srfi-78 既有的故意失败演示用例）
+
+### Why
+旧 `define-macro` 版本每次展开都要在 Scheme 层执行
+map/memq/quasiquote，每个使用 define-record-type 的库加载时都要支付一次。
+
+### How
+C 宏解析并校验语法后直接构建展开式返回（`s7_list`/`s7_cons`，
+GC 保护依赖 s7 的 GC_TEMPS 滞后机制 + 对 args/gensym/结果列表的
+via_stack 保护）。
+
+**关键设计决策：展开式保持 let 表示不变**。最初尝试改为 vector 表示
+（0 号槽存类型 tag），但原语级基准表明 s7 对 `inlet` 和常量键
+`let-ref` 有深度优化，let 表示的运行时性能反而更优：
+
+| 操作（1M 次，含闭包调用开销） | 最优 vector 候选 | let 表示（旧实现） |
+|---|---|---|
+| 字段访问 | 24.3ms（is?+vector-ref） | **16.3ms**（let-ref） |
+| 类型谓词 | **24.1ms**（C 函数） | 25.4ms（let?+let-ref） |
+| 构造 | 42.8ms（vector） | **31.5ms**（inlet） |
+
+此外 3 元以上的 safe C 函数每次调用要堆分配参数列表
+（如 g_record_ref 单次调用 29.2ms/1M 次 vs vector-ref 14.5ms），
+进一步削弱了 vector 方案的优势。保持 let 表示还意味着零可观察行为
+变化：记录仍是 let，打印格式不变，`let?`/`let-ref` 依旧可用。
+
+基准结果（bench/define-record-type.scm）：
+
+| 用例 | 旧 Scheme 宏 | 新 C 宏 | 提升 |
+|---|---|---|---|
+| 宏展开（4 字段记录 × 10000 次） | 0.0203 秒 | 0.0089 秒 | ~2.3x |
+| 构造（× 100000 次） | 0.0038 秒 | 0.0046 秒 | 一致（展开式相同） |
+| 访问（× 100000 次） | 0.0016 秒 | 0.0016 秒 | 一致（展开式相同） |

--- a/goldfish/scheme/base.scm
+++ b/goldfish/scheme/base.scm
@@ -257,41 +257,6 @@
          (varlet (curlet) ((lambda ,vars (curlet)) ,expression)))
     ) ;define-macro
 
-    (define-macro (define-record-type type make ? . fields)
-      (let ((obj (gensym))
-            (typ (gensym))
-            (args (map (lambda (field)
-                         (values (list 'quote (car field))
-                           (let ((par (memq (car field) (cdr make))))
-                             (and (pair? par) (car par))
-                           ) ;let
-                         ) ;values
-                       ) ;lambda
-                    fields
-                  ) ;map
-            ) ;args
-           ) ;
-        `(begin
-           (define (,? ,obj)
-             (and (let? ,obj) (eq? (let-ref ,obj (quote ,typ)) (quote ,type))))
-           (define ,make (inlet (quote ,typ) (quote ,type) ,@args))
-           ,@(map (lambda (field)
-                    (when (pair? field)
-                      (if (null? (cdr field))
-                        (values)
-                        (if (null? (cddr field))
-                          `(define (,(cadr field) ,obj)
-                             (let-ref ,obj (quote ,(car field))))
-                          `(begin
-                             (define (,(cadr field) ,obj)
-                               (let-ref ,obj (quote ,(car field))))
-                             (define (,(caddr field) ,obj val)
-                               (let-set! ,obj (quote ,(car field)) val)))))))
-               fields)
-           (quote ,type))
-      ) ;let
-    ) ;define-macro
-
     (define exact inexact->exact)
 
     (define inexact exact->inexact)

--- a/src/goldfish.hpp
+++ b/src/goldfish.hpp
@@ -15,8 +15,8 @@
 //
 
 #include "s7.h"
-#include "s7_r7rs_library.h"
 #include "s7_liii_record.h"
+#include "s7_r7rs_library.h"
 #include <algorithm>
 #include <argh.h>
 #include <cctype>

--- a/src/goldfish.hpp
+++ b/src/goldfish.hpp
@@ -16,6 +16,7 @@
 
 #include "s7.h"
 #include "s7_r7rs_library.h"
+#include "s7_liii_record.h"
 #include <algorithm>
 #include <argh.h>
 #include <cctype>
@@ -713,6 +714,7 @@ glue_for_community_edition (s7_scheme* sc) {
   glue_scheme_base (sc);
   glue_scheme_char (sc);
   glue_r7rs_library (sc);
+  glue_liii_record (sc);
   glue_njson (sc);
 #ifdef GOLDFISH_ENABLE_HTTP
   glue_http (sc);

--- a/src/s7_liii_record.c
+++ b/src/s7_liii_record.c
@@ -1,0 +1,189 @@
+//
+// Copyright (C) 2026 The Goldfish Scheme Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+// the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+/* s7_liii_record.c - C implementation of define-record-type (SRFI-9 / R7RS)
+ *
+ * The macro is implemented in C to avoid the expansion-time cost of the old
+ * define-macro version (Scheme-level map/memq/quasiquote for every record
+ * type at library load time).  The generated expansion is intentionally the
+ * same let-based one the Scheme macro produced: s7 heavily optimizes inlet
+ * and let-ref with constant keys, so the let representation is faster at run
+ * time than a vector-based one (see devel/0116.md for the benchmarks).
+ * Keeping the let representation also means zero observable behavior change:
+ * records are still lets, print the same, and let?/let-ref keep working on
+ * them.
+ */
+
+#include "s7_liii_record.h"
+
+static s7_pointer
+record_error (s7_scheme* sc, const char* msg, s7_pointer arg) {
+  return s7_error (sc, s7_make_symbol (sc, "wrong-type-arg"), s7_list (sc, 2, s7_make_string (sc, msg), arg));
+}
+
+static bool
+record_symbol_list (s7_scheme* sc, s7_pointer lst) {
+  if (s7_list_length (sc, lst) < 0) return false; /* improper or circular */
+  for (s7_pointer p= lst; s7_is_pair (p); p= s7_cdr (p))
+    if (!s7_is_symbol (s7_car (p))) return false;
+  return true;
+}
+
+static bool
+record_memq_sym (s7_pointer sym, s7_pointer lst) {
+  for (s7_pointer p= lst; s7_is_pair (p); p= s7_cdr (p))
+    if (s7_car (p) == sym) return true; /* symbols: pointer equality */
+  return false;
+}
+
+/* append form to the tail of the list headed by *tail (update *tail) */
+static void
+record_append (s7_scheme* sc, s7_pointer* tail, s7_pointer form) {
+  s7_pointer cell= s7_cons (sc, form, s7_nil (sc));
+  s7_set_cdr (*tail, cell);
+  *tail= cell;
+}
+
+/* (define-record-type type-name (constructor field ...) predicate
+ *   (field-name accessor [modifier]) ...)
+ *
+ * expands to
+ *   (begin
+ *     (define (predicate obj)
+ *       (and (let? obj) (eq? (let-ref obj 'typ) 'type-name)))
+ *     (define (constructor arg ...)
+ *       (inlet 'typ 'type-name 'field value ...))
+ *     (define (accessor obj) (let-ref obj 'field))
+ *     (define (modifier obj val) (let-set! obj 'field val))
+ *     ...
+ *     'type-name)
+ * where obj and typ are fresh gensyms and the constructor values are given in
+ * field declaration order (constructor arguments are reordered as needed,
+ * fields missing from the constructor spec default to #f).
+ */
+s7_pointer
+g_define_record_type (s7_scheme* sc, s7_pointer args) {
+  s7_gc_protect_via_stack (sc, args);
+
+  s7_pointer type_name= s7_car (args);
+  s7_pointer ctor_spec= s7_cadr (args);
+  s7_pointer pred_name= s7_caddr (args);
+  s7_pointer fields   = s7_cdddr (args);
+
+  if (!s7_is_symbol (type_name)) {
+    s7_gc_unprotect_via_stack (sc, args);
+    return record_error (sc, "define-record-type: type name should be a symbol, but got ~S", type_name);
+  }
+  if ((!s7_is_pair (ctor_spec)) || (!s7_is_symbol (s7_car (ctor_spec))) ||
+      (!record_symbol_list (sc, s7_cdr (ctor_spec)))) {
+    s7_gc_unprotect_via_stack (sc, args);
+    return record_error (sc, "define-record-type: constructor spec should be (name field ...), but got ~S", ctor_spec);
+  }
+  if (!s7_is_symbol (pred_name)) {
+    s7_gc_unprotect_via_stack (sc, args);
+    return record_error (sc, "define-record-type: predicate name should be a symbol, but got ~S", pred_name);
+  }
+  if (s7_list_length (sc, fields) < 0) {
+    s7_gc_unprotect_via_stack (sc, args);
+    return record_error (sc, "define-record-type: field specs should be a proper list, but got ~S", fields);
+  }
+  for (s7_pointer p= fields; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer spec    = s7_car (p);
+    s7_int     rest_len= (s7_is_pair (spec)) ? s7_list_length (sc, s7_cdr (spec)) : -1;
+    if ((!s7_is_pair (spec)) || (!s7_is_symbol (s7_car (spec))) || (rest_len < 0) || (rest_len > 2) ||
+        (!record_symbol_list (sc, s7_cdr (spec)))) {
+      s7_gc_unprotect_via_stack (sc, args);
+      return record_error (sc, "define-record-type: field spec should be (name [accessor [modifier]]), but got ~S",
+                           spec);
+    }
+  }
+
+  s7_pointer begin_sym  = s7_make_symbol (sc, "begin");
+  s7_pointer define_sym = s7_make_symbol (sc, "define");
+  s7_pointer lambda_sym = s7_make_symbol (sc, "lambda");
+  s7_pointer quote_sym  = s7_make_symbol (sc, "quote");
+  s7_pointer and_sym    = s7_make_symbol (sc, "and");
+  s7_pointer eq_sym     = s7_make_symbol (sc, "eq?");
+  s7_pointer is_let_sym = s7_make_symbol (sc, "let?");
+  s7_pointer let_ref_sym= s7_make_symbol (sc, "let-ref");
+  s7_pointer let_set_sym= s7_make_symbol (sc, "let-set!");
+  s7_pointer inlet_sym  = s7_make_symbol (sc, "inlet");
+  s7_pointer obj_sym    = s7_gensym (sc, "obj");
+  s7_pointer typ_sym    = s7_gensym (sc, "typ");
+  s7_pointer val_sym    = s7_make_symbol (sc, "val");
+
+  /* nested s7_list builds are covered by s7's GC_TEMPS lag (see s7.h): a
+   * freshly created object cannot be collected before several further
+   * allocations, and each form is attached to the protected result list
+   * immediately after being built */
+  s7_gc_protect_via_stack (sc, obj_sym);
+  s7_gc_protect_via_stack (sc, typ_sym);
+  s7_pointer result= s7_gc_protect_via_stack (sc, s7_list (sc, 1, begin_sym));
+  s7_pointer tail  = result;
+
+  /* predicate: (define (pred obj) (and (let? obj) (eq? (let-ref obj 'typ) 'type))) */
+  record_append (sc, &tail,
+                 s7_list (sc, 3, define_sym, s7_list (sc, 2, pred_name, obj_sym),
+                          s7_list (sc, 3, and_sym, s7_list (sc, 2, is_let_sym, obj_sym),
+                                   s7_list (sc, 3, eq_sym,
+                                            s7_list (sc, 3, let_ref_sym, obj_sym, s7_list (sc, 2, quote_sym, typ_sym)),
+                                            s7_list (sc, 2, quote_sym, type_name)))));
+
+  /* constructor: (define (ctor arg ...) (inlet 'typ 'type 'field value ...))
+   * with values in field declaration order */
+  {
+    s7_pointer call= s7_gc_protect_via_stack (
+        sc, s7_list (sc, 3, inlet_sym, s7_list (sc, 2, quote_sym, typ_sym), s7_list (sc, 2, quote_sym, type_name)));
+    s7_pointer ctail= s7_cdr (s7_cdr (call));
+    for (s7_pointer p= fields; s7_is_pair (p); p= s7_cdr (p)) {
+      s7_pointer field_name= s7_car (s7_car (p));
+      s7_pointer value     = (record_memq_sym (field_name, s7_cdr (ctor_spec))) ? field_name : s7_f (sc);
+      record_append (sc, &ctail, s7_list (sc, 2, quote_sym, field_name));
+      record_append (sc, &ctail, value);
+    }
+    record_append (sc, &tail, s7_list (sc, 3, define_sym, ctor_spec, call));
+    s7_gc_unprotect_via_stack (sc, call);
+  }
+
+  /* accessors and modifiers */
+  for (s7_pointer p= fields; s7_is_pair (p); p= s7_cdr (p)) {
+    s7_pointer rest= s7_cdr (s7_car (p));
+    if (!s7_is_pair (rest)) continue;
+    record_append (sc, &tail,
+                   s7_list (sc, 3, define_sym, s7_list (sc, 2, s7_car (rest), obj_sym),
+                            s7_list (sc, 3, let_ref_sym, obj_sym, s7_list (sc, 2, quote_sym, s7_car (s7_car (p))))));
+    if (s7_is_pair (s7_cdr (rest)))
+      record_append (
+          sc, &tail,
+          s7_list (sc, 3, define_sym, s7_list (sc, 3, s7_cadr (rest), obj_sym, val_sym),
+                   s7_list (sc, 4, let_set_sym, obj_sym, s7_list (sc, 2, quote_sym, s7_car (s7_car (p))), val_sym)));
+  }
+
+  record_append (sc, &tail, s7_list (sc, 2, quote_sym, type_name));
+
+  s7_gc_unprotect_via_stack (sc, result);
+  s7_gc_unprotect_via_stack (sc, typ_sym);
+  s7_gc_unprotect_via_stack (sc, obj_sym);
+  s7_gc_unprotect_via_stack (sc, args);
+  return result;
+}
+
+void
+glue_liii_record (s7_scheme* sc) {
+  s7_define_macro (sc, "define-record-type", g_define_record_type, 3, 0, true,
+                   "(define-record-type type-name (constructor field ...) predicate (field-name accessor "
+                   "[modifier]) ...) defines a new record type");
+}

--- a/src/s7_liii_record.h
+++ b/src/s7_liii_record.h
@@ -1,0 +1,34 @@
+//
+// Copyright (C) 2026 The Goldfish Scheme Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#ifndef S7_LIII_RECORD_H
+#define S7_LIII_RECORD_H
+
+#include "s7.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+s7_pointer g_define_record_type (s7_scheme* sc, s7_pointer args);
+
+void glue_liii_record (s7_scheme* sc);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* S7_LIII_RECORD_H */

--- a/tests/scheme/base/define-record-type-test.scm
+++ b/tests/scheme/base/define-record-type-test.scm
@@ -83,4 +83,94 @@
   (check (get-name p2) => "Bob")
   (check (+ (get-age p1) (get-age p2)) => 55)
 ) ;let
+;; 构造器参数顺序与字段声明顺序不同
+(define-record-type :point
+  (make-point y x)
+  point?
+  (x point-x)
+  (y point-y)
+) ;define-record-type
+(let ((p (make-point 10 20)))
+  (check (point-y p) => 10)
+  (check (point-x p) => 20)
+) ;let
+;; 构造器只初始化部分字段，其余字段默认 #f（Goldfish 行为）
+(define-record-type :partial
+  (make-partial a)
+  partial?
+  (a partial-a)
+  (b partial-b)
+) ;define-record-type
+(let ((p (make-partial 1)))
+  (check (partial-a p) => 1)
+  (check (partial-b p) => #f)
+) ;let
+;; 构造器不含任何字段
+(define-record-type :empty
+  (make-empty)
+  empty-rec?
+  (a empty-a)
+) ;define-record-type
+(check (empty-rec? (make-empty)) => #t)
+(check (empty-a (make-empty)) => #f)
+;; 跨类型谓词判断
+(check (pare? (make-person "Da" 3)) => #f)
+(check (person? (kons 1 2)) => #f)
+;; 谓词作用于非记录值
+(check (pare? 3) => #f)
+(check (pare? "abc") => #f)
+(check (pare? #(1 2)) => #f)
+(check (pare? (vector)) => #f)
+(check (pare? '()) => #f)
+;; 访问器/修改器作用于错误类型时报错
+(check-catch 'wrong-type-arg (kar 3))
+(check-catch 'wrong-type-arg (kar "abc"))
+(check-catch 'wrong-type-arg (kar (cons 1 2)))
+(check-catch 'wrong-type-arg (set-kar! (cons 1 2) 3))
+;; 参数个数错误
+(check-catch 'wrong-number-of-args (kons 1))
+(check-catch 'wrong-number-of-args (kons 1 2 3))
+(check-catch 'wrong-number-of-args (kar))
+(check-catch 'wrong-number-of-args (set-kar! (kons 1 2)))
+;; 在局部作用域中定义记录类型
+(let ()
+  (define-record-type :local
+    (make-local v)
+    local?
+    (v local-v set-local-v!)
+  ) ;define-record-type
+  (let ((r (make-local 5)))
+    (check (local? r) => #t)
+    (check (local-v r) => 5)
+    (set-local-v! r 6)
+    (check (local-v r) => 6)
+  ) ;let
+) ;let
+;; 字段值可以是另一个记录（嵌套记录）
+(define-record-type :holder
+  (make-holder content)
+  holder?
+  (content holder-content)
+) ;define-record-type
+(let ((h (make-holder (kons 1 2))))
+  (check (holder? h) => #t)
+  (check (pare? (holder-content h)) => #t)
+  (check (kar (holder-content h)) => 1)
+) ;let
+;; 同名类型重复定义互不干扰（各自拥有独立的类型标识）
+(let ()
+  (define-record-type :dup
+    (make-dup1 v)
+    dup1?
+    (v dup1-v)
+  ) ;define-record-type
+  (define-record-type :dup
+    (make-dup2 v)
+    dup2?
+    (v dup2-v)
+  ) ;define-record-type
+  (check (dup1? (make-dup1 1)) => #t)
+  (check (dup1? (make-dup2 1)) => #f)
+  (check (dup2? (make-dup2 1)) => #t)
+) ;let
 (check-report)

--- a/xmake.lua
+++ b/xmake.lua
@@ -126,6 +126,7 @@ target ("goldfish") do
     add_files ("src/s7_liii_string.c", {languages = "c11"})
     add_files ("src/s7_liii_hash_table.c", {languages = "c11"})
     add_files ("src/s7_liii_list.c", {languages = "c11"})
+    add_files ("src/s7_liii_record.c", {languages = "c11"})
     add_files ("src/s7_liii_vector.c", {languages = "c11"})
     add_files ("src/s7_module.c", {languages = "c11"})
     add_files ("src/s7_r7rs_library.c", {languages = "c11"})


### PR DESCRIPTION
## 概述

用 C 语言实现 `define-record-type`（SRFI-9 / R7RS），替换 `base.scm` 中的 `define-macro` 版本，宏展开提速约 **2.3 倍**（20.3µs → 8.9µs/次）。

## 实现

- 新增 `src/s7_liii_record.c/.h`：`g_define_record_type` 通过 `s7_define_macro` 注册（参照 `define-library` 的既定模式），C 端解析校验语法后直接构建展开式
- `goldfish/scheme/base.scm` 删除旧 define-macro（导出经 rootlet 虚解析，与 `when`/`unless` 同机制）
- 旧 Scheme 宏原样保留在 `bench/define-record-type.scm` 用于性能对比

## 关键设计决策：展开式保持 let 表示

最初尝试改为 vector 表示（0 号槽存类型 tag），但原语级基准表明 s7 对 `inlet` 和常量键 `let-ref` 有深度优化，let 表示运行时反而更快（构造 31.5ns vs 42.8ns，访问 16.3ns vs 24.3ns）。因此 C 宏生成与旧版完全相同的展开式：**收益全在展开速度，零可观察行为变化**（记录仍是 let，打印格式、`let?` 行为全不变）。详细基准数据见 `devel/0116.md`。

## 测试

- 测试用例 13 → 42 个：构造器参数乱序、缺省字段为 #f、空构造器、跨类型谓词、访问器/修改器错误处理、参数个数错误、局部作用域定义、嵌套记录、同名类型重复定义等
- 全量 1495 个测试文件无回归（仅 srfi-78 既有的故意失败演示用例）

🤖 Generated with [Claude Code](https://claude.com/claude-code)