### PR TITLE
[0120] json-ref/json-set 替换为 C++ 实现 g_json_ref/g_json_set，提升性能

### DIFF
--- a/bench/json-ref-set-perf.scm
+++ b/bench/json-ref-set-perf.scm
@@ -1,0 +1,301 @@
+;;
+;; Copyright (C) 2026 The Goldfish Scheme Authors
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+;; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+;; License for the specific language governing permissions and limitations
+;; under the License.
+;;
+
+;; json-ref / json-set 性能对比基准：C++ 实现 (g_json_ref / g_json_set) vs 历史 Scheme 实现
+;; 运行方式: bin/gf bench/json-ref-set-perf.scm
+
+(import (liii base) (liii json) (liii alist) (liii error) (liii timeit))
+
+;; 历史 Scheme 实现（原 (guenchi json) 的 json-ref/json-set 及 (liii json) 的包装），原样保留用于对比
+
+(define g-json-ref/scheme
+  (lambda (x k)
+    (define return
+      (lambda (x)
+        (if (symbol? x)
+          (cond ((symbol=? x 'true) #t)
+                ((symbol=? x 'false) #f)
+                (else x)
+          ) ;cond
+          x
+        ) ;if
+      ) ;lambda
+    ) ;define
+    (if (vector? x)
+      (return (vector-ref x k))
+      (let loop
+        ((x x) (k k))
+        (if (null? x) '() (if (equal? (caar x) k) (return (cdar x)) (loop (cdr x) k)))
+      ) ;let
+    ) ;if
+  ) ;lambda
+) ;define
+
+(define (json-ref/scheme json key . args)
+  (if (null? json)
+    '()
+    (begin
+      (unless (or (json-object? json) (json-array? json))
+        (type-error "Value is not a JSON object or array" json)
+      ) ;unless
+      (let ((val (if (and (json-object? json) (equal? json '(())))
+                   '()
+                   (g-json-ref/scheme json key)
+                 ) ;if
+            ) ;val
+           ) ;
+        (if (null? args) val (apply json-ref/scheme (cons val args)))
+      ) ;let
+    ) ;begin
+  ) ;if
+) ;define
+
+(define g-json-set/scheme
+  (lambda (x v p)
+    (let ((x x) (v v) (p (if (procedure? p) p (lambda (x) p))))
+      (if (vector? x)
+        (list->vector (cond ((boolean? v)
+                             (if v
+                               (let l
+                                 ((x (vector->alist x)) (p p))
+                                 (if (null? x) '() (cons (p (cdar x)) (l (cdr x) p)))
+                               ) ;let
+                             ) ;if
+                            ) ;
+                            ((procedure? v)
+                             (let l
+                               ((x (vector->alist x)) (v v) (p p))
+                               (if (null? x)
+                                 '()
+                                 (if (v (caar x))
+                                   (cons (p (cdar x)) (l (cdr x) v p))
+                                   (cons (cdar x) (l (cdr x) v p))
+                                 ) ;if
+                               ) ;if
+                             ) ;let
+                            ) ;
+                            (else (let l
+                                    ((x (vector->alist x)) (v v) (p p))
+                                    (if (null? x)
+                                      '()
+                                      (if (equal? (caar x) v)
+                                        (cons (p (cdar x)) (l (cdr x) v p))
+                                        (cons (cdar x) (l (cdr x) v p))
+                                      ) ;if
+                                    ) ;if
+                                  ) ;let
+                            ) ;else
+                      ) ;cond
+        ) ;list->vector
+        (cond ((boolean? v)
+               (if v
+                 (let l
+                   ((x x) (p p))
+                   (if (null? x) '() (cons (cons (caar x) (p (cdar x))) (l (cdr x) p)))
+                 ) ;let
+               ) ;if
+              ) ;
+              ((procedure? v)
+               (let l
+                 ((x x) (v v) (p p))
+                 (if (null? x)
+                   '()
+                   (if (v (caar x))
+                     (cons (cons (caar x) (p (cdar x))) (l (cdr x) v p))
+                     (cons (car x) (l (cdr x) v p))
+                   ) ;if
+                 ) ;if
+               ) ;let
+              ) ;
+              (else (let l
+                      ((x x) (v v) (p p))
+                      (if (null? x)
+                        '()
+                        (if (equal? (caar x) v)
+                          (cons (cons v (p (cdar x))) (l (cdr x) v p))
+                          (cons (car x) (l (cdr x) v p))
+                        ) ;if
+                      ) ;if
+                    ) ;let
+              ) ;else
+        ) ;cond
+      ) ;if
+    ) ;let
+  ) ;lambda
+) ;define
+
+(define (json-set/scheme json key val . args)
+  (unless (or (json-object? json) (json-array? json))
+    (type-error "Value is not a JSON object or array" json)
+  ) ;unless
+  (if (null? args)
+    (if (and (json-object? json) (equal? json '(())))
+      json
+      (g-json-set/scheme json key val)
+    ) ;if
+    (json-set/scheme json
+      key
+      (lambda (x) (apply json-set/scheme (cons x (cons val args))))
+    ) ;json-set/scheme
+  ) ;if
+) ;define
+
+(define (build-json-string n)
+  (let ((out (open-output-string)))
+    (display "{" out)
+    (do ((i 0 (+ i 1)))
+      ((= i n))
+      (when (> i 0)
+        (display "," out)
+      ) ;when
+      (display "\"k" out)
+      (display i out)
+      (display "\":" out)
+      (display i out)
+    ) ;do
+    (display "}" out)
+    (get-output-string out)
+  ) ;let
+) ;define
+
+(define bench-obj (string->json (build-json-string 200)))
+
+(define bench-arr (list->vector (iota 200)))
+
+(define bench-nested
+  (string->json "{\"user\":{\"id\":1001,\"name\":\"Alice\",\"profile\":{\"age\":21,\"height\":168.5,\"hobbies\":[\"music\",\"reading\"]}},\"scores\":[98,87,93]}"
+  ) ;string->json
+) ;define
+
+(define bench-ref-key (string-append "k" (number->string 100)))
+
+;; 正确性 sanity check：两种实现输出必须一致
+(unless (equal? (json-ref bench-obj bench-ref-key)
+          (json-ref/scheme bench-obj bench-ref-key)
+        ) ;equal?
+  (error 'value-error "object ref mismatch")
+) ;unless
+(unless (equal? (json-ref bench-nested 'user 'profile 'age)
+          (json-ref/scheme bench-nested 'user 'profile 'age)
+        ) ;equal?
+  (error 'value-error "nested ref mismatch")
+) ;unless
+(unless (equal? (json-set bench-obj bench-ref-key 0)
+          (json-set/scheme bench-obj bench-ref-key 0)
+        ) ;equal?
+  (error 'value-error "object set mismatch")
+) ;unless
+(unless (equal? (json-set bench-nested 'user 'profile 'age 22)
+          (json-set/scheme bench-nested 'user 'profile 'age 22)
+        ) ;equal?
+  (error 'value-error "nested set mismatch")
+) ;unless
+(unless (equal? (json-set bench-arr #t (lambda (x) (* x 2)))
+          (json-set/scheme bench-arr #t (lambda (x) (* x 2)))
+        ) ;equal?
+  (error 'value-error "array map-set mismatch")
+) ;unless
+
+(define ref-iter 2000)
+
+(define set-iter 500)
+
+(define (report title iterations time-val)
+  (display "[")
+  (display title)
+  (display "] iterations=")
+  (display iterations)
+  (display " time=")
+  (display time-val)
+  (display "s")
+  (newline)
+) ;define
+
+;; warmup
+(do ((i 0 (+ i 1)))
+  ((= i 20))
+  (json-ref bench-obj bench-ref-key)
+  (json-ref/scheme bench-obj bench-ref-key)
+  (json-set bench-obj bench-ref-key 0)
+  (json-set/scheme bench-obj bench-ref-key 0)
+) ;do
+
+(display "=== json-ref / json-set C++ vs Scheme 性能对比 ===")
+(newline)
+(newline)
+
+(let ((t (timeit (lambda () (json-ref bench-obj bench-ref-key)) '() ref-iter)))
+  (report "对象单键读取/C++" ref-iter t)
+) ;let
+(let ((t (timeit (lambda () (json-ref/scheme bench-obj bench-ref-key)) '() ref-iter))
+     ) ;
+  (report "对象单键读取/Scheme" ref-iter t)
+) ;let
+
+(let ((t (timeit (lambda () (json-ref bench-nested 'user 'profile 'age)) '() ref-iter)
+      ) ;t
+     ) ;
+  (report "多键路径读取/C++" ref-iter t)
+) ;let
+(let ((t (timeit (lambda () (json-ref/scheme bench-nested 'user 'profile 'age))
+           '()
+           ref-iter
+         ) ;timeit
+      ) ;t
+     ) ;
+  (report "多键路径读取/Scheme" ref-iter t)
+) ;let
+
+(let ((t (timeit (lambda () (json-set bench-obj bench-ref-key 0)) '() set-iter)))
+  (report "对象单键设置/C++" set-iter t)
+) ;let
+(let ((t (timeit (lambda () (json-set/scheme bench-obj bench-ref-key 0)) '() set-iter)
+      ) ;t
+     ) ;
+  (report "对象单键设置/Scheme" set-iter t)
+) ;let
+
+(let ((t (timeit (lambda () (json-set bench-nested 'user 'profile 'age 22)) '() set-iter)
+      ) ;t
+     ) ;
+  (report "多键路径设置/C++" set-iter t)
+) ;let
+(let ((t (timeit (lambda () (json-set/scheme bench-nested 'user 'profile 'age 22))
+           '()
+           set-iter
+         ) ;timeit
+      ) ;t
+     ) ;
+  (report "多键路径设置/Scheme" set-iter t)
+) ;let
+
+(let ((t (timeit (lambda () (json-set bench-arr #t (lambda (x) (* x 2)))) '() set-iter)
+      ) ;t
+     ) ;
+  (report "数组全映射设置/C++" set-iter t)
+) ;let
+(let ((t (timeit (lambda () (json-set/scheme bench-arr #t (lambda (x) (* x 2))))
+           '()
+           set-iter
+         ) ;timeit
+      ) ;t
+     ) ;
+  (report "数组全映射设置/Scheme" set-iter t)
+) ;let
+
+(newline)
+(display "=== 测试完成 ===")
+(newline)

--- a/devel/0120.md
+++ b/devel/0120.md
@@ -1,0 +1,47 @@
+# [0120] json-ref/json-set 替换为 C++ 实现，提升性能
+
+## 任务相关的代码文件
+- src/liii_json.cpp（新增 g_json_ref、g_json_set 的 C++ 实现）
+- goldfish/liii/json.scm（json-ref/json-set 绑定到 g_json_ref/g_json_set）
+- tests/liii/json/json-ref-test.scm（扩充边界测试用例）
+- tests/liii/json/json-set-test.scm（扩充边界测试用例）
+- bench/json-ref-set-perf.scm（新增，C++ vs Scheme 性能对比）
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf tests/liii/json/json-ref-test.scm
+bin/gf tests/liii/json/json-set-test.scm
+bin/gf tests/liii/json-test.scm
+bin/gf bench/json-ref-set-perf.scm
+```
+
+## 2026-08-16 json-ref/json-set 替换为 C++ 实现 g_json_ref/g_json_set，提升性能
+
+### What
+1. 在 `src/liii_json.cpp` 中新增 `g_json_ref`、`g_json_set`，完整复刻 `(liii json)` 包装 `(guenchi json)` 的 Scheme 实现语义（含变参多键路径）：
+   - json-ref：`'()` 透传安全导航；空对象 `'(())` 读出为 `'()`；每层先做结构校验（非对象/数组抛 `type-error`）；读到的符号 `'true`/`'false` 转为 `#t`/`#f`；数组索引用 vector-ref 语义（非整数索引抛 `wrong-type-arg`、越界抛 `out-of-range`，报错路径直接调用缓存的 `vector-ref` 保证错误逐字节一致）
+   - json-set：空对象 `'(())` 原样返回；键 `#t` 映射所有值；键为过程按键谓词筛选；普通键按 `equal?` 匹配（eqv? 语义，`1` 与 `1.0` 不相等）；匹配后 `#t`/过程键分支保留原键、普通键分支用传入的键构造新序对；叶层值可为过程；键 `#f` 落入 guenchi `(if v ...)` 无 else 分支的历史怪癖原样保留（对象返回 `#<unspecified>`，数组经缓存的 `list->vector` 抛 `wrong-type-arg`）
+2. `(liii json)` 中 `json-ref`/`json-set` 直接绑定到 C++ 实现；`json-push`/`json-drop` 的多键路径经本地 `json-set` 自动走 C++ 路径。`(guenchi json)` 的 `json-ref`/`json-set` 保留不动（`json-push*`/`json-drop*`/`json-reduce*` 内部仍在使用）。
+3. 扩充 `tests/liii/json/json-ref-test.scm`（16→44 条）、`json-set-test.scm`（16→45 条）：覆盖 `true/false` 转换、字符串/symbol/数字键匹配规则、`'(())` 各层级行为、数组索引错误类型、中间层结构校验、`#t`/`#f`/过程键、过程叶值、深路径等边界（先以原 Scheme 实现验证语义，再切换 C++ 实现回归）。
+4. 新增 `bench/json-ref-set-perf.scm`，同进程对比 C++ 与历史 Scheme 实现（含正确性 sanity check）。
+
+### Why
+`json-ref`/`json-set` 是 JSON 数据访问的热路径，原 Scheme 实现每层都要做 `json-object?` 全表扫描加 alist 线性查找/`cons` 重建，多层路径还要经过 `apply` + lambda 递归，解释执行开销大。
+
+### How
+在 C++ 中复刻同一套语义：
+- 多键路径在 C++ 内直接逐层下钻/递归，消除 Scheme 包装的 `apply` + lambda 开销；
+- alist 校验用 tortoise-hare 真列表检查（循环列表按非真列表处理，与 `list?` 一致）；
+- 对象更新先搭建等长结果骨架并 GC 保护，再逐个填充（未匹配条目复用原序对），用户过程调用结果立即挂到受保护骨架上，避免 GC 回收中间值；
+- 报错路径（数组索引越界/类型错误、`#f` 键的 `list->vector` 调用）转而调用 glue 时缓存的 `vector-ref`/`list->vector`，保证错误类型与消息和历史实现完全一致。
+
+性能对比（Windows，release 构建，bench/json-ref-set-perf.scm）：
+
+| 场景 | C++ | Scheme | 加速比 |
+|---|---|---|---|
+| 对象单键读取（200 键） | 0.0043s/2000 次 | 0.0170s/2000 次 | ~4x |
+| 多键路径读取 | 0.0002s/2000 次 | 0.0015s/2000 次 | ~8x |
+| 对象单键设置（200 键） | 0.0045s/500 次 | 0.0090s/500 次 | ~2x |
+| 多键路径设置 | 0.00006s/500 次 | 0.0005s/500 次 | ~9x |
+| 数组全映射设置（200 元素，#t 键 + 过程） | 0.0045s/500 次 | 0.0127s/500 次 | ~3x |

--- a/goldfish/liii/json.scm
+++ b/goldfish/liii/json.scm
@@ -2,10 +2,6 @@
   (import (liii base)
     (liii list)
     (rename (guenchi json)
-      (json-ref g:json-ref)
-      (json-ref* g:json-ref*)
-      (json-set g:json-set)
-      (json-set* g:json-set*)
       (json-push g:json-push)
       (json-push* g:json-push*)
       (json-drop g:json-drop)
@@ -56,35 +52,16 @@
     ;; string->json 由 C++ 实现（src/liii_json.cpp 中的 g_string->json）
     (define string->json g_string->json)
 
+    ;; json-ref 由 C++ 实现（src/liii_json.cpp 中的 g_json_ref）
+    (define json-ref g_json_ref)
+
+    ;; json-set 由 C++ 实现（src/liii_json.cpp 中的 g_json_set）
+    (define json-set g_json_set)
+
     (define (ensure-json-structure x)
       (unless (or (json-object? x) (json-array? x))
         (type-error "Value is not a JSON object or array" x)
       ) ;unless
-    ) ;define
-
-    (define (json-ref json key . args)
-      (if (null? json)
-        '()
-        (begin
-          (ensure-json-structure json)
-          (let ((val (if (and (json-object? json) (equal? json '(()))) '() (g:json-ref json key))
-                ) ;val
-               ) ;
-            (if (null? args) val (apply json-ref (cons val args)))
-          ) ;let
-        ) ;begin
-      ) ;if
-    ) ;define
-
-    (define (json-set json key val . args)
-      (ensure-json-structure json)
-      (if (null? args)
-        (if (and (json-object? json) (equal? json '(())))
-          json
-          (g:json-set json key val)
-        ) ;if
-        (json-set json key (lambda (x) (apply json-set (cons x (cons val args)))))
-      ) ;if
     ) ;define
 
     (define (json-push json key val . args)

--- a/src/liii_json.cpp
+++ b/src/liii_json.cpp
@@ -445,10 +445,281 @@ glue_string_to_json (s7_scheme* sc) {
   s7_gc_protect (sc, cached_open_input_string);
 }
 
+// json-ref / json-set 的 C++ 实现，语义与历史上 (liii json) 包装 (guenchi json)
+// 的 Scheme 实现完全一致：
+//   - json-ref：多键路径逐层下钻；'() 透传（安全导航）；空对象 '(()) 读出为 '()；
+//     每层先做结构校验（非对象/数组抛 type-error）；读到的符号 'true/'false 转为 #t/#f；
+//     数组用 vector-ref 语义（非整数索引抛 wrong-type-arg、越界抛 out-of-range）
+//   - json-set：多键路径逐层函数式更新；空对象 '(()) 原样返回；
+//     键 #t 表示映射所有值；键为过程表示按键谓词筛选；普通键按 equal? 匹配；
+//     匹配成功后新序对的键：普通键分支用传入的键，#t/过程键分支保留原键；
+//     叶层值可以是过程（接收旧值返回新值）；
+//     键 #f 落入 guenchi (if v ...) 无 else 分支的历史怪癖原样保留
+//     （对象返回 #<unspecified>，数组走 (list->vector #<unspecified>) 抛 wrong-type-arg）
+
+// 真列表长度；非真列表（含循环列表）返回 -1
+static s7_int
+json_proper_list_length (s7_scheme* sc, s7_pointer x) {
+  s7_pointer slow= x, fast= x;
+  s7_int     len = 0;
+  while (s7_is_pair (fast)) {
+    fast= s7_cdr (fast);
+    len++;
+    if (s7_is_pair (fast)) {
+      fast= s7_cdr (fast);
+      len++;
+      slow= s7_cdr (slow);
+      if (fast == slow) return -1; // 循环列表
+    }
+  }
+  if (!s7_is_null (sc, fast)) return -1;
+  return len;
+}
+
+// 空对象 '(())
+static bool
+json_is_null_object (s7_scheme* sc, s7_pointer x) {
+  return s7_is_pair (x) && s7_is_null (sc, s7_car (x)) && s7_is_null (sc, s7_cdr (x));
+}
+
+// 与 (liii json) 的 json-object? 一致（x 已知非 '()）：
+// (and (list? x) (not (null? x)) (or (equal? x '(())) (every pair? x)))
+static bool
+json_is_object (s7_scheme* sc, s7_pointer x, s7_int& len) {
+  if (!s7_is_pair (x)) return false;
+  if (json_is_null_object (sc, x)) {
+    len= 1;
+    return true;
+  }
+  len= json_proper_list_length (sc, x);
+  if (len < 0) return false;
+  s7_pointer p= x;
+  while (s7_is_pair (p)) {
+    if (!s7_is_pair (s7_car (p))) return false;
+    p= s7_cdr (p);
+  }
+  return true;
+}
+
+// glue 时缓存 vector-ref / list->vector 并永久 GC 保护：
+// 仅在报错路径上调用，保证错误类型和消息与 Scheme 实现逐字节一致
+static s7_pointer cached_vector_ref    = NULL;
+static s7_pointer cached_list_to_vector= NULL;
+
+// guenchi json-ref 的 return 包装：'true -> #t，'false -> #f
+static s7_pointer symbol_true = NULL;
+static s7_pointer symbol_false= NULL;
+
+static s7_pointer
+json_ref_convert (s7_scheme* sc, s7_pointer x) {
+  if (s7_is_symbol (x)) {
+    if (x == symbol_true) return s7_t (sc);
+    if (x == symbol_false) return s7_f (sc);
+  }
+  return x;
+}
+
+static s7_pointer
+f_json_ref (s7_scheme* sc, s7_pointer args) {
+  s7_pointer cur = s7_car (args);
+  s7_pointer keys= s7_cdr (args);
+  while (s7_is_pair (keys)) {
+    s7_pointer key= s7_car (keys);
+    keys        = s7_cdr (keys);
+    // '() 透传：安全导航，直接返回 '()
+    if (s7_is_null (sc, cur)) return s7_nil (sc);
+    s7_pointer val;
+    if (s7_is_vector (cur)) {
+      if (s7_is_integer (key)) {
+        s7_int i= s7_integer (key);
+        if (i >= 0 && i < s7_vector_length (cur)) {
+          val= s7_vector_elements (cur)[i];
+        }
+        else {
+          // 抛出与 vector-ref 一致的 out-of-range 错误
+          return s7_call (sc, cached_vector_ref, s7_list (sc, 2, cur, key));
+        }
+      }
+      else {
+        // 抛出与 vector-ref 一致的 wrong-type-arg 错误
+        return s7_call (sc, cached_vector_ref, s7_list (sc, 2, cur, key));
+      }
+    }
+    else if (s7_is_pair (cur)) {
+      if (json_is_null_object (sc, cur)) {
+        val= s7_nil (sc);
+      }
+      else {
+        s7_int len;
+        if (!json_is_object (sc, cur, len)) {
+          return json_type_error (sc, "Value is not a JSON object or array", cur);
+        }
+        val          = s7_nil (sc);
+        s7_pointer p = cur;
+        while (s7_is_pair (p)) {
+          s7_pointer entry= s7_car (p);
+          if (s7_is_equal (sc, s7_car (entry), key)) {
+            val= s7_cdr (entry);
+            break;
+          }
+          p= s7_cdr (p);
+        }
+      }
+    }
+    else {
+      return json_type_error (sc, "Value is not a JSON object or array", cur);
+    }
+    cur= json_ref_convert (sc, val);
+  }
+  return cur;
+}
+
+static void
+glue_json_ref (s7_scheme* sc) {
+  const char* name= "g_json_ref";
+  const char* desc= "(g_json_ref json key . keys) => value, ref a value from Scheme-form JSON data by key path";
+  s7_define_function (sc, name, f_json_ref, 2, 0, true, desc);
+  cached_vector_ref= s7_name_to_value (sc, "vector-ref");
+  s7_gc_protect (sc, cached_vector_ref);
+  symbol_true = s7_make_symbol (sc, "true");
+  s7_gc_protect (sc, symbol_true);
+  symbol_false= s7_make_symbol (sc, "false");
+  s7_gc_protect (sc, symbol_false);
+}
+
+// json-set 的叶层写入器：rest 非空表示多键路径（对旧值递归 json-set），
+// 否则写入叶层值（叶层值为过程时以旧值调用之）
+struct json_setter {
+  s7_pointer rest;        // 剩余 (key val ...) 参数；'() 表示已到叶层
+  s7_pointer leaf;        // 叶层值（仅 rest 为 '() 时有效）
+  bool       leaf_is_proc;
+};
+
+static s7_pointer json_set_dispatch (s7_scheme* sc, s7_pointer x, s7_pointer kargs);
+
+static s7_pointer
+json_setter_apply (s7_scheme* sc, const json_setter& st, s7_pointer old) {
+  if (!s7_is_null (sc, st.rest)) return json_set_dispatch (sc, old, st.rest);
+  if (st.leaf_is_proc) return s7_call (sc, st.leaf, s7_list (sc, 1, old));
+  return st.leaf;
+}
+
+// guenchi json-set 的单层语义：x 已校验为 JSON 对象（含 len 个条目）或数组
+static s7_pointer
+json_guenchi_set (s7_scheme* sc, s7_pointer x, s7_pointer v, s7_int len, const json_setter& st) {
+  if (s7_is_vector (x)) {
+    s7_int      n    = s7_vector_length (x);
+    s7_pointer* elems= s7_vector_elements (x);
+    if (s7_is_boolean (v) && !s7_boolean (sc, v)) {
+      // guenchi 的 (if v ...) 无 else 分支：(list->vector #<unspecified>) 抛 wrong-type-arg
+      return s7_call (sc, cached_list_to_vector, s7_list (sc, 1, s7_unspecified (sc)));
+    }
+    s7_pointer result= s7_make_vector (sc, n);
+    s7_gc_protect_via_stack (sc, result);
+    s7_pointer* relems= s7_vector_elements (result);
+    for (s7_int i= 0; i < n; i++) {
+      bool replace;
+      if (s7_is_boolean (v)) replace= true;
+      else if (s7_is_procedure (v)) {
+        replace= (s7_call (sc, v, s7_list (sc, 1, s7_make_integer (sc, i))) != s7_f (sc));
+      }
+      else {
+        replace= s7_is_equal (sc, s7_make_integer (sc, i), v);
+      }
+      relems[i]= replace ? json_setter_apply (sc, st, elems[i]) : elems[i];
+    }
+    s7_gc_unprotect_via_stack (sc, result);
+    return result;
+  }
+  // 对象（alist）：键 #t 或过程键保留原键，普通键匹配后用传入的键构造新序对
+  bool map_all= false, use_pred= false;
+  if (s7_is_boolean (v)) {
+    if (!s7_boolean (sc, v)) return s7_unspecified (sc); // (if v ...) 无 else 分支
+    map_all= true;
+  }
+  else if (s7_is_procedure (v)) {
+    use_pred= true;
+  }
+  // 先搭建与输入等长的结果骨架并 GC 保护（搭建期间不调用用户过程）
+  s7_pointer head= s7_cons (sc, s7_nil (sc), s7_nil (sc));
+  s7_gc_protect_via_stack (sc, head);
+  s7_pointer tail= head;
+  for (s7_int i= 1; i < len; i++) {
+    s7_set_cdr (tail, s7_cons (sc, s7_nil (sc), s7_nil (sc)));
+    tail= s7_cdr (tail);
+  }
+  s7_pointer p= x;
+  tail        = head;
+  while (s7_is_pair (p)) {
+    s7_pointer entry= s7_car (p);
+    bool       replace;
+    if (map_all) replace= true;
+    else if (use_pred) {
+      replace= (s7_call (sc, v, s7_list (sc, 1, s7_car (entry))) != s7_f (sc));
+    }
+    else {
+      replace= s7_is_equal (sc, s7_car (entry), v);
+    }
+    if (replace) {
+      s7_pointer newkey= (map_all || use_pred) ? s7_car (entry) : v;
+      s7_set_car (tail, s7_cons (sc, newkey, json_setter_apply (sc, st, s7_cdr (entry))));
+    }
+    else {
+      s7_set_car (tail, entry); // 未匹配的条目复用原序对
+    }
+    tail= s7_cdr (tail);
+    p   = s7_cdr (p);
+  }
+  s7_gc_unprotect_via_stack (sc, head);
+  return head;
+}
+
+// 对应 (liii json) 的 json-set 包装：结构校验 + '(()) 特判 + 单键/多键分派
+// kargs 为 (key val . rest)
+static s7_pointer
+json_set_dispatch (s7_scheme* sc, s7_pointer x, s7_pointer kargs) {
+  s7_int len= 0;
+  if (!s7_is_vector (x) && !json_is_object (sc, x, len)) {
+    return json_type_error (sc, "Value is not a JSON object or array", x);
+  }
+  // 空对象 '(()) 原样返回（单键与多键均如此）
+  if (json_is_null_object (sc, x)) return x;
+  s7_pointer key = s7_car (kargs);
+  s7_pointer rest= s7_cdr (kargs);
+  json_setter st;
+  if (s7_is_null (sc, s7_cdr (rest))) {
+    st.rest       = s7_nil (sc);
+    st.leaf       = s7_car (rest);
+    st.leaf_is_proc= s7_is_procedure (st.leaf);
+  }
+  else {
+    st.rest       = rest;
+    st.leaf       = NULL;
+    st.leaf_is_proc= false;
+  }
+  return json_guenchi_set (sc, x, key, len, st);
+}
+
+static s7_pointer
+f_json_set (s7_scheme* sc, s7_pointer args) {
+  return json_set_dispatch (sc, s7_car (args), s7_cdr (args));
+}
+
+static void
+glue_json_set (s7_scheme* sc) {
+  const char* name= "g_json_set";
+  const char* desc= "(g_json_set json key val . keys-and-val) => data, set a value in Scheme-form JSON data by key path";
+  s7_define_function (sc, name, f_json_set, 3, 0, true, desc);
+  cached_list_to_vector= s7_name_to_value (sc, "list->vector");
+  s7_gc_protect (sc, cached_list_to_vector);
+}
+
 void
 glue_liii_json (s7_scheme* sc) {
   glue_json_to_string (sc);
   glue_string_to_json (sc);
+  glue_json_ref (sc);
+  glue_json_set (sc);
 }
 
 } // namespace goldfish

--- a/src/liii_json.cpp
+++ b/src/liii_json.cpp
@@ -461,7 +461,7 @@ glue_string_to_json (s7_scheme* sc) {
 static s7_int
 json_proper_list_length (s7_scheme* sc, s7_pointer x) {
   s7_pointer slow= x, fast= x;
-  s7_int     len = 0;
+  s7_int     len= 0;
   while (s7_is_pair (fast)) {
     fast= s7_cdr (fast);
     len++;
@@ -525,7 +525,7 @@ f_json_ref (s7_scheme* sc, s7_pointer args) {
   s7_pointer keys= s7_cdr (args);
   while (s7_is_pair (keys)) {
     s7_pointer key= s7_car (keys);
-    keys        = s7_cdr (keys);
+    keys          = s7_cdr (keys);
     // '() 透传：安全导航，直接返回 '()
     if (s7_is_null (sc, cur)) return s7_nil (sc);
     s7_pointer val;
@@ -554,8 +554,8 @@ f_json_ref (s7_scheme* sc, s7_pointer args) {
         if (!json_is_object (sc, cur, len)) {
           return json_type_error (sc, "Value is not a JSON object or array", cur);
         }
-        val          = s7_nil (sc);
-        s7_pointer p = cur;
+        val         = s7_nil (sc);
+        s7_pointer p= cur;
         while (s7_is_pair (p)) {
           s7_pointer entry= s7_car (p);
           if (s7_is_equal (sc, s7_car (entry), key)) {
@@ -581,7 +581,7 @@ glue_json_ref (s7_scheme* sc) {
   s7_define_function (sc, name, f_json_ref, 2, 0, true, desc);
   cached_vector_ref= s7_name_to_value (sc, "vector-ref");
   s7_gc_protect (sc, cached_vector_ref);
-  symbol_true = s7_make_symbol (sc, "true");
+  symbol_true= s7_make_symbol (sc, "true");
   s7_gc_protect (sc, symbol_true);
   symbol_false= s7_make_symbol (sc, "false");
   s7_gc_protect (sc, symbol_false);
@@ -590,8 +590,8 @@ glue_json_ref (s7_scheme* sc) {
 // json-set 的叶层写入器：rest 非空表示多键路径（对旧值递归 json-set），
 // 否则写入叶层值（叶层值为过程时以旧值调用之）
 struct json_setter {
-  s7_pointer rest;        // 剩余 (key val ...) 参数；'() 表示已到叶层
-  s7_pointer leaf;        // 叶层值（仅 rest 为 '() 时有效）
+  s7_pointer rest; // 剩余 (key val ...) 参数；'() 表示已到叶层
+  s7_pointer leaf; // 叶层值（仅 rest 为 '() 时有效）
   bool       leaf_is_proc;
 };
 
@@ -684,17 +684,17 @@ json_set_dispatch (s7_scheme* sc, s7_pointer x, s7_pointer kargs) {
   }
   // 空对象 '(()) 原样返回（单键与多键均如此）
   if (json_is_null_object (sc, x)) return x;
-  s7_pointer key = s7_car (kargs);
-  s7_pointer rest= s7_cdr (kargs);
+  s7_pointer  key = s7_car (kargs);
+  s7_pointer  rest= s7_cdr (kargs);
   json_setter st;
   if (s7_is_null (sc, s7_cdr (rest))) {
-    st.rest       = s7_nil (sc);
-    st.leaf       = s7_car (rest);
+    st.rest        = s7_nil (sc);
+    st.leaf        = s7_car (rest);
     st.leaf_is_proc= s7_is_procedure (st.leaf);
   }
   else {
-    st.rest       = rest;
-    st.leaf       = NULL;
+    st.rest        = rest;
+    st.leaf        = NULL;
     st.leaf_is_proc= false;
   }
   return json_guenchi_set (sc, x, key, len, st);
@@ -708,7 +708,8 @@ f_json_set (s7_scheme* sc, s7_pointer args) {
 static void
 glue_json_set (s7_scheme* sc) {
   const char* name= "g_json_set";
-  const char* desc= "(g_json_set json key val . keys-and-val) => data, set a value in Scheme-form JSON data by key path";
+  const char* desc=
+      "(g_json_set json key val . keys-and-val) => data, set a value in Scheme-form JSON data by key path";
   s7_define_function (sc, name, f_json_set, 3, 0, true, desc);
   cached_list_to_vector= s7_name_to_value (sc, "list->vector");
   s7_gc_protect (sc, cached_list_to_vector);

--- a/tests/liii/json/json-ref-test.scm
+++ b/tests/liii/json/json-ref-test.scm
@@ -58,4 +58,58 @@
 (check-catch 'type-error (json-ref "not-a-json" 'key))
 (check-catch 'type-error (json-ref 123 'key))
 
+;; symbol 'true/'false 在每一层都会被转换为 #t/#f（'null 保持符号不变）
+(check (json-ref '((a . true)) 'a) => #t)
+(check (json-ref '((a . false)) 'a) => #f)
+(check (json-ref '((a . null)) 'a) => 'null)
+(check (json-ref '((a . other)) 'a) => 'other)
+(check (json-ref '((a (b . true))) 'a 'b) => #t)
+(check (json-ref #(true false null) 0) => #t)
+(check (json-ref #(true false null) 1) => #f)
+(check (json-ref #(true false null) 2) => 'null)
+
+;; 字符串键与 symbol 键互不匹配（equal? 语义）
+(check (json-ref '(("age" . 18)) "age") => 18)
+(check (json-ref '(("age" . 18)) 'age) => '())
+(check (json-ref '((age . 18)) "age") => '())
+
+;; 数字键按 equal? 匹配（eqv? 语义：1 与 1.0 不相等）
+(check (json-ref '((1 . one) (2 . two)) 2) => 'two)
+(check (json-ref '((1 . one)) 1.0) => '())
+
+;; 空对象 '(()) 特判：任意深度都返回 '()
+(check (json-ref '(()) 'a) => '())
+(check (json-ref '(()) 'a 'b) => '())
+(check (json-ref '() 'a) => '())
+(check (json-ref '() 'a 'b) => '())
+
+;; 数组路径
+(check (json-ref #(1 2 3) 0) => 1)
+(check (json-ref '((a . #(10 20 30))) 'a 1) => 20)
+(check (json-ref #(((x . 1))) 0 'x) => 1)
+
+;; 数组索引错误：越界抛 out-of-range，非整数索引抛 wrong-type-arg
+(check-catch 'out-of-range (json-ref #(1 2) 5))
+(check-catch 'out-of-range (json-ref #(1 2) -1))
+(check-catch 'wrong-type-arg (json-ref #(1 2) 'a))
+(check-catch 'wrong-type-arg (json-ref #(1 2) 1.5))
+
+;; 中间层不是对象/数组时抛 type-error（每层都做结构校验）
+(check-catch 'type-error (json-ref '((a . 1)) 'a 'b))
+(check-catch 'type-error (json-ref '((a . "s")) 'a 'b))
+
+;; 非键路径上的值不做结构校验，直接返回
+(check (json-ref '((a . 1)) 'a) => 1)
+(check (json-ref '((a . "s")) 'a) => "s")
+
+;; 非 pair 列表/非真列表不是合法 JSON 结构
+(check-catch 'type-error (json-ref '((a . 1) b) 'a))
+(check-catch 'type-error (json-ref '(1 . 2) 'a))
+
+;; 未找到键时返回 '()，原对象不受影响
+(let ((j '((a . 1))))
+  (check (json-ref j 'b) => '())
+  (check j => '((a . 1)))
+) ;let
+
 (check-report)

--- a/tests/liii/json/json-set-test.scm
+++ b/tests/liii/json/json-set-test.scm
@@ -137,4 +137,59 @@
 (check-catch 'type-error (json-set "not-a-json" 'key "val"))
 (check-catch 'type-error (json-set 123 'key "val"))
 
+;; 键不存在时返回内容不变的新对象，原对象不受影响
+(let* ((j0 '((a . 1))) (j1 (json-set j0 'b 2)))
+  (check j1 => '((a . 1)))
+  (check j0 => '((a . 1)))
+) ;let*
+
+;; 空对象 '(()) 特判：json-set 原样返回，不做任何修改
+(check (json-set '(()) 'a 1) => '(()))
+(check (json-set '(()) 'a 'b 1) => '(()))
+
+;; 键 #t：对对象/数组的所有值应用更新
+(check (json-set '((a . 1) (b . 2)) #t 0) => '((a . 0) (b . 0)))
+(check (json-set '((a . 1) (b . 2)) #t (lambda (x) (* x 10)))
+  =>
+  '((a . 10) (b . 20))
+) ;check
+(check (json-set #(1 2 3) #t 0) => #(0 0 0))
+(check (json-set #(1 2 3) #t (lambda (x) (+ x 1))) => #(2 3 4))
+
+;; 键为过程：按键谓词筛选要更新的条目/元素
+(check (json-set '((a . 1) (b . 2)) (lambda (k) (eq? k 'a)) 0)
+  =>
+  '((a . 0) (b . 2))
+) ;check
+(check (json-set #(10 20 30) odd? 0) => #(10 0 30))
+
+;; 数组上未匹配的键（越界索引、非整数索引）返回内容不变的新数组
+(check (json-set #(1 2) 5 0) => #(1 2))
+(check (json-set #(1 2) 'a 0) => #(1 2))
+
+;; 字符串键与 symbol 键互不匹配
+(check (json-set '(("age" . 18)) 'age 19) => '(("age" . 18)))
+(check (json-set '((age . 18)) "age" 19) => '((age . 18)))
+
+;; 多键路径：中间层不是对象/数组时抛 type-error
+(check-catch 'type-error (json-set '((a . 1)) 'a 'b 2))
+(check-catch 'type-error (json-set '((a)) 'a 'b 2))
+
+;; 多键路径穿过数组
+(let ((j1 (json-set '((a . #(1 2 3))) 'a 1 20)))
+  (check (json-ref j1 'a 1) => 20)
+) ;let
+
+;; 多键路径 + 叶值为过程
+(let ((j1 (json-set '((a (b . 1))) 'a 'b (lambda (x) (+ x 10)))))
+  (check (json-ref j1 'a 'b) => 11)
+) ;let
+
+;; 多键路径中间层为 '(()) 时原样返回（不深入递归）
+(check (json-set '((a (()))) 'a 'b 1) => '((a (()))))
+
+;; 键 #f 的历史怪癖：guenchi 实现落入 (if v ...) 无 else 分支，结果为 #<unspecified>
+(check (eq? (json-set '((a . 1)) #f 0) (if #f #f)) => #t)
+(check-catch 'wrong-type-arg (json-set #(1 2) #f 0))
+
 (check-report)


### PR DESCRIPTION
## 概述

将 `(liii json)` 的 `json-ref`/`json-set` 从 Scheme 实现替换为 C++ 实现（`g_json_ref`/`g_json_set`），语义与历史实现完全一致，性能提升 2x~9x。

## 实现要点

- `g_json_ref`：`()` 透传安全导航、`'(())` 空对象特判、逐层结构校验（`type-error`）、`'true`/`'false` 符号转换、数组索引经缓存的 `vector-ref` 复现原版报错
- `g_json_set`：`#t` 键全映射、过程键谓词筛选、`equal?` 匹配（eqv? 语义）、过程叶值、`#f` 键的历史怪癖原样保留
- GC 安全：对象更新先建等长骨架并保护，用户过程返回值立即挂到骨架上
- `(guenchi json)` 的 Scheme 实现保留不动（`json-push*`/`json-drop*`/`json-reduce*` 内部仍依赖）

## 测试

- json-ref 测试 16→44 条、json-set 测试 16→45 条，先在原 Scheme 实现上验证语义再切换回归
- 全量 1496 个测试文件回归通过（仅 srfi-78 两个与本次无关的既有失败）

## 性能（Windows release，bench/json-ref-set-perf.scm）

| 场景 | 加速比 |
|---|---|
| 对象单键读取（200 键） | ~4x |
| 多键路径读取 | ~8x |
| 对象单键设置 | ~2x |
| 多键路径设置 | ~9x |
| 数组全映射设置（200 元素） | ~3x |

详见 devel/0120.md。

🤖 Generated with [Claude Code](https://claude.com/claude-code)