### PR TITLE
[0123] 优化 list-take-right 性能并新增 bench

### DIFF
--- a/devel/202_5.md
+++ b/devel/202_5.md
@@ -1,0 +1,31 @@
+# [202_5] list-take-right 性能优化
+
+## 任务相关的代码文件
+- goldfish/liii/list.scm
+- tests/liii/list/list-take-right-test.scm
+- tests/liii/list/list-drop-right-test.scm
+- tests/liii/list/bench-list-right.scm
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf fmt goldfish/liii/list.scm
+bin/gf tests/liii/list/list-take-right-test.scm
+bin/gf tests/liii/list/list-drop-right-test.scm
+bin/gf tests/liii/list/bench-list-right.scm
+```
+
+## 2026-08-18 优化 list-take-right，评估 list-drop-right
+
+### What
+1. `list-take-right` 改为单遍快慢指针实现：先推进快指针 n 步（列表不够长则返回原列表），再快慢指针同步推进，消除原先 `length` 全遍历 + `take-right` 的两次遍历
+2. `list-drop-right` 增加 `(= n 0)` 快路径直接返回原列表（行为不变，避免复制）
+3. 新增 `tests/liii/list/bench-list-right.scm` 基准测试
+
+### Why
+原实现先 `(length lst)` 全遍历一次，再调 srfi-1 的 `take-right`/`drop-right` 遍历第二次，循环调用时开销放大。
+
+### How
+用 `(liii timeit)` 对比新旧实现（len=10000, 2000 次）：
+- `list-take-right`：快约 1.7x（0.058 vs 0.095 秒/千次），已采用单遍实现
+- `list-drop-right`：srfi-1 的 `drop-right` 是 C 实现（`g_drop_right`），纯 Scheme 单遍实现（set-cdr! 尾接版本和 reverse+acc 版本）分别只有 0.34x 和 0.73x，`reverse`+`drop`+`reverse` 组合也只有 0.9x，故保留 `length` + `drop-right` 原写法，仅加 n=0 快路径

--- a/goldfish/liii/list.scm
+++ b/goldfish/liii/list.scm
@@ -93,8 +93,20 @@
         (type-error "list-take-right: second argument must be an integer" n)
       ) ;unless
       (cond ((< n 0) '())
-            ((>= n (length lst)) lst)
-            (else (take-right lst n))
+            ((= n 0) '())
+            (else (let advance
+                    ((lead lst) (count 0))
+                    (cond ((null? lead) lst)
+                          ((>= count n)
+                           (let scan
+                             ((lead lead) (lag lst))
+                             (if (null? lead) lag (scan (cdr lead) (cdr lag)))
+                           ) ;let
+                          ) ;
+                          (else (advance (cdr lead) (+ count 1)))
+                    ) ;cond
+                  ) ;let
+            ) ;else
       ) ;cond
     ) ;define
 
@@ -106,6 +118,7 @@
         (type-error "list-drop-right: second argument must be an integer" n)
       ) ;unless
       (cond ((< n 0) lst)
+            ((= n 0) lst)
             ((>= n (length lst)) '())
             (else (drop-right lst n))
       ) ;cond

--- a/goldfish/liii/list.scm
+++ b/goldfish/liii/list.scm
@@ -92,8 +92,7 @@
       (unless (integer? n)
         (type-error "list-take-right: second argument must be an integer" n)
       ) ;unless
-      (cond ((< n 0) '())
-            ((= n 0) '())
+      (cond ((<= n 0) '())
             (else (let advance
                     ((lead lst) (count 0))
                     (cond ((null? lead) lst)
@@ -117,8 +116,7 @@
       (unless (integer? n)
         (type-error "list-drop-right: second argument must be an integer" n)
       ) ;unless
-      (cond ((< n 0) lst)
-            ((= n 0) lst)
+      (cond ((<= n 0) lst)
             ((>= n (length lst)) '())
             (else (drop-right lst n))
       ) ;cond

--- a/tests/liii/list/bench-list-right.scm
+++ b/tests/liii/list/bench-list-right.scm
@@ -1,0 +1,45 @@
+(import (liii list) (liii timeit) (srfi srfi-1))
+
+;; bench: list-take-right / list-drop-right 与旧模式 (length + srfi-1) 的对比
+;;
+;; 结论 (2026-08-18, len=10000)：
+;;   - list-take-right 单遍快慢指针实现约比旧模式快 1.7x，已采用
+;;   - list-drop-right 的 srfi-1 drop-right 是 C 实现 (g_drop_right)，
+;;     Scheme 单遍实现反而慢 0.7x，故保留 length + drop-right 的写法
+
+(define (old-take-right lst n)
+  (cond ((< n 0) '())
+        ((>= n (length lst)) lst)
+        (else (take-right lst n))
+  ) ;cond
+) ;define
+
+(define (bench name new-proc old-proc lst n number)
+  (let ((t-new (timeit (lambda () (new-proc lst n)) (lambda () #t) number))
+        (t-old (timeit (lambda () (old-proc lst n)) (lambda () #t) number))
+       ) ;
+    (display name)
+    (display " : new=")
+    (display t-new)
+    (display " old=")
+    (display t-old)
+    (display " speedup=")
+    (display (/ t-old t-new))
+    (newline)
+  ) ;let
+) ;define
+
+(define lst (iota 10000))
+
+;; 正确性抽检
+(if (not (equal? (list-take-right lst 100) (old-take-right lst 100)))
+  (begin
+    (display "FAILED: results differ")
+    (exit 1)
+  ) ;begin
+) ;if
+
+(bench "take-right  n=100, len=10000" list-take-right old-take-right lst 100
+  2000
+) ;bench
+(bench "take-right  n=1,   len=10000" list-take-right old-take-right lst 1 2000)


### PR DESCRIPTION
## 概要
- `list-take-right` 改为单遍快慢指针实现，消除 `length` + `take-right` 两次遍历，bench 实测快约 1.7x（len=10000）
- `list-drop-right` 增加 `(= n 0)` 快路径；srfi-1 的 `drop-right` 是 C 实现，纯 Scheme 单遍写法均不及其原写法，故保留
- 新增基准测试 `tests/liii/list/bench-list-right.scm` 和开发文档 `devel/202_5.md`

## 测试
```bash
bin/gf tests/liii/list/list-take-right-test.scm   # 8 correct, 0 failed
bin/gf tests/liii/list/list-drop-right-test.scm   # 8 correct, 0 failed
bin/gf tests/liii/list/bench-list-right.scm
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)