### PR TITLE
[0124] string->json 对单引号字符串报 parse-error

### DIFF
--- a/devel/0124.md
+++ b/devel/0124.md
@@ -1,0 +1,27 @@
+# [0124] string->json 对单引号字符串报 parse-error
+
+## 任务相关的代码文件
+- `src/liii_json.cpp` - string->json 的 C++ 实现（f_string_to_json）
+- `tests/liii/json/string-to-json-test.scm` - string->json 测试用例
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf fmt tests/liii/json/string-to-json-test.scm
+bin/gf tests/liii/json/string-to-json-test.scm
+```
+
+## 2026/08/19 string->json 对单引号字符串报 parse-error
+
+### What
+1. `f_string_to_json` 主循环中，非字符串状态下遇到 `'` 直接抛 `parse-error`
+2. 新增 3 条单引号输入的 `check-catch 'parse-error` 用例，以及 2 条双引号字符串内含 `'` 的正向用例
+
+### Why
+JSON 标准（RFC 8259）规定字符串必须用双引号，Python 的 `json.loads` 也会拒绝单引号。而 Goldfish 之前的实现对 `'` 不做任何处理、原样透传给 Scheme reader，导致静默容错产生错误数据：
+
+- `{'key': 1}` 被解析为 `(('key' . 1))`（字符串内容带着 `'`）
+- `['a','b']` 被解析为 `#('a' 'b')`
+
+### How
+JSON 改写循环中只有 `"` 会翻转 `quts` 状态。在非字符串状态的 `switch` 中增加 `case '\''` 分支调用 `json_parse_error`；双引号字符串内的 `'`（如 `{"a": "it's"}`）走 `quts && c != '"'` 分支，不受影响，仍是合法内容。

--- a/src/liii_json.cpp
+++ b/src/liii_json.cpp
@@ -413,6 +413,9 @@ f_string_to_json (s7_scheme* sc, s7_pointer args) {
         quts= !quts;
         end++;
         break;
+      case '\'':
+        // 单引号字符串不是合法 JSON（RFC 8259）
+        return json_parse_error (sc, "Single-quoted strings are not valid JSON");
       default:
         end++;
         break;

--- a/tests/liii/json/string-to-json-test.scm
+++ b/tests/liii/json/string-to-json-test.scm
@@ -161,4 +161,12 @@
 (check-catch 'read-error (string->json "{a:}"))
 (check-catch 'parse-error (string->json "[\"\\u0041"))
 
+;;; 单引号字符串不是合法 JSON，应报 parse-error
+(check-catch 'parse-error (string->json "{'key': 1}"))
+(check-catch 'parse-error (string->json "['a','b']"))
+(check-catch 'parse-error (string->json "'hello'"))
+;;; 双引号字符串内的单引号是合法内容
+(check (string->json "{\"a\": \"it's\"}") => '(("a" . "it's")))
+(check (string->json "[\"don't\"]") => #("don't"))
+
 (check-report)


### PR DESCRIPTION
## What
- `src/liii_json.cpp`：`f_string_to_json` 主循环中，非字符串状态下遇到 `'` 抛 `parse-error`
- `tests/liii/json/string-to-json-test.scm`：新增 3 条单引号输入的 `parse-error` 用例，2 条双引号字符串内含 `'` 的正向用例
- `devel/0124.md`：任务文档

## Why
JSON 标准（RFC 8259）规定字符串必须用双引号，Python 的 `json.loads` 同样拒绝单引号。此前 Goldfish 对 `'` 原样透传给 Scheme reader，导致静默容错产生错误数据：

- `{'key': 1}` 被解析为 `(('key' . 1))`
- `['a','b']` 被解析为 `#('a' 'b')`

## How
双引号字符串内的 `'`（如 `{"a": "it's"}`）走 `quts && c != '"'` 分支，不受影响，仍是合法内容。

## 测试
- `tests/liii/json/` 目录下全部 20 个测试文件通过（string-to-json 75 条用例）
- njson 相关测试不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)