### PR TITLE
[0118] json->string 替换为 C++ 实现 g_json->string，提升性能

### DIFF
--- a/bench/json-to-string-perf.scm
+++ b/bench/json-to-string-perf.scm
@@ -1,0 +1,212 @@
+;;
+;; Copyright (C) 2026 The Goldfish Scheme Authors
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+;; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+;; License for the specific language governing permissions and limitations
+;; under the License.
+;;
+
+;; json->string 性能对比基准：C++ 实现 (g_json->string) vs 历史 Scheme 实现
+;; 运行方式: bin/gf bench/json-to-string-perf.scm
+
+(import (liii base)
+  (liii json)
+  (liii timeit)
+) ;import
+
+;; 历史 Scheme 实现（原 (guenchi json) 中的 json->string），原样保留用于对比
+(define (json->string/scheme json-scm)
+  (when (procedure? json-scm)
+    (type-error "json->string: input must not be a procedure")
+  ) ;when
+  (let ((out (open-output-string)))
+    (define (write-scalar x)
+      (cond ((string? x) (display (json-string-escape x) out))
+            ((number? x) (display (number->string x) out))
+            ((boolean? x) (display (if x "true" "false") out))
+            ((symbol? x) (display (symbol->string x) out))
+            ((null? x) (display "{}" out))
+            (else (type-error "Unexpected x: " x))
+      ) ;cond
+    ) ;define
+    (define (write-json x)
+      (cond ((vector? x)
+             (display "[" out)
+             (let ((len (vector-length x)))
+               (do ((i 0 (+ i 1)))
+                 ((= i len))
+                 (when (> i 0)
+                   (display "," out)
+                 ) ;when
+                 (let ((k (vector-ref x i)))
+                   (cond ((vector? k) (write-json k))
+                         ((pair? k) (write-json k))
+                         (else (write-scalar k))
+                   ) ;cond
+                 ) ;let
+               ) ;do
+             ) ;let
+             (display "]" out)
+            ) ;
+            ((pair? x)
+             (display "{" out)
+             (let loop
+               ((lst x) (i 0))
+               (unless (null? lst)
+                 (let ((d (car lst)))
+                   (when (> i 0)
+                     (display "," out)
+                   ) ;when
+                   (if (null? d)
+                     (display "{}" out)
+                     (begin
+                       (let ((len (length d)))
+                         (when (not (or (= len 0) (= len -1) (>= len 2)))
+                           (value-error d " must be null, pair, or list with at least 2 elements")
+                         ) ;when
+                       ) ;let
+                       (let ((k (loose-car d)) (v (loose-cdr d)))
+                         (write-scalar k)
+                         (display ":" out)
+                         (cond ((null? v) (display "{}" out))
+                               ((list? v) (write-json v))
+                               ((vector? v) (write-json v))
+                               (else (write-scalar v))
+                         ) ;cond
+                       ) ;let
+                     ) ;begin
+                   ) ;if
+                   (loop (cdr lst) (+ i 1))
+                 ) ;let
+               ) ;unless
+             ) ;let
+             (display "}" out)
+            ) ;
+            (else (write-scalar x))
+      ) ;cond
+    ) ;define
+    (write-json json-scm)
+    (get-output-string out)
+  ) ;let
+) ;define
+
+(define (build-json-string n)
+  (let ((out (open-output-string)))
+    (display "{" out)
+    (do ((i 0 (+ i 1)))
+      ((= i n))
+      (when (> i 0)
+        (display "," out)
+      ) ;when
+      (display "\"k" out)
+      (display i out)
+      (display "\":" out)
+      (display i out)
+    ) ;do
+    (display "}" out)
+    (get-output-string out)
+  ) ;let
+) ;define
+
+(define (build-array-string n)
+  (let ((out (open-output-string)))
+    (display "[" out)
+    (do ((i 0 (+ i 1)))
+      ((= i n))
+      (when (> i 0)
+        (display "," out)
+      ) ;when
+      (display i out)
+    ) ;do
+    (display "]" out)
+    (get-output-string out)
+  ) ;let
+) ;define
+
+(define bench-obj-scm (string->json (build-json-string 200)))
+(define bench-arr-scm (string->json (build-array-string 200)))
+(define bench-nested-scm
+  '((user (id . 1001)
+      (name . "Alice")
+      (active . #t)
+      (email . null)
+      (tags . #("dev" "scheme" "json"))
+      (profile (age . 21) (height . 168.5) (hobbies . #("music" "reading"))))
+    (scores . #(98 87 93)))
+) ;define
+
+;; 正确性 sanity check：两种实现输出必须一致
+(unless (equal? (json->string bench-obj-scm) (json->string/scheme bench-obj-scm))
+  (error 'value-error "object output mismatch")
+) ;unless
+(unless (equal? (json->string bench-arr-scm) (json->string/scheme bench-arr-scm))
+  (error 'value-error "array output mismatch")
+) ;unless
+(unless (equal? (json->string bench-nested-scm) (json->string/scheme bench-nested-scm))
+  (error 'value-error "nested output mismatch")
+) ;unless
+
+(define iter 200)
+
+(define (report title time-val)
+  (display "[")
+  (display title)
+  (display "] iterations=")
+  (display iter)
+  (display " time=")
+  (display time-val)
+  (display "s")
+  (newline)
+) ;define
+
+;; warmup
+(do ((i 0 (+ i 1)))
+  ((= i 20))
+  (json->string bench-obj-scm)
+  (json->string/scheme bench-obj-scm)
+) ;do
+
+(display "=== json->string C++ vs Scheme 性能对比 ===")
+(newline)
+(newline)
+
+(let ((t (timeit (lambda () (json->string bench-obj-scm)) '() iter)))
+  (report "对象/C++" t)
+) ;let
+(let ((t (timeit (lambda () (json->string/scheme bench-obj-scm)) '() iter)))
+  (report "对象/Scheme" t)
+) ;let
+(let ((t (timeit (lambda () (json->string bench-arr-scm)) '() iter)))
+  (report "数组/C++" t)
+) ;let
+(let ((t (timeit (lambda () (json->string/scheme bench-arr-scm)) '() iter)))
+  (report "数组/Scheme" t)
+) ;let
+(let ((t (timeit (lambda () (json->string bench-nested-scm)) '() (* 10 iter))))
+  (display "[嵌套/C++] iterations=")
+  (display (* 10 iter))
+  (display " time=")
+  (display t)
+  (display "s")
+  (newline)
+) ;let
+(let ((t (timeit (lambda () (json->string/scheme bench-nested-scm)) '() (* 10 iter))))
+  (display "[嵌套/Scheme] iterations=")
+  (display (* 10 iter))
+  (display " time=")
+  (display t)
+  (display "s")
+  (newline)
+) ;let
+
+(newline)
+(display "=== 测试完成 ===")
+(newline)

--- a/devel/0118.md
+++ b/devel/0118.md
@@ -1,0 +1,43 @@
+# [0118] json->string 替换为 C++ 实现，提升性能
+
+## 任务相关的代码文件
+- src/liii_json.cpp（新增，C++ 实现 g_json->string）
+- src/goldfish.hpp（声明并调用 glue_liii_json）
+- xmake.lua（goldfish target 加入 src/liii_json.cpp）
+- goldfish/liii/json.scm（json->string 绑定到 g_json->string）
+- goldfish/guenchi/json.scm（移除 Scheme 版 json->string 的导出与实现）
+- bench/json-to-string-perf.scm（新增，C++ vs Scheme 性能对比）
+- tests/liii/json/json-to-string-test.scm（已有测试，语义回归）
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf tests/liii/json/json-to-string-test.scm
+bin/gf tests/liii/json-test.scm
+bin/gf bench/json-to-string-perf.scm
+```
+
+## 2026-08-14 json->string 替换为 C++ 实现 g_json->string，提升性能
+
+### What
+1. 新增 `src/liii_json.cpp`，用 C++ 实现 `g_json->string`，语义与原 (guenchi json) 的 Scheme 实现完全一致：
+   - vector => JSON 数组；序对列表 => JSON 对象；`'()` => `{}`
+   - 字符串转义规则一致（`\" \\ \/ \b \f \n \r \t`，多字节 UTF-8 原样输出）
+   - 符号原样输出（宽松键格式，如 `{a:1}`）；数字走 `s7_number_to_string`（等价 `number->string`）
+   - 错误类型一致：procedure 输入抛 `type-error`；非法对象条目抛 `value-error`
+2. `(guenchi json)` 移除 `json->string` 的导出与 Scheme 实现，仅在 `(liii json)` 中导出 `json->string`（绑定到 `g_json->string`）。
+3. 新增 `bench/json-to-string-perf.scm`，同进程对比 C++ 与历史 Scheme 实现。
+
+### Why
+`json->string` 是 JSON 序列化的热路径，原 Scheme 实现通过 `open-output-string` 逐段 `display`，开销大。
+
+### How
+C++ 侧用 `std::string` 递归拼接，避免端口写入和中间字符串分配；通过 `s7_vector_elements` 直接访问向量元素；`glue_liii_json` 在 `goldfish.hpp` 中注册到全局环境，`(liii json)` 中以 `(define json->string g_json->string)` 绑定导出。
+
+性能对比（Windows，release 构建，bench/json-to-string-perf.scm）：
+
+| 场景 | C++ | Scheme | 加速比 |
+|---|---|---|---|
+| 对象（200 键） | 0.0036s/200 次 | 0.0803s/200 次 | ~22x |
+| 数组（200 元素） | 0.0022s/200 次 | 0.0107s/200 次 | ~4.8x |
+| 嵌套结构 | 0.0033s/2000 次 | 0.0469s/2000 次 | ~14x |

--- a/goldfish/guenchi/json.scm
+++ b/goldfish/guenchi/json.scm
@@ -27,7 +27,7 @@
     (liii string)
     (liii unicode)
   ) ;import
-  (export json-string-escape string->json json->string json-ref json-ref*
+  (export json-string-escape string->json json-ref json-ref*
     json-set json-set* json-push json-push* json-drop json-drop* json-reduce
     json-reduce*
   ) ;export
@@ -267,80 +267,6 @@
               ) ;open-input-string
         ) ;read
       ) ;lambda
-    ) ;define
-    (define (json->string json-scm)
-      (when (procedure? json-scm)
-        (type-error "json->string: input must not be a procedure")
-      ) ;when
-      (let ((out (open-output-string)))
-        (define (write-scalar x)
-          (cond ((string? x) (display (json-string-escape x) out))
-                ((number? x) (display (number->string x) out))
-                ((boolean? x) (display (if x "true" "false") out))
-                ((symbol? x) (display (symbol->string x) out))
-                ((null? x) (display "{}" out))
-                (else (type-error "Unexpected x: " x))
-          ) ;cond
-        ) ;define
-        (define (write-json x)
-          (cond ((vector? x)
-                 (display "[" out)
-                 (let ((len (vector-length x)))
-                   (do ((i 0 (+ i 1)))
-                     ((= i len))
-                     (when (> i 0)
-                       (display "," out)
-                     ) ;when
-                     (let ((k (vector-ref x i)))
-                       (cond ((vector? k) (write-json k))
-                             ((pair? k) (write-json k))
-                             (else (write-scalar k))
-                       ) ;cond
-                     ) ;let
-                   ) ;do
-                 ) ;let
-                 (display "]" out)
-                ) ;
-                ((pair? x)
-                 (display "{" out)
-                 (let loop
-                   ((lst x) (i 0))
-                   (unless (null? lst)
-                     (let ((d (car lst)))
-                       (when (> i 0)
-                         (display "," out)
-                       ) ;when
-                       (if (null? d)
-                         (display "{}" out)
-                         (begin
-                           (let ((len (length d)))
-                             (when (not (or (= len 0) (= len -1) (>= len 2)))
-                               (value-error d " must be null, pair, or list with at least 2 elements")
-                             ) ;when
-                           ) ;let
-                           (let ((k (loose-car d)) (v (loose-cdr d)))
-                             (write-scalar k)
-                             (display ":" out)
-                             (cond ((null? v) (display "{}" out))
-                                   ((list? v) (write-json v))
-                                   ((vector? v) (write-json v))
-                                   (else (write-scalar v))
-                             ) ;cond
-                           ) ;let
-                         ) ;begin
-                       ) ;if
-                       (loop (cdr lst) (+ i 1))
-                     ) ;let
-                   ) ;unless
-                 ) ;let
-                 (display "}" out)
-                ) ;
-                (else (write-scalar x))
-          ) ;cond
-        ) ;define
-        (write-json json-scm)
-        (get-output-string out)
-      ) ;let
     ) ;define
     (define json-ref
       (lambda (x k)

--- a/goldfish/guenchi/json.scm
+++ b/goldfish/guenchi/json.scm
@@ -27,9 +27,8 @@
     (liii string)
     (liii unicode)
   ) ;import
-  (export json-string-escape string->json json-ref json-ref*
-    json-set json-set* json-push json-push* json-drop json-drop* json-reduce
-    json-reduce*
+  (export json-string-escape string->json json-ref json-ref* json-set json-set*
+    json-push json-push* json-drop json-drop* json-reduce json-reduce*
   ) ;export
   (begin
 

--- a/goldfish/liii/json.scm
+++ b/goldfish/liii/json.scm
@@ -50,6 +50,9 @@
     ;; ; 0. 统一接口
     ;; ; ---------------------------------------------------------
 
+    ;; json->string 由 C++ 实现（src/liii_json.cpp 中的 g_json->string）
+    (define json->string g_json->string)
+
     (define (ensure-json-structure x)
       (unless (or (json-object? x) (json-array? x))
         (type-error "Value is not a JSON object or array" x)

--- a/src/goldfish.hpp
+++ b/src/goldfish.hpp
@@ -113,6 +113,7 @@ void glue_http (s7_scheme* sc);
 void glue_http_async (s7_scheme* sc);
 #endif
 void glue_liii_base64 (s7_scheme* sc);
+void glue_liii_json (s7_scheme* sc);
 void glue_scheme_base (s7_scheme* sc);
 void glue_scheme_char (s7_scheme* sc);
 void glue_liii_hashlib (s7_scheme* sc);
@@ -711,6 +712,7 @@ glue_for_community_edition (s7_scheme* sc) {
   glue_liii_uuid (sc);
   glue_liii_hashlib (sc);
   glue_liii_base64 (sc);
+  glue_liii_json (sc);
   glue_scheme_base (sc);
   glue_scheme_char (sc);
   glue_r7rs_library (sc);

--- a/src/liii_json.cpp
+++ b/src/liii_json.cpp
@@ -41,15 +41,33 @@ json_write_escaped_string (std::string& out, const char* s, s7_int len) {
     unsigned char c= (unsigned char) s[i];
     if (c < 0x80) {
       switch (c) {
-        case '"': out+= "\\\""; break;
-        case '\\': out+= "\\\\"; break;
-        case '/': out+= "\\/"; break;
-        case '\b': out+= "\\b"; break;
-        case '\f': out+= "\\f"; break;
-        case '\n': out+= "\\n"; break;
-        case '\r': out+= "\\r"; break;
-        case '\t': out+= "\\t"; break;
-        default: out.push_back ((char) c); break;
+      case '"':
+        out+= "\\\"";
+        break;
+      case '\\':
+        out+= "\\\\";
+        break;
+      case '/':
+        out+= "\\/";
+        break;
+      case '\b':
+        out+= "\\b";
+        break;
+      case '\f':
+        out+= "\\f";
+        break;
+      case '\n':
+        out+= "\\n";
+        break;
+      case '\r':
+        out+= "\\r";
+        break;
+      case '\t':
+        out+= "\\t";
+        break;
+      default:
+        out.push_back ((char) c);
+        break;
       }
     }
     else {

--- a/src/liii_json.cpp
+++ b/src/liii_json.cpp
@@ -1,0 +1,198 @@
+//
+// Copyright (C) 2026 The Goldfish Scheme Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+
+#include "s7.h"
+#include <cstdlib>
+#include <string>
+
+namespace goldfish {
+
+// json->string 的 C++ 实现，语义与历史上 (guenchi json) 中的 Scheme 实现完全一致：
+//   - vector   => JSON 数组
+//   - 序对列表  => JSON 对象（键为符号时输出宽松格式，即不带引号）
+//   - '()      => {}
+//   - 字符串    => 转义后带引号输出（\" \\ \/ \b \f \n \r \t，多字节 UTF-8 原样输出）
+//   - symbol   => 原样输出（如 true false null）
+//   - number   => number->string
+//   - boolean  => true / false
+
+static s7_pointer
+json_type_error (s7_scheme* sc, const char* msg, s7_pointer arg) {
+  return s7_error (sc, s7_make_symbol (sc, "type-error"), s7_list (sc, 2, s7_make_string (sc, msg), arg));
+}
+
+static void
+json_write_escaped_string (std::string& out, const char* s, s7_int len) {
+  out.push_back ('"');
+  for (s7_int i= 0; i < len; i++) {
+    unsigned char c= (unsigned char) s[i];
+    if (c < 0x80) {
+      switch (c) {
+        case '"': out+= "\\\""; break;
+        case '\\': out+= "\\\\"; break;
+        case '/': out+= "\\/"; break;
+        case '\b': out+= "\\b"; break;
+        case '\f': out+= "\\f"; break;
+        case '\n': out+= "\\n"; break;
+        case '\r': out+= "\\r"; break;
+        case '\t': out+= "\\t"; break;
+        default: out.push_back ((char) c); break;
+      }
+    }
+    else {
+      // 多字节 UTF-8 字符，直接输出原始字节
+      out.push_back ((char) c);
+    }
+  }
+  out.push_back ('"');
+}
+
+static void json_write_value (s7_scheme* sc, s7_pointer x, std::string& out);
+
+static void
+json_write_scalar (s7_scheme* sc, s7_pointer x, std::string& out) {
+  if (s7_is_string (x)) {
+    json_write_escaped_string (out, s7_string (x), s7_string_length (x));
+  }
+  else if (s7_is_number (x)) {
+    char* s= s7_number_to_string (sc, x, 10);
+    out+= s;
+    free (s);
+  }
+  else if (s7_is_boolean (x)) {
+    out+= (s7_boolean (sc, x) ? "true" : "false");
+  }
+  else if (s7_is_symbol (x)) {
+    out+= s7_symbol_name (x);
+  }
+  else if (s7_is_null (sc, x)) {
+    out+= "{}";
+  }
+  else {
+    json_type_error (sc, "Unexpected x: ", x);
+  }
+}
+
+// 统计序对链的长度；链以非空原子结尾（非真列表）时返回 -1
+static s7_int
+json_pair_chain_length (s7_scheme* sc, s7_pointer x) {
+  s7_int     len= 0;
+  s7_pointer p  = x;
+  while (s7_is_pair (p)) {
+    len++;
+    p= s7_cdr (p);
+  }
+  if (!s7_is_null (sc, p)) return -1;
+  return len;
+}
+
+static void
+json_write_object_entry (s7_scheme* sc, s7_pointer d, std::string& out) {
+  if (s7_is_null (sc, d)) {
+    out+= "{}";
+    return;
+  }
+  if (!s7_is_pair (d)) {
+    s7_error (sc, s7_make_symbol (sc, "value-error"),
+              s7_list (sc, 2, d, s7_make_string (sc, " must be null, pair, or list with at least 2 elements")));
+    return;
+  }
+  s7_int len= json_pair_chain_length (sc, d);
+  if (!(len == -1 || len >= 2)) {
+    s7_error (sc, s7_make_symbol (sc, "value-error"),
+              s7_list (sc, 2, d, s7_make_string (sc, " must be null, pair, or list with at least 2 elements")));
+    return;
+  }
+  s7_pointer k= s7_car (d);
+  s7_pointer v= s7_cdr (d);
+  json_write_scalar (sc, k, out);
+  out.push_back (':');
+  if (s7_is_null (sc, v)) {
+    out+= "{}";
+  }
+  else if ((s7_is_pair (v) && json_pair_chain_length (sc, v) != -1) || s7_is_vector (v)) {
+    json_write_value (sc, v, out);
+  }
+  else {
+    json_write_scalar (sc, v, out);
+  }
+}
+
+static void
+json_write_value (s7_scheme* sc, s7_pointer x, std::string& out) {
+  if (s7_is_vector (x)) {
+    out.push_back ('[');
+    s7_int      len  = s7_vector_length (x);
+    s7_pointer* elems= s7_vector_elements (x);
+    for (s7_int i= 0; i < len; i++) {
+      if (i > 0) out.push_back (',');
+      s7_pointer k= elems[i];
+      if (s7_is_vector (k) || s7_is_pair (k)) {
+        json_write_value (sc, k, out);
+      }
+      else {
+        json_write_scalar (sc, k, out);
+      }
+    }
+    out.push_back (']');
+  }
+  else if (s7_is_pair (x)) {
+    out.push_back ('{');
+    s7_pointer lst= x;
+    s7_int     i  = 0;
+    while (s7_is_pair (lst)) {
+      if (i > 0) out.push_back (',');
+      json_write_object_entry (sc, s7_car (lst), out);
+      lst= s7_cdr (lst);
+      i++;
+    }
+    if (!s7_is_null (sc, lst)) {
+      s7_error (sc, s7_make_symbol (sc, "value-error"),
+                s7_list (sc, 2, lst, s7_make_string (sc, " must be null, pair, or list with at least 2 elements")));
+      return;
+    }
+    out.push_back ('}');
+  }
+  else {
+    json_write_scalar (sc, x, out);
+  }
+}
+
+static s7_pointer
+f_json_to_string (s7_scheme* sc, s7_pointer args) {
+  s7_pointer x= s7_car (args);
+  if (s7_is_procedure (x)) {
+    return s7_error (sc, s7_make_symbol (sc, "type-error"),
+                     s7_list (sc, 1, s7_make_string (sc, "json->string: input must not be a procedure")));
+  }
+  std::string out;
+  json_write_value (sc, x, out);
+  return s7_make_string_with_length (sc, out.data (), (s7_int) out.size ());
+}
+
+static void
+glue_json_to_string (s7_scheme* sc) {
+  const char* name= "g_json->string";
+  const char* desc= "(g_json->string data) => string, encode Scheme-form JSON data to a JSON string";
+  s7_define_function (sc, name, f_json_to_string, 1, 0, false, desc);
+}
+
+void
+glue_liii_json (s7_scheme* sc) {
+  glue_json_to_string (sc);
+}
+
+} // namespace goldfish

--- a/xmake.lua
+++ b/xmake.lua
@@ -115,6 +115,7 @@ target ("goldfish") do
     add_files ("src/liii_string.cpp")
     add_files ("src/liii_hashlib.cpp")
     add_files ("src/liii_base64.cpp")
+    add_files ("src/liii_json.cpp")
     add_files ("src/scheme_base.cpp")
     add_files ("src/scheme_char.cpp")
     add_files ("src/s7.c", {languages = "c11"})


### PR DESCRIPTION
## What
- 新增 `src/liii_json.cpp`，用 C++ 实现 `g_json->string`，语义与原 (guenchi json) 的 Scheme 实现完全一致（转义规则、宽松键格式、错误类型）
- `(guenchi json)` 移除 `json->string` 的导出与实现，仅在 `(liii json)` 中导出（绑定到 `g_json->string`）
- 新增 `bench/json-to-string-perf.scm`，同进程对比 C++ 与历史 Scheme 实现（输出逐字节一致）

## 性能对比（Windows，release 构建）

| 场景 | C++ | Scheme | 加速比 |
|---|---|---|---|
| 对象（200 键） | 0.0036s/200 次 | 0.0803s/200 次 | ~22x |
| 数组（200 元素） | 0.0022s/200 次 | 0.0107s/200 次 | ~4.8x |
| 嵌套结构 | 0.0033s/2000 次 | 0.0469s/2000 次 | ~14x |

## 测试
- `tests/liii/json/` 全部测试通过（含 json-to-string-test.scm 18 checks）
- 依赖 (liii json) 的回归测试通过：njson 系列、inlet-test、goldfmt-config、goldhelp

详见 devel/0118.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)