### PR TITLE
[0121] (liii http) 模块协议改为 Apache License 2.0

### DIFF
--- a/devel/0121.md
+++ b/devel/0121.md
@@ -1,0 +1,22 @@
+# [0121] (liii http) 模块协议改为 Apache License 2.0
+
+## 任务相关的代码文件
+- goldfish/liii/http.scm（协议头替换）
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf tests/liii/http/http-ok-p-test.scm
+```
+
+## 2026-08-17 (liii http) 模块协议改为 Apache License 2.0
+
+### What
+1. 将 `goldfish/liii/http.scm` 文件头部的 `COPYRIGHT: (C) 2025 Liii Network Inc, All rights reverved.` 声明替换为项目标准的 Apache License 2.0 协议头，版权归属改为 `The Goldfish Scheme Authors`（年份保留 2025，格式与 `goldfish/liii/logging.scm` 等模块一致）。
+2. 全仓库检索确认无其他文件残留 `Liii Network` 版权声明；`tests/liii/http*.scm` 测试文件按项目规范本就不放协议头，无需改动。
+
+### Why
+`(liii http)` 是仓库中唯一仍使用私有版权声明的模块，与项目整体 Apache License 2.0 协议不一致。
+
+### How
+仅修改文件头注释，不涉及任何代码逻辑；通过运行 `tests/liii/http/http-ok-p-test.scm` 验证模块可正常加载。

--- a/goldfish/liii/http.scm
+++ b/goldfish/liii/http.scm
@@ -1,6 +1,17 @@
 ;;
-;; COPYRIGHT: (C) 2025  Liii Network Inc
-;; All rights reverved.
+;; Copyright (C) 2025 The Goldfish Scheme Authors
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 ;;
 
 (define-library (liii http)


### PR DESCRIPTION
## What
- 将 `goldfish/liii/http.scm` 文件头部的私有版权声明（`COPYRIGHT: (C) 2025 Liii Network Inc, All rights reverved.`）替换为项目标准的 Apache License 2.0 协议头，版权归属改为 `The Goldfish Scheme Authors`（年份保留 2025）。
- 新增 `devel/0121.md` 开发文档。

## Why
`(liii http)` 是仓库中唯一仍使用私有版权声明的模块，与项目整体 Apache License 2.0 协议不一致。

## 测试
仅修改文件头注释，不涉及代码逻辑；通过 `bin/gf tests/liii/http/http-ok-p-test.scm` 验证模块可正常加载。

🤖 Generated with [Claude Code](https://claude.com/claude-code)