### PR TITLE
[0127] (liii string-cursor) 核心游标原语下沉到 C++ 实现

### DIFF
--- a/devel/0127.md
+++ b/devel/0127.md
@@ -1,0 +1,63 @@
+# [0127] (liii string-cursor) 核心原语下沉到 C++ 实现
+
+## 任务相关的代码文件
+- src/liii_string_cursor.cpp（新增）
+- src/goldfish.hpp
+- xmake.lua
+- goldfish/liii/string-cursor.scm
+- tests/liii/string-cursor/（14 个测试文件，作为回归测试）
+- bench/string-cursor.scm
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf fmt goldfish/liii/string-cursor.scm
+for f in tests/liii/string-cursor/*-test.scm; do bin/gf "$f"; done
+bin/gf bench/string-cursor.scm
+```
+
+## 2026-08-19 核心游标原语用 C++ 实现
+
+### What
+1. 新增 `src/liii_string_cursor.cpp`，在 s7 中注册 `g_string-cursor-*` 等函数，
+   实现核心游标原语：start/end/next/prev/forward/back、五个比较运算、
+   cursor-diff、cursor->index、index->cursor、string-ref/cursor、substring/cursors
+2. `goldfish/liii/string-cursor.scm` 中上述原语改为直接别名到 `g_*` 函数；
+   上层函数（fold/split/contains/trim 等）保持 Scheme 实现，改用公共原语重写
+3. 删除原有的 `<string-offsets>` / `<string-cursor>` record 类型和 positions
+   向量机制
+
+### Why
+原实现每次 `string-cursor-start` / `string-index->cursor` 都要
+`string->utf8` 整串复制并全串扫描建 positions 向量，每次 O(n) 且有两次分配；
+cursor 本身是 record，迭代 n 个字符就有 n 次分配。bench 显示 cursor 遍历
+比原生 string-ref 慢约 45 倍。
+
+### How
+1. **游标表示**：负整数 `-(byte_offset+2)`，即字节 0 对应 -2。与字符索引
+   （非负整数）不相交，比较是 O(1) 整数运算（注意负数方向取反），无分配。
+   **-1 不是合法游标**，保留"负索引"错误语义：`validate-start-end` 中
+   -1 仍按负索引报 value-error，与旧实现（record 游标可区分）的错误类型
+   保持兼容
+2. C++ 侧直接在 `s7_string` 的原始 UTF-8 字节上扫描：next/prev 按 UTF-8
+   首字节宽度前进/按连续字节回退；`string-cursor-start/end` O(1)；
+   `substring/cursors` 是字节区间 memcpy
+3. `string-index->cursor` / `string-cursor->index` 仍需 O(n) 扫描（无法避免），
+   但无分配，C 扫描远快于旧的 record+vector 方案
+4. Scheme 层以 `as-cursor` 在 API 边界把索引参数统一转换为游标，内部循环
+   全程在游标空间，不再反复转换
+
+### 性能对比（bench/string-cursor.scm，改前 → 改后）
+| 场景 | cursor 遍历 | string-fold | string-every |
+|---|---|---|---|
+| ASCII 50 字符 | 0.915 → 0.057 (16x) | 1.165 → 0.208 (5.6x) | 1.357 → 0.232 (5.9x) |
+| UTF-8 20 汉字 | 0.530 → 0.024 (22x) | 0.692 → 0.086 (8.0x) | 0.729 → 0.115 (6.3x) |
+| Emoji 10 个 | 0.322 → 0.015 (21x) | 0.404 → 0.049 (8.3x) | 0.449 → 0.051 (8.8x) |
+
+cursor 遍历已与原生 string-ref 遍历同一量级。
+
+### 已知限制
+- `string-replicate` 的 from/to 不再检查"不能是游标"（负整数表示法下
+  负的 from 与游标无法区分；from 本身允许为负数用于循环移位）
+- 混用游标与索引的比较运算（如 `(string-cursor=? cur 0)`）现在是
+  type-error，旧实现允许（SRFI 130 规定混用即是错误）

--- a/goldfish/liii/string-cursor.scm
+++ b/goldfish/liii/string-cursor.scm
@@ -86,205 +86,88 @@
 
   (begin
 
-    ;; ==== Internal data structures ====
+    ;; ==== Cursor representation ====
+    ;; 核心原语由 src/liii_string_cursor.cpp 实现（g_* 函数）。
+    ;; 游标表示为负整数 -(byte_offset+2)，即字节 0 对应 -2。
+    ;; -1 不是合法游标，保留给"负索引"错误语义。
 
-    (define-record-type <string-offsets>
-      (make-string-offsets bv positions)
-      string-offsets?
-      (bv string-offsets-bv)
-      (positions string-offsets-positions)
-    ) ;define-record-type
-
-    (define-record-type <string-cursor>
-      (make-string-cursor-raw offsets char-index)
-      string-cursor?
-      (offsets string-cursor-offsets)
-      (char-index string-cursor-char-index)
-    ) ;define-record-type
-
-    ;; Pre-scan a UTF-8 bytevector to generate position vector
-    (define (make-string-positions bv)
-      (let ((len (bytevector-length bv)))
-        (let loop
-          ((pos 0) (result '(0)))
-          (if (>= pos len)
-            (list->vector (reverse result))
-            (let ((next (bytevector-advance-utf8 bv pos len)))
-              (loop next (cons next result))
-            ) ;let
-          ) ;if
-        ) ;let
-      ) ;let
+    (define (string-cursor? obj)
+      (and (integer? obj) (< obj -1))
     ) ;define
 
-    ;; ==== Cursor operations ====
+    (define string-cursor-start g_string-cursor-start)
+    (define string-cursor-end g_string-cursor-end)
+    (define string-cursor-next g_string-cursor-next)
+    (define string-cursor-prev g_string-cursor-prev)
+    (define string-cursor-forward g_string-cursor-forward)
+    (define string-cursor-back g_string-cursor-back)
+    (define string-cursor=? g_string-cursor=?)
+    (define string-cursor<? g_string-cursor<?)
+    (define string-cursor>? g_string-cursor>?)
+    (define string-cursor<=? g_string-cursor<=?)
+    (define string-cursor>=? g_string-cursor>=?)
+    (define string-ref/cursor g_string-ref/cursor)
 
-    (define (string-cursor-start str)
-      (let* ((bv (string->utf8 str))
-             (off (make-string-offsets bv (make-string-positions bv)))
-            ) ;
-        (make-string-cursor-raw off 0)
-      ) ;let*
+    ;; ==== Helper functions ====
+
+    ;; 将索引或游标统一转换为游标
+    (define (as-cursor s x)
+      (cond ((string-cursor? x) x)
+            ((integer? x) (string-index->cursor s x))
+            (else (error 'type-error "cursor argument must be integer or cursor"))
+      ) ;cond
     ) ;define
 
-    (define (string-cursor-end str)
-      (let* ((bv (string->utf8 str))
-             (off (make-string-offsets bv (make-string-positions bv)))
-             (positions (string-offsets-positions off))
-            ) ;
-        (make-string-cursor-raw off (- (vector-length positions) 1))
-      ) ;let*
+    ;; 将索引或游标转换为游标，索引超出 char-len 时截断到 char-len
+    (define (as-cursor-clamped s x char-len)
+      (if (string-cursor? x) x (string-index->cursor s (min x char-len)))
     ) ;define
 
-    (define (string-cursor-next str cursor)
-      (let* ((c (if (string-cursor? cursor) cursor (string-index->cursor str cursor)))
-             (off (string-cursor-offsets c))
-             (char-idx (string-cursor-char-index c))
-             (positions (string-offsets-positions off))
-             (max-idx (- (vector-length positions) 1))
-            ) ;
-        (if (>= char-idx max-idx)
-          (error 'value-error "string-cursor-next: already at end cursor")
-          (let ((new-idx (+ char-idx 1)))
-            (if (string-cursor? cursor) (make-string-cursor-raw off new-idx) new-idx)
-          ) ;let
-        ) ;if
-      ) ;let*
-    ) ;define
-
-    (define (string-cursor-prev str cursor)
-      (let* ((c (if (string-cursor? cursor) cursor (string-index->cursor str cursor)))
-             (off (string-cursor-offsets c))
-             (char-idx (string-cursor-char-index c))
-            ) ;
-        (if (<= char-idx 0)
-          (error 'value-error "string-cursor-prev: already at start cursor")
-          (let ((new-idx (- char-idx 1)))
-            (if (string-cursor? cursor) (make-string-cursor-raw off new-idx) new-idx)
-          ) ;let
-        ) ;if
-      ) ;let*
-    ) ;define
-
-    (define (string-cursor-forward str cursor nchars)
-      (let* ((c (if (string-cursor? cursor) cursor (string-index->cursor str cursor)))
-             (off (string-cursor-offsets c))
-             (char-idx (string-cursor-char-index c))
-             (positions (string-offsets-positions off))
-             (max-idx (- (vector-length positions) 1))
-             (new-idx (+ char-idx nchars))
-            ) ;
-        (if (or (< new-idx 0) (> new-idx max-idx))
-          (error 'value-error "string-cursor-forward: result would be invalid cursor")
-          (if (string-cursor? cursor) (make-string-cursor-raw off new-idx) new-idx)
-        ) ;if
-      ) ;let*
-    ) ;define
-
-    (define (string-cursor-back str cursor nchars)
-      (string-cursor-forward str cursor (- nchars))
-    ) ;define
-
-    (define (string-cursor=? cursor1 cursor2)
-      (let ((idx1 (if (string-cursor? cursor1) (string-cursor-char-index cursor1) cursor1))
-            (idx2 (if (string-cursor? cursor2) (string-cursor-char-index cursor2) cursor2))
-           ) ;
-        (= idx1 idx2)
-      ) ;let
-    ) ;define
-
-    (define (string-cursor<? cursor1 cursor2)
-      (let ((idx1 (if (string-cursor? cursor1) (string-cursor-char-index cursor1) cursor1))
-            (idx2 (if (string-cursor? cursor2) (string-cursor-char-index cursor2) cursor2))
-           ) ;
-        (< idx1 idx2)
-      ) ;let
-    ) ;define
-
-    (define (string-cursor>? cursor1 cursor2)
-      (let ((idx1 (if (string-cursor? cursor1) (string-cursor-char-index cursor1) cursor1))
-            (idx2 (if (string-cursor? cursor2) (string-cursor-char-index cursor2) cursor2))
-           ) ;
-        (> idx1 idx2)
-      ) ;let
-    ) ;define
-
-    (define (string-cursor<=? cursor1 cursor2)
-      (let ((idx1 (if (string-cursor? cursor1) (string-cursor-char-index cursor1) cursor1))
-            (idx2 (if (string-cursor? cursor2) (string-cursor-char-index cursor2) cursor2))
-           ) ;
-        (<= idx1 idx2)
-      ) ;let
-    ) ;define
-
-    (define (string-cursor>=? cursor1 cursor2)
-      (let ((idx1 (if (string-cursor? cursor1) (string-cursor-char-index cursor1) cursor1))
-            (idx2 (if (string-cursor? cursor2) (string-cursor-char-index cursor2) cursor2))
-           ) ;
-        (>= idx1 idx2)
-      ) ;let
+    (define (validate-start-end start end)
+      (when (not (integer? start))
+        (error 'type-error "start must be integer or cursor")
+      ) ;when
+      (when (not (integer? end))
+        (error 'type-error "end must be integer or cursor")
+      ) ;when
+      (cond
+        ;; 两者均为负整数：游标模式
+        ((and (string-cursor? start) (string-cursor? end))
+         (when (string-cursor>? start end)
+           (error 'value-error "start must be <= end")
+         ) ;when
+        ) ;
+        ;; start 为负、end 为非负：按旧索引语义报 value-error
+        ((string-cursor? start) (error 'value-error "start must be >= 0"))
+        ;; start 为非负、end 为负：视为游标与索引混用
+        ((string-cursor? end)
+         (error 'type-error "start and end must both be integer or both be cursor")
+        ) ;
+        ;; 两者均为非负整数：索引模式（-1 视为负索引）
+        (else (when (> start end)
+                (error 'value-error "start must be <= end")
+              ) ;when
+          (when (< start 0)
+            (error 'value-error "start must be >= 0")
+          ) ;when
+          (when (< end 0)
+            (error 'value-error "end must be >= 0")
+          ) ;when
+        ) ;else
+      ) ;cond
     ) ;define
 
     (define (string-cursor-diff str start end)
       (validate-start-end start end)
-      (let ((s-idx (if (string-cursor? start) (string-cursor-char-index start) start))
-            (e-idx (if (string-cursor? end) (string-cursor-char-index end) end))
-           ) ;
-        (- e-idx s-idx)
-      ) ;let
+      (g_string-cursor-diff str start end)
     ) ;define
 
     (define (string-cursor->index str cursor)
-      (if (string-cursor? cursor) (string-cursor-char-index cursor) cursor)
+      (g_string-cursor->index str cursor)
     ) ;define
 
     (define (string-index->cursor str index)
-      (if (string-cursor? index)
-        index
-        (let* ((bv (string->utf8 str))
-               (off (make-string-offsets bv (make-string-positions bv)))
-               (positions (string-offsets-positions off))
-               (max-idx (- (vector-length positions) 1))
-              ) ;
-          (if (or (< index 0) (> index max-idx))
-            (error 'value-error "string-index->cursor: index out of range")
-            (make-string-cursor-raw off index)
-          ) ;if
-        ) ;let*
-      ) ;if
-    ) ;define
-
-    ;; ==== Helper functions ====
-
-    (define (cursor->index c)
-      (if (string-cursor? c) (string-cursor-char-index c) c)
-    ) ;define
-
-    (define (validate-start-end start end)
-      (let ((start-cursor? (string-cursor? start)) (end-cursor? (string-cursor? end)))
-        (when (and (not start-cursor?) (not (integer? start)))
-          (error 'type-error "start must be integer or cursor")
-        ) ;when
-        (when (and (not end-cursor?) (not (integer? end)))
-          (error 'type-error "end must be integer or cursor")
-        ) ;when
-        (when (not (eq? start-cursor? end-cursor?))
-          (error 'type-error "start and end must both be integer or both be cursor")
-        ) ;when
-        (let ((start-idx (if start-cursor? (string-cursor-char-index start) start))
-              (end-idx (if end-cursor? (string-cursor-char-index end) end))
-             ) ;
-          (when (> start-idx end-idx)
-            (error 'value-error "start must be <= end")
-          ) ;when
-          (when (< start-idx 0)
-            (error 'value-error "start must be >= 0")
-          ) ;when
-          (when (< end-idx 0)
-            (error 'value-error "end must be >= 0")
-          ) ;when
-        ) ;let
-      ) ;let
+      (g_string-index->cursor str index)
     ) ;define
 
     (define (list->utf8-string chars)
@@ -293,79 +176,40 @@
       ) ;let
     ) ;define
 
-    ;; ==== Selection ====
-
-    (define (string-ref/cursor str cursor)
-      (let* ((c (if (string-cursor? cursor) cursor (string-index->cursor str cursor)))
-             (off (string-cursor-offsets c))
-             (bv (string-offsets-bv off))
-             (pos (string-offsets-positions off))
-             (idx (string-cursor-char-index c))
-             (max-idx (- (vector-length pos) 1))
-             (_ (when (>= idx max-idx)
-                  (error 'value-error "string-ref/cursor: cursor at or past end of string")
-                ) ;when
-             ) ;_
-             (start (vector-ref pos idx))
-            ) ;
-        (integer->char (utf8->codepoint-at bv start))
-      ) ;let*
-    ) ;define
+    ;; ==== Cursor operations (with validation) ====
 
     (define (substring/cursors str start end)
       (validate-start-end start end)
-      (let* ((start-off (if (string-cursor? start)
-                          (string-cursor-offsets start)
-                          (let ((bv (string->utf8 str)))
-                            (make-string-offsets bv (make-string-positions bv))
-                          ) ;let
-                        ) ;if
-             ) ;start-off
-             (end-off (if (string-cursor? end) (string-cursor-offsets end) start-off))
-             (pos (string-offsets-positions start-off))
-             (bv (string-offsets-bv start-off))
-             (start-idx (if (string-cursor? start) (string-cursor-char-index start) start))
-             (end-idx (if (string-cursor? end) (string-cursor-char-index end) end))
-             (max-idx (- (vector-length pos) 1))
-             (_ (when (> end-idx max-idx)
-                  (error 'value-error "substring/cursors: end index out of range")
-                ) ;when
-             ) ;_
-             (byte-start (vector-ref pos start-idx))
-             (byte-end (vector-ref pos end-idx))
-            ) ;
-        (utf8->string (bytevector-copy bv byte-start byte-end))
-      ) ;let*
+      (g_substring/cursors str start end)
     ) ;define
 
+    ;; ==== Selection ====
+
     (define (string-copy/cursors str . maybe-start+end)
-      (let* ((bv (string->utf8 str))
-             (off (make-string-offsets bv (make-string-positions bv)))
-             (positions (string-offsets-positions off))
-             (len (- (vector-length positions) 1))
-             (end-c-raw (make-string-cursor-raw off len))
+      (let* ((end-c (string-cursor-end str))
+             (start (if (null? maybe-start+end) (string-cursor-start str) (car maybe-start+end))
+             ) ;start
+             (rest (if (null? maybe-start+end) '() (cdr maybe-start+end)))
+             (end (if (null? rest)
+                    (if (string-cursor? start) end-c (string-cursor->index str end-c))
+                    (car rest)
+                  ) ;if
+             ) ;end
             ) ;
-        (if (null? maybe-start+end)
-          (substring/cursors str (make-string-cursor-raw off 0) end-c-raw)
-          (let ((start (car maybe-start+end)) (rest (cdr maybe-start+end)))
-            (let ((end (if (null? rest) (if (string-cursor? start) end-c-raw len) (car rest))))
-              (substring/cursors str start end)
-            ) ;let
-          ) ;let
-        ) ;if
+        (substring/cursors str start end)
       ) ;let*
     ) ;define
 
     ;; ==== String operations ====
 
     (define (string-take str nchars)
-      (let ((end (string-index->cursor str nchars)))
+      (let ((end (string-cursor-forward str (string-cursor-start str) nchars)))
         (substring/cursors str (string-cursor-start str) end)
       ) ;let
     ) ;define
 
     (define (string-drop str nchars)
-      (let ((start (string-index->cursor str nchars)))
+      (let ((start (string-cursor-forward str (string-cursor-start str) nchars)))
         (substring/cursors str start (string-cursor-end str))
       ) ;let
     ) ;define
@@ -389,14 +233,13 @@
     ) ;define
 
     (define (string-every pred s . maybe-start+end)
-      (let* ((end-c-raw (string-cursor-end s))
-             (char-len (string-cursor-char-index end-c-raw))
+      (let* ((char-len (string-cursor->index s (string-cursor-end s)))
              (start (if (null? maybe-start+end) 0 (car maybe-start+end)))
              (rest (if (null? maybe-start+end) '() (cdr maybe-start+end)))
              (end (if (null? rest) char-len (car rest)))
              (_ (validate-start-end start end))
-             (start-c (string-index->cursor s start))
-             (end-c (string-index->cursor s end))
+             (start-c (as-cursor s start))
+             (end-c (as-cursor s end))
             ) ;
         (let loop
           ((cur start-c))
@@ -416,14 +259,13 @@
     ) ;define
 
     (define (string-any pred s . maybe-start+end)
-      (let* ((end-c-raw (string-cursor-end s))
-             (char-len (string-cursor-char-index end-c-raw))
+      (let* ((char-len (string-cursor->index s (string-cursor-end s)))
              (start (if (null? maybe-start+end) 0 (car maybe-start+end)))
              (rest (if (null? maybe-start+end) '() (cdr maybe-start+end)))
              (end (if (null? rest) char-len (car rest)))
              (_ (validate-start-end start end))
-             (start-c (string-index->cursor s start))
-             (end-c (string-index->cursor s end))
+             (start-c (as-cursor s start))
+             (end-c (as-cursor s end))
             ) ;
         (let loop
           ((cur start-c))
@@ -440,14 +282,13 @@
     ;; ==== Fold and iteration ====
 
     (define (string-fold kons knil s . maybe-start+end)
-      (let* ((end-c-raw (string-cursor-end s))
-             (char-len (string-cursor-char-index end-c-raw))
+      (let* ((char-len (string-cursor->index s (string-cursor-end s)))
              (start (if (null? maybe-start+end) 0 (car maybe-start+end)))
              (rest (if (null? maybe-start+end) '() (cdr maybe-start+end)))
              (end (if (null? rest) char-len (car rest)))
              (_ (validate-start-end start end))
-             (start-c (string-index->cursor s start))
-             (end-c (string-index->cursor s end))
+             (start-c (as-cursor s start))
+             (end-c (as-cursor s end))
             ) ;
         (let loop
           ((acc knil) (cur start-c))
@@ -460,14 +301,13 @@
     ) ;define
 
     (define (string-fold-right kons knil s . maybe-start+end)
-      (let* ((end-c-raw (string-cursor-end s))
-             (char-len (string-cursor-char-index end-c-raw))
+      (let* ((char-len (string-cursor->index s (string-cursor-end s)))
              (start (if (null? maybe-start+end) 0 (car maybe-start+end)))
              (rest (if (null? maybe-start+end) '() (cdr maybe-start+end)))
              (end (if (null? rest) char-len (car rest)))
              (_ (validate-start-end start end))
-             (start-c (string-index->cursor s start))
-             (end-c (string-index->cursor s end))
+             (start-c (as-cursor s start))
+             (end-c (as-cursor s end))
             ) ;
         ;; Non-recursive implementation using iteration
         (let ((chars (let collect
@@ -490,14 +330,13 @@
     ) ;define
 
     (define (string-for-each-cursor proc s . maybe-start+end)
-      (let* ((end-c-raw (string-cursor-end s))
-             (char-len (string-cursor-char-index end-c-raw))
+      (let* ((char-len (string-cursor->index s (string-cursor-end s)))
              (start (if (null? maybe-start+end) 0 (car maybe-start+end)))
              (rest (if (null? maybe-start+end) '() (cdr maybe-start+end)))
              (end (if (null? rest) char-len (car rest)))
              (_ (validate-start-end start end))
-             (start-c (string-index->cursor s start))
-             (end-c (string-index->cursor s end))
+             (start-c (as-cursor s start))
+             (end-c (as-cursor s end))
             ) ;
         (let loop
           ((cur start-c))
@@ -510,14 +349,13 @@
     ) ;define
 
     (define (string-count pred s . maybe-start+end)
-      (let* ((end-c-raw (string-cursor-end s))
-             (char-len (string-cursor-char-index end-c-raw))
+      (let* ((char-len (string-cursor->index s (string-cursor-end s)))
              (start (if (null? maybe-start+end) 0 (car maybe-start+end)))
              (rest (if (null? maybe-start+end) '() (cdr maybe-start+end)))
              (end (if (null? rest) char-len (car rest)))
              (_ (validate-start-end start end))
-             (start-c (string-index->cursor s start))
-             (end-c (string-index->cursor s end))
+             (start-c (as-cursor s start))
+             (end-c (as-cursor s end))
             ) ;
         (let loop
           ((cur start-c) (count 0))
@@ -534,14 +372,13 @@
     ;; ==== Searching ====
 
     (define (string-index s pred . maybe-start+end)
-      (let* ((end-c-raw (string-cursor-end s))
-             (char-len (string-cursor-char-index end-c-raw))
+      (let* ((char-len (string-cursor->index s (string-cursor-end s)))
              (start (if (null? maybe-start+end) 0 (car maybe-start+end)))
              (rest (if (null? maybe-start+end) '() (cdr maybe-start+end)))
              (end (if (null? rest) char-len (car rest)))
              (_ (validate-start-end start end))
-             (start-c (string-index->cursor s start))
-             (end-c (string-index->cursor s end))
+             (start-c (as-cursor s start))
+             (end-c (as-cursor s end))
             ) ;
         (let loop
           ((cur start-c))
@@ -554,14 +391,13 @@
     ) ;define
 
     (define (string-index-right s pred . maybe-start+end)
-      (let* ((end-c-raw (string-cursor-end s))
-             (char-len (string-cursor-char-index end-c-raw))
+      (let* ((char-len (string-cursor->index s (string-cursor-end s)))
              (start (if (null? maybe-start+end) 0 (car maybe-start+end)))
              (rest (if (null? maybe-start+end) '() (cdr maybe-start+end)))
              (end (if (null? rest) char-len (car rest)))
              (_ (validate-start-end start end))
-             (start-c (string-index->cursor s start))
-             (end-c (string-index->cursor s end))
+             (start-c (as-cursor s start))
+             (end-c (as-cursor s end))
             ) ;
         (if (string-cursor=? start-c end-c)
           start-c
@@ -577,14 +413,13 @@
     ) ;define
 
     (define (string-skip s pred . maybe-start+end)
-      (let* ((end-c-raw (string-cursor-end s))
-             (char-len (string-cursor-char-index end-c-raw))
+      (let* ((char-len (string-cursor->index s (string-cursor-end s)))
              (start (if (null? maybe-start+end) 0 (car maybe-start+end)))
              (rest (if (null? maybe-start+end) '() (cdr maybe-start+end)))
              (end (if (null? rest) char-len (car rest)))
              (_ (validate-start-end start end))
-             (start-c (string-index->cursor s start))
-             (end-c (string-index->cursor s end))
+             (start-c (as-cursor s start))
+             (end-c (as-cursor s end))
             ) ;
         (let loop
           ((cur start-c))
@@ -597,14 +432,13 @@
     ) ;define
 
     (define (string-skip-right s pred . maybe-start+end)
-      (let* ((end-c-raw (string-cursor-end s))
-             (char-len (string-cursor-char-index end-c-raw))
+      (let* ((char-len (string-cursor->index s (string-cursor-end s)))
              (start (if (null? maybe-start+end) 0 (car maybe-start+end)))
              (rest (if (null? maybe-start+end) '() (cdr maybe-start+end)))
              (end (if (null? rest) char-len (car rest)))
              (_ (validate-start-end start end))
-             (start-c (string-index->cursor s start))
-             (end-c (string-index->cursor s end))
+             (start-c (as-cursor s start))
+             (end-c (as-cursor s end))
             ) ;
         (if (string-cursor=? start-c end-c)
           start-c
@@ -622,12 +456,11 @@
     ;; ==== Trim and Pad ====
 
     (define* (string-trim s (pred char-whitespace?) (start 0) (end #t))
-      (let* ((end-c-raw (string-cursor-end s))
-             (char-len (string-cursor-char-index end-c-raw))
+      (let* ((char-len (string-cursor->index s (string-cursor-end s)))
              (end-idx (if (eq? end #t) char-len end))
              (_ (validate-start-end start end-idx))
-             (start-c (string-index->cursor s start))
-             (end-c (string-index->cursor s end-idx))
+             (start-c (as-cursor s start))
+             (end-c (as-cursor s end-idx))
             ) ;
         (let ((trimmed-start (string-skip s pred start-c end-c)))
           (substring/cursors s trimmed-start end-c)
@@ -636,12 +469,11 @@
     ) ;define*
 
     (define* (string-trim-right s (pred char-whitespace?) (start 0) (end #t))
-      (let* ((end-c-raw (string-cursor-end s))
-             (char-len (string-cursor-char-index end-c-raw))
+      (let* ((char-len (string-cursor->index s (string-cursor-end s)))
              (end-idx (if (eq? end #t) char-len end))
              (_ (validate-start-end start end-idx))
-             (start-c (string-index->cursor s start))
-             (end-c (string-index->cursor s end-idx))
+             (start-c (as-cursor s start))
+             (end-c (as-cursor s end-idx))
             ) ;
         (let ((trimmed-end (string-skip-right s pred start-c end-c)))
           (substring/cursors s start-c trimmed-end)
@@ -650,12 +482,11 @@
     ) ;define*
 
     (define* (string-trim-both s (pred char-whitespace?) (start 0) (end #t))
-      (let* ((end-c-raw (string-cursor-end s))
-             (char-len (string-cursor-char-index end-c-raw))
+      (let* ((char-len (string-cursor->index s (string-cursor-end s)))
              (end-idx (if (eq? end #t) char-len end))
              (_ (validate-start-end start end-idx))
-             (start-c (string-index->cursor s start))
-             (end-c (string-index->cursor s end-idx))
+             (start-c (as-cursor s start))
+             (end-c (as-cursor s end-idx))
             ) ;
         (let ((trimmed-start (string-skip s pred start-c end-c))
               (trimmed-end (string-skip-right s pred start-c end-c))
@@ -669,37 +500,35 @@
     ) ;define*
 
     (define* (string-pad s len (char #\space) (start 0) (end #t))
-      (let* ((end-c-raw (string-cursor-end s))
-             (char-len (string-cursor-char-index end-c-raw))
+      (let* ((char-len (string-cursor->index s (string-cursor-end s)))
              (end-idx (if (eq? end #t) char-len end))
              (_ (validate-start-end start end-idx))
-             (start-c (string-index->cursor s start))
-             (end-c (string-index->cursor s end-idx))
-             (sub (substring/cursors s start-c end-c))
-             (sub-len (string-cursor-diff sub (string-cursor-start sub) (string-cursor-end sub))
-             ) ;sub-len
+             (start-c (as-cursor s start))
+             (end-c (as-cursor s end-idx))
+             (sub-len (string-cursor-diff s start-c end-c))
             ) ;
         (if (>= sub-len len)
-          (string-take-right sub len)
-          (string-append (make-string (- len sub-len) char) sub)
+          (string-take-right (substring/cursors s start-c end-c) len)
+          (string-append (make-string (- len sub-len) char)
+            (substring/cursors s start-c end-c)
+          ) ;string-append
         ) ;if
       ) ;let*
     ) ;define*
 
     (define* (string-pad-right s len (char #\space) (start 0) (end #t))
-      (let* ((end-c-raw (string-cursor-end s))
-             (char-len (string-cursor-char-index end-c-raw))
+      (let* ((char-len (string-cursor->index s (string-cursor-end s)))
              (end-idx (if (eq? end #t) char-len end))
              (_ (validate-start-end start end-idx))
-             (start-c (string-index->cursor s start))
-             (end-c (string-index->cursor s end-idx))
-             (sub (substring/cursors s start-c end-c))
-             (sub-len (string-cursor-diff sub (string-cursor-start sub) (string-cursor-end sub))
-             ) ;sub-len
+             (start-c (as-cursor s start))
+             (end-c (as-cursor s end-idx))
+             (sub-len (string-cursor-diff s start-c end-c))
             ) ;
         (if (>= sub-len len)
-          (string-take sub len)
-          (string-append sub (make-string (- len sub-len) char))
+          (string-take (substring/cursors s start-c end-c) len)
+          (string-append (substring/cursors s start-c end-c)
+            (make-string (- len sub-len) char)
+          ) ;string-append
         ) ;if
       ) ;let*
     ) ;define*
@@ -707,10 +536,8 @@
     ;; ==== Prefix and Suffix ====
 
     (define (string-prefix-length s1 s2 . maybe-start+end)
-      (let* ((end1-c-raw (string-cursor-end s1))
-             (char-len1 (string-cursor-char-index end1-c-raw))
-             (end2-c-raw (string-cursor-end s2))
-             (char-len2 (string-cursor-char-index end2-c-raw))
+      (let* ((char-len1 (string-cursor->index s1 (string-cursor-end s1)))
+             (char-len2 (string-cursor->index s2 (string-cursor-end s2)))
              (start1 (if (null? maybe-start+end) 0 (car maybe-start+end)))
              (rest1 (if (null? maybe-start+end) '() (cdr maybe-start+end)))
              (end1 (if (null? rest1) char-len1 (car rest1)))
@@ -720,38 +547,27 @@
              (end2 (if (null? rest3) char-len2 (car rest3)))
              (_ (validate-start-end start1 end1))
              (_ (validate-start-end start2 end2))
-             (start1-idx (cursor->index start1))
-             (end1-idx (min (cursor->index end1) char-len1))
-             (start2-idx (cursor->index start2))
-             (end2-idx (min (cursor->index end2) char-len2))
-             (off1 (string-cursor-offsets end1-c-raw))
-             (pos1 (string-offsets-positions off1))
-             (bv1 (string-offsets-bv off1))
-             (off2 (string-cursor-offsets end2-c-raw))
-             (pos2 (string-offsets-positions off2))
-             (bv2 (string-offsets-bv off2))
+             (start1-c (as-cursor-clamped s1 start1 char-len1))
+             (end1-c (as-cursor-clamped s1 end1 char-len1))
+             (start2-c (as-cursor-clamped s2 start2 char-len2))
+             (end2-c (as-cursor-clamped s2 end2 char-len2))
             ) ;
         (let loop
-          ((i start1-idx) (j start2-idx) (count 0))
-          (if (or (>= i end1-idx) (>= j end2-idx))
+          ((i start1-c) (j start2-c) (count 0))
+          (if (or (string-cursor>=? i end1-c) (string-cursor>=? j end2-c))
             count
-            (let* ((b1-start (vector-ref pos1 i))
-                   (ch1 (integer->char (utf8->codepoint-at bv1 b1-start)))
-                   (b2-start (vector-ref pos2 j))
-                   (ch2 (integer->char (utf8->codepoint-at bv2 b2-start)))
-                  ) ;
-              (if (char=? ch1 ch2) (loop (+ i 1) (+ j 1) (+ count 1)) count)
-            ) ;let*
+            (if (char=? (string-ref/cursor s1 i) (string-ref/cursor s2 j))
+              (loop (string-cursor-next s1 i) (string-cursor-next s2 j) (+ count 1))
+              count
+            ) ;if
           ) ;if
         ) ;let
       ) ;let*
     ) ;define
 
     (define (string-suffix-length s1 s2 . maybe-start+end)
-      (let* ((end1-c-raw (string-cursor-end s1))
-             (char-len1 (string-cursor-char-index end1-c-raw))
-             (end2-c-raw (string-cursor-end s2))
-             (char-len2 (string-cursor-char-index end2-c-raw))
+      (let* ((char-len1 (string-cursor->index s1 (string-cursor-end s1)))
+             (char-len2 (string-cursor->index s2 (string-cursor-end s2)))
              (start1 (if (null? maybe-start+end) 0 (car maybe-start+end)))
              (rest1 (if (null? maybe-start+end) '() (cdr maybe-start+end)))
              (end1 (if (null? rest1) char-len1 (car rest1)))
@@ -761,38 +577,32 @@
              (end2 (if (null? rest3) char-len2 (car rest3)))
              (_ (validate-start-end start1 end1))
              (_ (validate-start-end start2 end2))
-             (start1-idx (cursor->index start1))
-             (end1-idx (min (cursor->index end1) char-len1))
-             (start2-idx (cursor->index start2))
-             (end2-idx (min (cursor->index end2) char-len2))
-             (off1 (string-cursor-offsets end1-c-raw))
-             (pos1 (string-offsets-positions off1))
-             (bv1 (string-offsets-bv off1))
-             (off2 (string-cursor-offsets end2-c-raw))
-             (pos2 (string-offsets-positions off2))
-             (bv2 (string-offsets-bv off2))
+             (start1-c (as-cursor-clamped s1 start1 char-len1))
+             (end1-c (as-cursor-clamped s1 end1 char-len1))
+             (start2-c (as-cursor-clamped s2 start2 char-len2))
+             (end2-c (as-cursor-clamped s2 end2 char-len2))
             ) ;
         (let loop
-          ((i (- end1-idx 1)) (j (- end2-idx 1)) (count 0))
-          (if (or (< i start1-idx) (< j start2-idx))
-            count
-            (let* ((b1-start (vector-ref pos1 i))
-                   (ch1 (integer->char (utf8->codepoint-at bv1 b1-start)))
-                   (b2-start (vector-ref pos2 j))
-                   (ch2 (integer->char (utf8->codepoint-at bv2 b2-start)))
-                  ) ;
-              (if (char=? ch1 ch2) (loop (- i 1) (- j 1) (+ count 1)) count)
-            ) ;let*
-          ) ;if
+          ((i end1-c) (j end2-c) (count 0))
+          (let ((i2 (if (string-cursor>? i start1-c) (string-cursor-prev s1 i) i))
+                (j2 (if (string-cursor>? j start2-c) (string-cursor-prev s2 j) j))
+               ) ;
+            (if (or (string-cursor=? i i2) (string-cursor=? j j2))
+              ;; 某一侧已无法后退（到 start），停止
+              count
+              (if (char=? (string-ref/cursor s1 i2) (string-ref/cursor s2 j2))
+                (loop i2 j2 (+ count 1))
+                count
+              ) ;if
+            ) ;if
+          ) ;let
         ) ;let
       ) ;let*
     ) ;define
 
     (define (string-prefix? s1 s2 . maybe-start+end)
-      (let* ((end1-c-raw (string-cursor-end s1))
-             (char-len1 (string-cursor-char-index end1-c-raw))
-             (end2-c-raw (string-cursor-end s2))
-             (char-len2 (string-cursor-char-index end2-c-raw))
+      (let* ((char-len1 (string-cursor->index s1 (string-cursor-end s1)))
+             (char-len2 (string-cursor->index s2 (string-cursor-end s2)))
              (start1 (if (null? maybe-start+end) 0 (car maybe-start+end)))
              (rest1 (if (null? maybe-start+end) '() (cdr maybe-start+end)))
              (end1 (if (null? rest1) char-len1 (car rest1)))
@@ -802,10 +612,18 @@
              (end2 (if (null? rest3) char-len2 (car rest3)))
              (_ (validate-start-end start1 end1))
              (_ (validate-start-end start2 end2))
-             (start1-idx (cursor->index start1))
-             (end1-idx (min (cursor->index end1) char-len1))
-             (start2-idx (cursor->index start2))
-             (end2-idx (min (cursor->index end2) char-len2))
+             (start1-idx (min (if (string-cursor? start1) (string-cursor->index s1 start1) start1)
+                           char-len1
+                         ) ;min
+             ) ;start1-idx
+             (end1-idx (min (if (string-cursor? end1) (string-cursor->index s1 end1) end1) char-len1)
+             ) ;end1-idx
+             (start2-idx (min (if (string-cursor? start2) (string-cursor->index s2 start2) start2)
+                           char-len2
+                         ) ;min
+             ) ;start2-idx
+             (end2-idx (min (if (string-cursor? end2) (string-cursor->index s2 end2) end2) char-len2)
+             ) ;end2-idx
             ) ;
         (let ((len1 (- end1-idx start1-idx)))
           (and (<= len1 (- end2-idx start2-idx))
@@ -816,10 +634,8 @@
     ) ;define
 
     (define (string-suffix? s1 s2 . maybe-start+end)
-      (let* ((end1-c-raw (string-cursor-end s1))
-             (char-len1 (string-cursor-char-index end1-c-raw))
-             (end2-c-raw (string-cursor-end s2))
-             (char-len2 (string-cursor-char-index end2-c-raw))
+      (let* ((char-len1 (string-cursor->index s1 (string-cursor-end s1)))
+             (char-len2 (string-cursor->index s2 (string-cursor-end s2)))
              (start1 (if (null? maybe-start+end) 0 (car maybe-start+end)))
              (rest1 (if (null? maybe-start+end) '() (cdr maybe-start+end)))
              (end1 (if (null? rest1) char-len1 (car rest1)))
@@ -829,10 +645,18 @@
              (end2 (if (null? rest3) char-len2 (car rest3)))
              (_ (validate-start-end start1 end1))
              (_ (validate-start-end start2 end2))
-             (start1-idx (cursor->index start1))
-             (end1-idx (min (cursor->index end1) char-len1))
-             (start2-idx (cursor->index start2))
-             (end2-idx (min (cursor->index end2) char-len2))
+             (start1-idx (min (if (string-cursor? start1) (string-cursor->index s1 start1) start1)
+                           char-len1
+                         ) ;min
+             ) ;start1-idx
+             (end1-idx (min (if (string-cursor? end1) (string-cursor->index s1 end1) end1) char-len1)
+             ) ;end1-idx
+             (start2-idx (min (if (string-cursor? start2) (string-cursor->index s2 start2) start2)
+                           char-len2
+                         ) ;min
+             ) ;start2-idx
+             (end2-idx (min (if (string-cursor? end2) (string-cursor->index s2 end2) end2) char-len2)
+             ) ;end2-idx
             ) ;
         (let ((len1 (- end1-idx start1-idx)))
           (and (<= len1 (- end2-idx start2-idx))
@@ -844,29 +668,23 @@
 
     ;; ==== Contains ====
 
-    (define (string-prefix-at? s1 s2 s1-pos s2-start s2-end off1 pos1 bv1 off2 pos2 bv2)
-      ;; Check if s2[s2-start:s2-end] matches s1 at character position s1-pos
-      ;; Uses pre-computed offsets for O(m) comparison without re-scanning
+    ;; Check if s2[s2-start:s2-end] matches s1 at cursor s1-pos
+    (define (string-prefix-at? s1 s2 s1-pos s2-start s2-end)
       (let loop
         ((i s1-pos) (j s2-start))
-        (if (>= j s2-end)
+        (if (string-cursor>=? j s2-end)
           #t
-          (let* ((b1-start (vector-ref pos1 i))
-                 (ch1 (integer->char (utf8->codepoint-at bv1 b1-start)))
-                 (b2-start (vector-ref pos2 j))
-                 (ch2 (integer->char (utf8->codepoint-at bv2 b2-start)))
-                ) ;
-            (if (char=? ch1 ch2) (loop (+ i 1) (+ j 1)) #f)
-          ) ;let*
+          (if (char=? (string-ref/cursor s1 i) (string-ref/cursor s2 j))
+            (loop (string-cursor-next s1 i) (string-cursor-next s2 j))
+            #f
+          ) ;if
         ) ;if
       ) ;let
     ) ;define
 
     (define (string-contains s1 s2 . maybe-start+end)
-      (let* ((end1-c-raw (string-cursor-end s1))
-             (char-len1 (string-cursor-char-index end1-c-raw))
-             (end2-c-raw (string-cursor-end s2))
-             (char-len2 (string-cursor-char-index end2-c-raw))
+      (let* ((char-len1 (string-cursor->index s1 (string-cursor-end s1)))
+             (char-len2 (string-cursor->index s2 (string-cursor-end s2)))
              (start1 (if (null? maybe-start+end) 0 (car maybe-start+end)))
              (rest1 (if (null? maybe-start+end) '() (cdr maybe-start+end)))
              (end1 (if (null? rest1) char-len1 (car rest1)))
@@ -876,40 +694,36 @@
              (end2 (if (null? rest3) char-len2 (car rest3)))
              (_ (validate-start-end start1 end1))
              (_ (validate-start-end start2 end2))
-             (start1-idx (cursor->index start1))
-             (end1-idx (min (cursor->index end1) char-len1))
-             (start2-idx (cursor->index start2))
-             (end2-idx (min (cursor->index end2) char-len2))
-             (off1 (string-cursor-offsets end1-c-raw))
-             (pos1 (string-offsets-positions off1))
-             (bv1 (string-offsets-bv off1))
-             (off2 (string-cursor-offsets end2-c-raw))
-             (pos2 (string-offsets-positions off2))
-             (bv2 (string-offsets-bv off2))
+             (start1-c (as-cursor s1 start1))
+             (end1-c (as-cursor-clamped s1 end1 char-len1))
+             (start2-c (as-cursor s2 start2))
+             (end2-c (as-cursor-clamped s2 end2 char-len2))
+             (s2-len (string-cursor-diff s2 start2-c end2-c))
             ) ;
-        (let ((s2-len (- end2-idx start2-idx)))
-          (if (zero? s2-len)
-            (string-index->cursor s1 start1-idx)
-            (let loop
-              ((i start1-idx))
-              (if (> (+ i s2-len) end1-idx)
-                #f
-                (if (string-prefix-at? s1 s2 i start2-idx end2-idx off1 pos1 bv1 off2 pos2 bv2)
-                  (string-index->cursor s1 i)
-                  (loop (+ i 1))
+        (if (zero? s2-len)
+          start1-c
+          (if (< (string-cursor-diff s1 start1-c end1-c) s2-len)
+            #f
+            (let ((limit (string-cursor-back s1 end1-c s2-len)))
+              (let loop
+                ((i start1-c))
+                (if (string-cursor>? i limit)
+                  #f
+                  (if (string-prefix-at? s1 s2 i start2-c end2-c)
+                    i
+                    (loop (string-cursor-next s1 i))
+                  ) ;if
                 ) ;if
-              ) ;if
+              ) ;let
             ) ;let
           ) ;if
-        ) ;let
+        ) ;if
       ) ;let*
     ) ;define
 
     (define (string-contains-right s1 s2 . maybe-start+end)
-      (let* ((end1-c-raw (string-cursor-end s1))
-             (char-len1 (string-cursor-char-index end1-c-raw))
-             (end2-c-raw (string-cursor-end s2))
-             (char-len2 (string-cursor-char-index end2-c-raw))
+      (let* ((char-len1 (string-cursor->index s1 (string-cursor-end s1)))
+             (char-len2 (string-cursor->index s2 (string-cursor-end s2)))
              (start1 (if (null? maybe-start+end) 0 (car maybe-start+end)))
              (rest1 (if (null? maybe-start+end) '() (cdr maybe-start+end)))
              (end1 (if (null? rest1) char-len1 (car rest1)))
@@ -919,32 +733,29 @@
              (end2 (if (null? rest3) char-len2 (car rest3)))
              (_ (validate-start-end start1 end1))
              (_ (validate-start-end start2 end2))
-             (start1-idx (cursor->index start1))
-             (end1-idx (min (cursor->index end1) char-len1))
-             (start2-idx (cursor->index start2))
-             (end2-idx (min (cursor->index end2) char-len2))
-             (off1 (string-cursor-offsets end1-c-raw))
-             (pos1 (string-offsets-positions off1))
-             (bv1 (string-offsets-bv off1))
-             (off2 (string-cursor-offsets end2-c-raw))
-             (pos2 (string-offsets-positions off2))
-             (bv2 (string-offsets-bv off2))
+             (start1-c (as-cursor s1 start1))
+             (end1-c (as-cursor-clamped s1 end1 char-len1))
+             (start2-c (as-cursor s2 start2))
+             (end2-c (as-cursor-clamped s2 end2 char-len2))
+             (s2-len (string-cursor-diff s2 start2-c end2-c))
             ) ;
-        (let ((s2-len (- end2-idx start2-idx)))
-          (if (zero? s2-len)
-            (string-index->cursor s1 end1-idx)
-            (let loop
-              ((i (- end1-idx s2-len)))
-              (if (< i start1-idx)
-                #f
-                (if (string-prefix-at? s1 s2 i start2-idx end2-idx off1 pos1 bv1 off2 pos2 bv2)
-                  (string-index->cursor s1 i)
-                  (loop (- i 1))
-                ) ;if
-              ) ;if
+        (if (zero? s2-len)
+          end1-c
+          (if (< (string-cursor-diff s1 start1-c end1-c) s2-len)
+            #f
+            (let ((limit (string-cursor-back s1 end1-c s2-len)))
+              (let loop
+                ((i limit))
+                (cond ((string-cursor<? i start1-c) #f)
+                  ((string-prefix-at? s1 s2 i start2-c end2-c) i)
+                  ;; 已到 start，无法再后退
+                  ((string-cursor=? i start1-c) #f)
+                  (else (loop (string-cursor-prev s1 i)))
+                ) ;cond
+              ) ;let
             ) ;let
           ) ;if
-        ) ;let
+        ) ;if
       ) ;let*
     ) ;define
 
@@ -956,11 +767,11 @@
       (let* ((final (if (null? maybe-final+end) "" (car maybe-final+end)))
              (rest (if (null? maybe-final+end) '() (cdr maybe-final+end)))
              (end (if (null? rest)
-                    (string-cursor-char-index (string-cursor-end final))
+                    (string-cursor->index final (string-cursor-end final))
                     (car rest)
                   ) ;if
              ) ;end
-             (end-idx (cursor->index end))
+             (end-idx (if (string-cursor? end) (string-cursor->index final end) end))
              (final-part (substring/cursors final 0 end-idx))
             ) ;
         (let* ((all-strings (reverse (cons final-part string-list)))
@@ -972,16 +783,13 @@
     ) ;define
 
     (define (string-reverse s . maybe-start+end)
-      (let* ((end-c-raw (string-cursor-end s))
-             (char-len (string-cursor-char-index end-c-raw))
+      (let* ((char-len (string-cursor->index s (string-cursor-end s)))
              (start (if (null? maybe-start+end) 0 (car maybe-start+end)))
              (rest (if (null? maybe-start+end) '() (cdr maybe-start+end)))
              (end (if (null? rest) char-len (car rest)))
              (_ (validate-start-end start end))
-             (start-idx (cursor->index start))
-             (end-idx (min (cursor->index end) char-len))
-             (start-c (string-index->cursor s start-idx))
-             (end-c (string-index->cursor s end-idx))
+             (start-c (as-cursor s start))
+             (end-c (as-cursor s end))
             ) ;
         (let loop
           ((cur start-c) (result '()))
@@ -994,30 +802,19 @@
     ) ;define
 
     (define (string-replicate s from . maybe-to+start+end)
-      (when (string-cursor? from)
-        (error 'type-error "string-replicate: from cannot be a cursor")
-      ) ;when
       (when (null? maybe-to+start+end)
         (error 'value-error "string-replicate: to argument is required")
       ) ;when
-      (let* ((end-c-raw (string-cursor-end s))
-             (char-len (string-cursor-char-index end-c-raw))
+      (let* ((char-len (string-cursor->index s (string-cursor-end s)))
              (to (car maybe-to+start+end))
              (start (if (null? (cdr maybe-to+start+end)) 0 (cadr maybe-to+start+end)))
              (rest1 (if (null? (cdr maybe-to+start+end)) '() (cddr maybe-to+start+end)))
              (end (if (null? rest1) char-len (car rest1)))
-             (_ (when (string-cursor? to)
-                  (error 'type-error "string-replicate: to cannot be a cursor")
-                ) ;when
-             ) ;_
              (_ (validate-start-end start end))
-             (start-idx (cursor->index start))
-             (end-idx (cursor->index end))
-             (from-idx from)
-             (to-idx to)
-             (slen (- end-idx start-idx))
-             (anslen (- to-idx from-idx))
-             (start-c (string-index->cursor s start-idx))
+             (start-c (as-cursor s start))
+             (end-c (as-cursor s end))
+             (slen (string-cursor-diff s start-c end-c))
+             (anslen (- to from))
              (source-chars (let loop
                              ((cur start-c) (n 0) (result '()))
                              (if (>= n slen)
@@ -1030,7 +827,7 @@
                            ) ;let
              ) ;source-chars
             ) ;
-        (when (> from-idx to-idx)
+        (when (> from to)
           (error 'value-error "string-replicate: from > to")
         ) ;when
         (cond ((zero? anslen) "")
@@ -1039,7 +836,7 @@
                       ((i 0) (result '()))
                       (if (>= i anslen)
                         (list->utf8-string (reverse result))
-                        (let ((ch (vector-ref source-chars (modulo (+ from-idx i) slen))))
+                        (let ((ch (vector-ref source-chars (modulo (+ from i) slen))))
                           (loop (+ i 1) (cons ch result))
                         ) ;let
                       ) ;if
@@ -1050,43 +847,35 @@
     ) ;define
 
     (define (string-replace s1 s2 start1 end1 . maybe-start+end)
-      (let* ((end1-c-raw (string-cursor-end s1))
-             (char-len1 (string-cursor-char-index end1-c-raw))
-             (end2-c-raw (string-cursor-end s2))
-             (char-len2 (string-cursor-char-index end2-c-raw))
+      (let* ((char-len1 (string-cursor->index s1 (string-cursor-end s1)))
+             (char-len2 (string-cursor->index s2 (string-cursor-end s2)))
              (start2 (if (null? maybe-start+end) 0 (car maybe-start+end)))
              (rest (if (null? maybe-start+end) '() (cdr maybe-start+end)))
              (end2 (if (null? rest) char-len2 (car rest)))
              (_ (validate-start-end start1 end1))
              (_ (validate-start-end start2 end2))
-             (start1-idx (cursor->index start1))
-             (end1-idx (cursor->index end1))
-             (start2-idx (cursor->index start2))
-             (end2-idx (cursor->index end2))
-             (before (substring/cursors s1 0 start1-idx))
-             (middle (substring/cursors s2 start2-idx end2-idx))
-             (after (substring/cursors s1 end1-idx char-len1))
+             (before (substring/cursors s1 (as-cursor s1 0) (as-cursor s1 start1)))
+             (middle (substring/cursors s2 (as-cursor s2 start2) (as-cursor s2 end2)))
+             (after (substring/cursors s1 (as-cursor s1 end1) (as-cursor s1 char-len1)))
             ) ;
         (string-append before middle after)
       ) ;let*
     ) ;define
 
     (define (string-split s delimiter . args)
-      (let* ((slen (string-cursor-char-index (string-cursor-end s)))
+      (let* ((char-len (string-cursor->index s (string-cursor-end s)))
              (grammar (if (null? args) 'infix (car args)))
              (rest1 (if (null? args) '() (cdr args)))
              (limit (if (null? rest1) #f (car rest1)))
              (rest2 (if (null? rest1) '() (cdr rest1)))
              (start (if (null? rest2) 0 (car rest2)))
              (rest3 (if (null? rest2) '() (cdr rest2)))
-             (end (if (null? rest3) slen (car rest3)))
+             (end (if (null? rest3) char-len (car rest3)))
              (_ (validate-start-end start end))
-             (start-idx (cursor->index start))
-             (end-idx (cursor->index end))
-             (start-c (string-index->cursor s start-idx))
-             (end-c (string-index->cursor s end-idx))
+             (start-c (as-cursor s start))
+             (end-c (as-cursor s end))
             ) ;
-        (cond ((= start-idx end-idx)
+        (cond ((= start end)
                (if (eq? grammar 'strict-infix)
                  (error 'value-error "empty string cannot be split with strict-infix grammar")
                  '()
@@ -1107,7 +896,7 @@
                  ) ;cond
                ) ;let
               ) ;
-              (else (let ((dlen (string-cursor-char-index (string-cursor-end delimiter))))
+              (else (let ((dlen (string-cursor->index delimiter (string-cursor-end delimiter))))
                       (define (finish r c)
                         (let ((rest-str (substring/cursors s c end-c)))
                           (if (and (eq? grammar 'suffix) (string-null? rest-str))
@@ -1140,16 +929,13 @@
     ) ;define
 
     (define (string-filter pred s . maybe-start+end)
-      (let* ((end-c-raw (string-cursor-end s))
-             (char-len (string-cursor-char-index end-c-raw))
+      (let* ((char-len (string-cursor->index s (string-cursor-end s)))
              (start (if (null? maybe-start+end) 0 (car maybe-start+end)))
              (rest (if (null? maybe-start+end) '() (cdr maybe-start+end)))
              (end (if (null? rest) char-len (car rest)))
              (_ (validate-start-end start end))
-             (start-idx (cursor->index start))
-             (end-idx (cursor->index end))
-             (start-c (string-index->cursor s start-idx))
-             (end-c (string-index->cursor s end-idx))
+             (start-c (as-cursor s start))
+             (end-c (as-cursor s end))
             ) ;
         (let loop
           ((cur start-c) (result '()))
@@ -1167,16 +953,13 @@
     ) ;define
 
     (define (string-remove pred s . maybe-start+end)
-      (let* ((end-c-raw (string-cursor-end s))
-             (char-len (string-cursor-char-index end-c-raw))
+      (let* ((char-len (string-cursor->index s (string-cursor-end s)))
              (start (if (null? maybe-start+end) 0 (car maybe-start+end)))
              (rest (if (null? maybe-start+end) '() (cdr maybe-start+end)))
              (end (if (null? rest) char-len (car rest)))
              (_ (validate-start-end start end))
-             (start-idx (cursor->index start))
-             (end-idx (cursor->index end))
-             (start-c (string-index->cursor s start-idx))
-             (end-c (string-index->cursor s end-idx))
+             (start-c (as-cursor s start))
+             (end-c (as-cursor s end))
             ) ;
         (let loop
           ((cur start-c) (result '()))
@@ -1238,16 +1021,13 @@
     ;; ==== Conversion ====
 
     (define (string->list/cursors s . maybe-start+end)
-      (let* ((end-c-raw (string-cursor-end s))
-             (char-len (string-cursor-char-index end-c-raw))
+      (let* ((char-len (string-cursor->index s (string-cursor-end s)))
              (start (if (null? maybe-start+end) 0 (car maybe-start+end)))
              (rest (if (null? maybe-start+end) '() (cdr maybe-start+end)))
              (end (if (null? rest) char-len (car rest)))
              (_ (validate-start-end start end))
-             (start-idx (cursor->index start))
-             (end-idx (cursor->index end))
-             (start-c (string-index->cursor s start-idx))
-             (end-c (string-index->cursor s end-idx))
+             (start-c (as-cursor s start))
+             (end-c (as-cursor s end))
             ) ;
         (let loop
           ((cur start-c) (result '()))

--- a/goldfish/liii/string-cursor.scm
+++ b/goldfish/liii/string-cursor.scm
@@ -747,10 +747,10 @@
               (let loop
                 ((i limit))
                 (cond ((string-cursor<? i start1-c) #f)
-                  ((string-prefix-at? s1 s2 i start2-c end2-c) i)
-                  ;; 已到 start，无法再后退
-                  ((string-cursor=? i start1-c) #f)
-                  (else (loop (string-cursor-prev s1 i)))
+                      ((string-prefix-at? s1 s2 i start2-c end2-c) i)
+                      ;; 已到 start，无法再后退
+                      ((string-cursor=? i start1-c) #f)
+                      (else (loop (string-cursor-prev s1 i)))
                 ) ;cond
               ) ;let
             ) ;let

--- a/src/goldfish.hpp
+++ b/src/goldfish.hpp
@@ -121,6 +121,7 @@ void glue_liii_os (s7_scheme* sc);
 void glue_liii_path (s7_scheme* sc);
 void glue_liii_sort (s7_scheme* sc);
 void glue_liii_string (s7_scheme* sc);
+void glue_liii_string_cursor (s7_scheme* sc);
 void glue_subprocess_run_values (s7_scheme* sc);
 
 inline s7_pointer
@@ -707,6 +708,7 @@ glue_for_community_edition (s7_scheme* sc) {
   glue_liii_sort (sc);
   glue_liii_list (sc);
   glue_liii_string (sc);
+  glue_liii_string_cursor (sc);
   glue_liii_time (sc);
   glue_liii_datetime (sc);
   glue_liii_uuid (sc);

--- a/src/liii_string_cursor.cpp
+++ b/src/liii_string_cursor.cpp
@@ -1,0 +1,412 @@
+//
+// Copyright (C) 2026 The Goldfish Scheme Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// (liii string-cursor) 的核心游标原语的 C++ 实现
+//
+// 游标表示：负整数 -(byte_offset+2)，即字节 0 对应 -2。-1 不是合法游标，
+// 保留给"负索引"错误语义（见 validate-start-end）。
+// 与字符索引（非负整数）天然不相交，满足 SRFI 130 的要求，
+// 且比较、前进、后退都是 O(1) 或 O(字符宽度) 的整数/字节运算，无分配。
+
+#include "s7.h"
+#include <cstdint>
+#include <cstring>
+
+namespace goldfish {
+
+static s7_pointer
+liii_string_cursor_type_error (s7_scheme* sc, const char* msg, s7_pointer arg) {
+  return s7_error (sc, s7_make_symbol (sc, "type-error"), s7_list (sc, 2, s7_make_string (sc, msg), arg));
+}
+
+static s7_pointer
+liii_string_cursor_value_error (s7_scheme* sc, const char* msg) {
+  return s7_error (sc, s7_make_symbol (sc, "value-error"), s7_list (sc, 1, s7_make_string (sc, msg)));
+}
+
+// 返回 UTF-8 首字节 b 对应的码点字节宽度（1~4）；非法首字节返回 1
+static inline s7_int
+utf8_seq_len (uint8_t b) {
+  if (b < 0x80) return 1;
+  if ((b & 0xE0) == 0xC0) return 2;
+  if ((b & 0xF0) == 0xE0) return 3;
+  if ((b & 0xF8) == 0xF0) return 4;
+  return 1;
+}
+
+// 游标 <-> 字节偏移
+static inline s7_int
+cursor_to_offset (s7_pointer cursor) {
+  return -s7_integer (cursor) - 2;
+}
+
+static inline s7_pointer
+offset_to_cursor (s7_scheme* sc, s7_int offset) {
+  return s7_make_integer (sc, -offset - 2);
+}
+
+// 校验第一个参数是字符串；失败时抛 type-error 并返回 NULL
+static const char*
+check_string_arg (s7_scheme* sc, s7_pointer arg, const char* who) {
+  if (!s7_is_string (arg)) {
+    liii_string_cursor_type_error (sc, who, arg);
+    return NULL;
+  }
+  return s7_string (arg);
+}
+
+// 校验 cursor 参数：负整数（游标）或非负整数（索引）；返回 true 表示是游标
+static bool
+parse_cursor_arg (s7_scheme* sc, s7_pointer arg, const char* who, s7_int* value) {
+  if (!s7_is_integer (arg)) {
+    liii_string_cursor_type_error (sc, who, arg);
+    return false;
+  }
+  *value= s7_integer (arg);
+  return *value < -1;
+}
+
+// ---- string-cursor-start / string-cursor-end ----
+
+static s7_pointer
+f_string_cursor_start (s7_scheme* sc, s7_pointer args) {
+  s7_pointer str= s7_car (args);
+  if (!check_string_arg (sc, str, "string-cursor-start: first parameter must be string"))
+    return NULL;
+  return s7_make_integer (sc, -2);
+}
+
+static s7_pointer
+f_string_cursor_end (s7_scheme* sc, s7_pointer args) {
+  s7_pointer str= s7_car (args);
+  if (!check_string_arg (sc, str, "string-cursor-end: first parameter must be string"))
+    return NULL;
+  return offset_to_cursor (sc, (s7_int) s7_string_length (str));
+}
+
+// ---- 字节偏移上的前进/后退 ----
+
+static s7_int
+utf8_advance (const char* s, s7_int off) {
+  return off + utf8_seq_len ((uint8_t) s[off]);
+}
+
+static s7_int
+utf8_retreat (const char* s, s7_int off) {
+  do { off--; } while (off > 0 && ((s[off] & 0xC0) == 0x80));
+  return off;
+}
+
+// ---- string-cursor-next / string-cursor-prev ----
+
+static s7_pointer
+f_string_cursor_next (s7_scheme* sc, s7_pointer args) {
+  s7_pointer str= s7_car (args);
+  const char* s= check_string_arg (sc, str, "string-cursor-next: first parameter must be string");
+  if (!s) return NULL;
+  s7_int cur;
+  bool is_cursor= parse_cursor_arg (sc, s7_cadr (args), "string-cursor-next: second parameter must be integer or cursor", &cur);
+  s7_int len= (s7_int) s7_string_length (str);
+
+  if (!is_cursor) {
+    // 索引语义：返回索引 +1
+    if (cur < 0 || cur >= len)
+      return liii_string_cursor_value_error (sc, "string-cursor-next: already at end cursor");
+    return s7_make_integer (sc, cur + 1);
+  }
+  s7_int off= cursor_to_offset (s7_car (s7_cdr (args)));
+  if (off >= len)
+    return liii_string_cursor_value_error (sc, "string-cursor-next: already at end cursor");
+  return offset_to_cursor (sc, utf8_advance (s, off));
+}
+
+static s7_pointer
+f_string_cursor_prev (s7_scheme* sc, s7_pointer args) {
+  s7_pointer str= s7_car (args);
+  const char* s= check_string_arg (sc, str, "string-cursor-prev: first parameter must be string");
+  if (!s) return NULL;
+  s7_pointer cur_arg= s7_cadr (args);
+  s7_int cur;
+  bool is_cursor= parse_cursor_arg (sc, cur_arg, "string-cursor-prev: second parameter must be integer or cursor", &cur);
+  if (is_cursor) {
+    s7_int off= cursor_to_offset (cur_arg);
+    if (off <= 0)
+      return liii_string_cursor_value_error (sc, "string-cursor-prev: already at start cursor");
+    return offset_to_cursor (sc, utf8_retreat (s, off));
+  }
+  if (cur <= 0)
+    return liii_string_cursor_value_error (sc, "string-cursor-prev: already at start cursor");
+  return s7_make_integer (sc, cur - 1);
+}
+
+// ---- string-cursor-forward / string-cursor-back ----
+
+static s7_pointer
+string_cursor_move (s7_scheme* sc, s7_pointer args, bool forward, const char* who) {
+  s7_pointer str= s7_car (args);
+  const char* s= check_string_arg (sc, str, who);
+  if (!s) return NULL;
+  s7_pointer cur_arg= s7_cadr (args);
+  s7_int cur, nchars;
+  bool is_cursor= parse_cursor_arg (sc, cur_arg, who, &cur);
+  s7_pointer n_arg= s7_cadr (s7_cdr (args));
+  if (!s7_is_integer (n_arg))
+    return liii_string_cursor_type_error (sc, who, n_arg);
+  nchars= s7_integer (n_arg);
+  if (!forward) nchars= -nchars;
+  s7_int len= (s7_int) s7_string_length (str);
+
+  if (!is_cursor)
+    return s7_make_integer (sc, cur + nchars);
+
+  s7_int off= cursor_to_offset (cur_arg);
+  if (nchars >= 0) {
+    for (s7_int i= 0; i < nchars; i++) {
+      if (off >= len)
+        return liii_string_cursor_value_error (sc, "string-cursor-forward: result would be invalid cursor");
+      off= utf8_advance (s, off);
+    }
+  } else {
+    for (s7_int i= 0; i < -nchars; i++) {
+      if (off <= 0)
+        return liii_string_cursor_value_error (sc, "string-cursor-back: result would be invalid cursor");
+      off= utf8_retreat (s, off);
+    }
+  }
+  return offset_to_cursor (sc, off);
+}
+
+static s7_pointer
+f_string_cursor_forward (s7_scheme* sc, s7_pointer args) {
+  return string_cursor_move (sc, args, true, "string-cursor-forward");
+}
+
+static s7_pointer
+f_string_cursor_back (s7_scheme* sc, s7_pointer args) {
+  return string_cursor_move (sc, args, false, "string-cursor-back");
+}
+
+// ---- 游标比较 ----
+// 索引空间：非负整数直接比较；游标空间：字节偏移越大，负整数越小，方向取反。
+// 混用游标与索引是类型错误。
+
+enum cursor_cmp { CMP_EQ, CMP_LT, CMP_GT, CMP_LE, CMP_GE };
+
+static s7_pointer
+string_cursor_compare (s7_scheme* sc, s7_pointer args, cursor_cmp op, const char* who) {
+  s7_pointer a= s7_car (args), b= s7_cadr (args);
+  s7_int ia, ib;
+  bool ca= parse_cursor_arg (sc, a, who, &ia);
+  bool cb= parse_cursor_arg (sc, b, who, &ib);
+  if (ca != cb)
+    return liii_string_cursor_type_error (sc, "string-cursor compare: cannot mix cursor and index", b);
+
+  s7_int x, y;
+  if (ca) { x= -ia; y= -ib; }  // 取反后恢复字节偏移的升序
+  else    { x= ia;  y= ib; }
+
+  bool result;
+  switch (op) {
+    case CMP_EQ: result= (x == y); break;
+    case CMP_LT: result= (x <  y); break;
+    case CMP_GT: result= (x >  y); break;
+    case CMP_LE: result= (x <= y); break;
+    default:     result= (x >= y); break;
+  }
+  return s7_make_boolean (sc, result);
+}
+
+static s7_pointer f_string_cursor_eq (s7_scheme* sc, s7_pointer args) { return string_cursor_compare (sc, args, CMP_EQ, "string-cursor=?"); }
+static s7_pointer f_string_cursor_lt (s7_scheme* sc, s7_pointer args) { return string_cursor_compare (sc, args, CMP_LT, "string-cursor<?"); }
+static s7_pointer f_string_cursor_gt (s7_scheme* sc, s7_pointer args) { return string_cursor_compare (sc, args, CMP_GT, "string-cursor>?"); }
+static s7_pointer f_string_cursor_le (s7_scheme* sc, s7_pointer args) { return string_cursor_compare (sc, args, CMP_LE, "string-cursor<=?"); }
+static s7_pointer f_string_cursor_ge (s7_scheme* sc, s7_pointer args) { return string_cursor_compare (sc, args, CMP_GE, "string-cursor>=?"); }
+
+// ---- string-cursor-diff ----
+
+static s7_pointer
+f_string_cursor_diff (s7_scheme* sc, s7_pointer args) {
+  s7_pointer str= s7_car (args);
+  const char* s= check_string_arg (sc, str, "string-cursor-diff: first parameter must be string");
+  if (!s) return NULL;
+  s7_pointer a= s7_cadr (args), b= s7_caddr (args);
+  s7_int ia, ib;
+  bool ca= parse_cursor_arg (sc, a, "string-cursor-diff: start must be integer or cursor", &ia);
+  bool cb= parse_cursor_arg (sc, b, "string-cursor-diff: end must be integer or cursor", &ib);
+  if (ca != cb)
+    return liii_string_cursor_type_error (sc, "string-cursor-diff: cannot mix cursor and index", b);
+
+  if (!ca)
+    return s7_make_integer (sc, ib - ia);
+
+  s7_int off1= cursor_to_offset (a), off2= cursor_to_offset (b);
+  s7_int count= 0;
+  while (off1 < off2) {
+    off1= utf8_advance (s, off1);
+    count++;
+  }
+  return s7_make_integer (sc, count);
+}
+
+// ---- string-cursor->index / string-index->cursor ----
+
+static s7_pointer
+f_string_cursor_to_index (s7_scheme* sc, s7_pointer args) {
+  s7_pointer str= s7_car (args);
+  const char* s= check_string_arg (sc, str, "string-cursor->index: first parameter must be string");
+  if (!s) return NULL;
+  s7_pointer cur_arg= s7_cadr (args);
+  s7_int cur;
+  bool is_cursor= parse_cursor_arg (sc, cur_arg, "string-cursor->index: second parameter must be integer or cursor", &cur);
+  if (!is_cursor)
+    return s7_make_integer (sc, cur);
+
+  s7_int off= cursor_to_offset (cur_arg);
+  s7_int len= (s7_int) s7_string_length (str);
+  if (off > len)
+    return liii_string_cursor_value_error (sc, "string-cursor->index: cursor out of range");
+  s7_int count= 0;
+  while (off > 0) {
+    off= utf8_retreat (s, off);
+    count++;
+  }
+  return s7_make_integer (sc, count);
+}
+
+static s7_pointer
+f_string_index_to_cursor (s7_scheme* sc, s7_pointer args) {
+  s7_pointer str= s7_car (args);
+  const char* s= check_string_arg (sc, str, "string-index->cursor: first parameter must be string");
+  if (!s) return NULL;
+  s7_pointer idx_arg= s7_cadr (args);
+  s7_int idx;
+  bool is_cursor= parse_cursor_arg (sc, idx_arg, "string-index->cursor: second parameter must be integer or cursor", &idx);
+  if (is_cursor)
+    return idx_arg;
+
+  if (idx < 0)
+    return liii_string_cursor_value_error (sc, "string-index->cursor: index out of range");
+  s7_int off= 0, len= (s7_int) s7_string_length (str);
+  for (s7_int i= 0; i < idx; i++) {
+    if (off >= len)
+      return liii_string_cursor_value_error (sc, "string-index->cursor: index out of range");
+    off= utf8_advance (s, off);
+  }
+  return offset_to_cursor (sc, off);
+}
+
+// ---- string-ref/cursor ----
+
+static s7_pointer
+f_string_ref_cursor (s7_scheme* sc, s7_pointer args) {
+  s7_pointer str= s7_car (args);
+  const char* s= check_string_arg (sc, str, "string-ref/cursor: first parameter must be string");
+  if (!s) return NULL;
+  s7_pointer cur_arg= s7_cadr (args);
+  s7_int cur;
+  bool is_cursor= parse_cursor_arg (sc, cur_arg, "string-ref/cursor: second parameter must be integer or cursor", &cur);
+  if (!is_cursor && cur < 0)
+    return liii_string_cursor_value_error (sc, "string-ref/cursor: cursor at or past end of string");
+
+  s7_int len= (s7_int) s7_string_length (str);
+  s7_int off;
+  if (is_cursor) {
+    off= cursor_to_offset (cur_arg);
+    if (off >= len)
+      return liii_string_cursor_value_error (sc, "string-ref/cursor: cursor at or past end of string");
+  } else {
+    off= 0;
+    for (s7_int i= 0; i < cur; i++) {
+      if (off >= len)
+        return liii_string_cursor_value_error (sc, "string-ref/cursor: cursor at or past end of string");
+      off= utf8_advance (s, off);
+    }
+    if (off >= len)
+      return liii_string_cursor_value_error (sc, "string-ref/cursor: cursor at or past end of string");
+  }
+
+  // 解码 UTF-8 码点
+  uint32_t cp;
+  uint8_t b0= (uint8_t) s[off];
+  s7_int n= utf8_seq_len (b0);
+  if (n == 1)      cp= b0;
+  else if (n == 2) cp= ((b0 & 0x1F) << 6) | (s[off + 1] & 0x3F);
+  else if (n == 3) cp= ((b0 & 0x0F) << 12) | ((s[off + 1] & 0x3F) << 6) | (s[off + 2] & 0x3F);
+  else             cp= ((b0 & 0x07) << 18) | ((s[off + 1] & 0x3F) << 12) | ((s[off + 2] & 0x3F) << 6) | (s[off + 3] & 0x3F);
+  return s7_make_character (sc, cp);
+}
+
+// ---- substring/cursors ----
+
+static s7_pointer
+f_substring_cursors (s7_scheme* sc, s7_pointer args) {
+  s7_pointer str= s7_car (args);
+  const char* s= check_string_arg (sc, str, "substring/cursors: first parameter must be string");
+  if (!s) return NULL;
+  s7_pointer a= s7_cadr (args), b= s7_caddr (args);
+  s7_int ia, ib;
+  bool ca= parse_cursor_arg (sc, a, "substring/cursors: start must be integer or cursor", &ia);
+  bool cb= parse_cursor_arg (sc, b, "substring/cursors: end must be integer or cursor", &ib);
+  if (ca != cb)
+    return liii_string_cursor_type_error (sc, "substring/cursors: cannot mix cursor and index", b);
+
+  s7_int len= (s7_int) s7_string_length (str);
+  s7_int byte_start, byte_end;
+  if (ca) {
+    byte_start= cursor_to_offset (a);
+    byte_end= cursor_to_offset (b);
+  } else {
+    byte_end= 0;
+    for (s7_int i= 0; i < ib; i++) {
+      if (byte_end >= len)
+        return liii_string_cursor_value_error (sc, "substring/cursors: end index out of range");
+      byte_end= utf8_advance (s, byte_end);
+    }
+    byte_start= 0;
+    for (s7_int i= 0; i < ia; i++)
+      byte_start= utf8_advance (s, byte_start);
+  }
+  if (byte_start > byte_end || byte_end > len)
+    return liii_string_cursor_value_error (sc, "substring/cursors: end index out of range");
+
+  s7_pointer result= s7_make_string_with_length (sc, "", byte_end - byte_start);
+  memcpy ((char*) s7_string (result), s + byte_start, byte_end - byte_start);
+  return result;
+}
+
+// ---- 注册 ----
+
+void
+glue_liii_string_cursor (s7_scheme* sc) {
+  s7_define_function (sc, "g_string-cursor-start", f_string_cursor_start, 1, 0, false, "(g_string-cursor-start str) => start cursor");
+  s7_define_function (sc, "g_string-cursor-end", f_string_cursor_end, 1, 0, false, "(g_string-cursor-end str) => post-end cursor");
+  s7_define_function (sc, "g_string-cursor-next", f_string_cursor_next, 2, 0, false, "(g_string-cursor-next str cur) => next cursor");
+  s7_define_function (sc, "g_string-cursor-prev", f_string_cursor_prev, 2, 0, false, "(g_string-cursor-prev str cur) => previous cursor");
+  s7_define_function (sc, "g_string-cursor-forward", f_string_cursor_forward, 3, 0, false, "(g_string-cursor-forward str cur nchars) => cursor");
+  s7_define_function (sc, "g_string-cursor-back", f_string_cursor_back, 3, 0, false, "(g_string-cursor-back str cur nchars) => cursor");
+  s7_define_function (sc, "g_string-cursor=?", f_string_cursor_eq, 2, 0, false, "(g_string-cursor=? c1 c2) => boolean");
+  s7_define_function (sc, "g_string-cursor<?", f_string_cursor_lt, 2, 0, false, "(g_string-cursor<? c1 c2) => boolean");
+  s7_define_function (sc, "g_string-cursor>?", f_string_cursor_gt, 2, 0, false, "(g_string-cursor>? c1 c2) => boolean");
+  s7_define_function (sc, "g_string-cursor<=?", f_string_cursor_le, 2, 0, false, "(g_string-cursor<=? c1 c2) => boolean");
+  s7_define_function (sc, "g_string-cursor>=?", f_string_cursor_ge, 2, 0, false, "(g_string-cursor>=? c1 c2) => boolean");
+  s7_define_function (sc, "g_string-cursor-diff", f_string_cursor_diff, 3, 0, false, "(g_string-cursor-diff str start end) => nchars");
+  s7_define_function (sc, "g_string-cursor->index", f_string_cursor_to_index, 2, 0, false, "(g_string-cursor->index str cur) => index");
+  s7_define_function (sc, "g_string-index->cursor", f_string_index_to_cursor, 2, 0, false, "(g_string-index->cursor str idx) => cursor");
+  s7_define_function (sc, "g_string-ref/cursor", f_string_ref_cursor, 2, 0, false, "(g_string-ref/cursor str cur) => char");
+  s7_define_function (sc, "g_substring/cursors", f_substring_cursors, 3, 0, false, "(g_substring/cursors str start end) => string");
+}
+
+} // namespace goldfish

--- a/src/liii_string_cursor.cpp
+++ b/src/liii_string_cursor.cpp
@@ -84,16 +84,14 @@ parse_cursor_arg (s7_scheme* sc, s7_pointer arg, const char* who, s7_int* value)
 static s7_pointer
 f_string_cursor_start (s7_scheme* sc, s7_pointer args) {
   s7_pointer str= s7_car (args);
-  if (!check_string_arg (sc, str, "string-cursor-start: first parameter must be string"))
-    return NULL;
+  if (!check_string_arg (sc, str, "string-cursor-start: first parameter must be string")) return NULL;
   return s7_make_integer (sc, -2);
 }
 
 static s7_pointer
 f_string_cursor_end (s7_scheme* sc, s7_pointer args) {
   s7_pointer str= s7_car (args);
-  if (!check_string_arg (sc, str, "string-cursor-end: first parameter must be string"))
-    return NULL;
+  if (!check_string_arg (sc, str, "string-cursor-end: first parameter must be string")) return NULL;
   return offset_to_cursor (sc, (s7_int) s7_string_length (str));
 }
 
@@ -106,7 +104,9 @@ utf8_advance (const char* s, s7_int off) {
 
 static s7_int
 utf8_retreat (const char* s, s7_int off) {
-  do { off--; } while (off > 0 && ((s[off] & 0xC0) == 0x80));
+  do {
+    off--;
+  } while (off > 0 && ((s[off] & 0xC0) == 0x80));
   return off;
 }
 
@@ -114,41 +114,39 @@ utf8_retreat (const char* s, s7_int off) {
 
 static s7_pointer
 f_string_cursor_next (s7_scheme* sc, s7_pointer args) {
-  s7_pointer str= s7_car (args);
-  const char* s= check_string_arg (sc, str, "string-cursor-next: first parameter must be string");
+  s7_pointer  str= s7_car (args);
+  const char* s  = check_string_arg (sc, str, "string-cursor-next: first parameter must be string");
   if (!s) return NULL;
   s7_int cur;
-  bool is_cursor= parse_cursor_arg (sc, s7_cadr (args), "string-cursor-next: second parameter must be integer or cursor", &cur);
+  bool   is_cursor=
+      parse_cursor_arg (sc, s7_cadr (args), "string-cursor-next: second parameter must be integer or cursor", &cur);
   s7_int len= (s7_int) s7_string_length (str);
 
   if (!is_cursor) {
     // 索引语义：返回索引 +1
-    if (cur < 0 || cur >= len)
-      return liii_string_cursor_value_error (sc, "string-cursor-next: already at end cursor");
+    if (cur < 0 || cur >= len) return liii_string_cursor_value_error (sc, "string-cursor-next: already at end cursor");
     return s7_make_integer (sc, cur + 1);
   }
   s7_int off= cursor_to_offset (s7_car (s7_cdr (args)));
-  if (off >= len)
-    return liii_string_cursor_value_error (sc, "string-cursor-next: already at end cursor");
+  if (off >= len) return liii_string_cursor_value_error (sc, "string-cursor-next: already at end cursor");
   return offset_to_cursor (sc, utf8_advance (s, off));
 }
 
 static s7_pointer
 f_string_cursor_prev (s7_scheme* sc, s7_pointer args) {
-  s7_pointer str= s7_car (args);
-  const char* s= check_string_arg (sc, str, "string-cursor-prev: first parameter must be string");
+  s7_pointer  str= s7_car (args);
+  const char* s  = check_string_arg (sc, str, "string-cursor-prev: first parameter must be string");
   if (!s) return NULL;
   s7_pointer cur_arg= s7_cadr (args);
-  s7_int cur;
-  bool is_cursor= parse_cursor_arg (sc, cur_arg, "string-cursor-prev: second parameter must be integer or cursor", &cur);
+  s7_int     cur;
+  bool       is_cursor=
+      parse_cursor_arg (sc, cur_arg, "string-cursor-prev: second parameter must be integer or cursor", &cur);
   if (is_cursor) {
     s7_int off= cursor_to_offset (cur_arg);
-    if (off <= 0)
-      return liii_string_cursor_value_error (sc, "string-cursor-prev: already at start cursor");
+    if (off <= 0) return liii_string_cursor_value_error (sc, "string-cursor-prev: already at start cursor");
     return offset_to_cursor (sc, utf8_retreat (s, off));
   }
-  if (cur <= 0)
-    return liii_string_cursor_value_error (sc, "string-cursor-prev: already at start cursor");
+  if (cur <= 0) return liii_string_cursor_value_error (sc, "string-cursor-prev: already at start cursor");
   return s7_make_integer (sc, cur - 1);
 }
 
@@ -156,21 +154,19 @@ f_string_cursor_prev (s7_scheme* sc, s7_pointer args) {
 
 static s7_pointer
 string_cursor_move (s7_scheme* sc, s7_pointer args, bool forward, const char* who) {
-  s7_pointer str= s7_car (args);
-  const char* s= check_string_arg (sc, str, who);
+  s7_pointer  str= s7_car (args);
+  const char* s  = check_string_arg (sc, str, who);
   if (!s) return NULL;
   s7_pointer cur_arg= s7_cadr (args);
-  s7_int cur, nchars;
-  bool is_cursor= parse_cursor_arg (sc, cur_arg, who, &cur);
-  s7_pointer n_arg= s7_cadr (s7_cdr (args));
-  if (!s7_is_integer (n_arg))
-    return liii_string_cursor_type_error (sc, who, n_arg);
+  s7_int     cur, nchars;
+  bool       is_cursor= parse_cursor_arg (sc, cur_arg, who, &cur);
+  s7_pointer n_arg    = s7_cadr (s7_cdr (args));
+  if (!s7_is_integer (n_arg)) return liii_string_cursor_type_error (sc, who, n_arg);
   nchars= s7_integer (n_arg);
   if (!forward) nchars= -nchars;
   s7_int len= (s7_int) s7_string_length (str);
 
-  if (!is_cursor)
-    return s7_make_integer (sc, cur + nchars);
+  if (!is_cursor) return s7_make_integer (sc, cur + nchars);
 
   s7_int off= cursor_to_offset (cur_arg);
   if (nchars >= 0) {
@@ -179,10 +175,10 @@ string_cursor_move (s7_scheme* sc, s7_pointer args, bool forward, const char* wh
         return liii_string_cursor_value_error (sc, "string-cursor-forward: result would be invalid cursor");
       off= utf8_advance (s, off);
     }
-  } else {
+  }
+  else {
     for (s7_int i= 0; i < -nchars; i++) {
-      if (off <= 0)
-        return liii_string_cursor_value_error (sc, "string-cursor-back: result would be invalid cursor");
+      if (off <= 0) return liii_string_cursor_value_error (sc, "string-cursor-back: result would be invalid cursor");
       off= utf8_retreat (s, off);
     }
   }
@@ -208,49 +204,77 @@ enum cursor_cmp { CMP_EQ, CMP_LT, CMP_GT, CMP_LE, CMP_GE };
 static s7_pointer
 string_cursor_compare (s7_scheme* sc, s7_pointer args, cursor_cmp op, const char* who) {
   s7_pointer a= s7_car (args), b= s7_cadr (args);
-  s7_int ia, ib;
-  bool ca= parse_cursor_arg (sc, a, who, &ia);
-  bool cb= parse_cursor_arg (sc, b, who, &ib);
-  if (ca != cb)
-    return liii_string_cursor_type_error (sc, "string-cursor compare: cannot mix cursor and index", b);
+  s7_int     ia, ib;
+  bool       ca= parse_cursor_arg (sc, a, who, &ia);
+  bool       cb= parse_cursor_arg (sc, b, who, &ib);
+  if (ca != cb) return liii_string_cursor_type_error (sc, "string-cursor compare: cannot mix cursor and index", b);
 
   s7_int x, y;
-  if (ca) { x= -ia; y= -ib; }  // 取反后恢复字节偏移的升序
-  else    { x= ia;  y= ib; }
+  if (ca) {
+    x= -ia;
+    y= -ib;
+  } // 取反后恢复字节偏移的升序
+  else {
+    x= ia;
+    y= ib;
+  }
 
   bool result;
   switch (op) {
-    case CMP_EQ: result= (x == y); break;
-    case CMP_LT: result= (x <  y); break;
-    case CMP_GT: result= (x >  y); break;
-    case CMP_LE: result= (x <= y); break;
-    default:     result= (x >= y); break;
+  case CMP_EQ:
+    result= (x == y);
+    break;
+  case CMP_LT:
+    result= (x < y);
+    break;
+  case CMP_GT:
+    result= (x > y);
+    break;
+  case CMP_LE:
+    result= (x <= y);
+    break;
+  default:
+    result= (x >= y);
+    break;
   }
   return s7_make_boolean (sc, result);
 }
 
-static s7_pointer f_string_cursor_eq (s7_scheme* sc, s7_pointer args) { return string_cursor_compare (sc, args, CMP_EQ, "string-cursor=?"); }
-static s7_pointer f_string_cursor_lt (s7_scheme* sc, s7_pointer args) { return string_cursor_compare (sc, args, CMP_LT, "string-cursor<?"); }
-static s7_pointer f_string_cursor_gt (s7_scheme* sc, s7_pointer args) { return string_cursor_compare (sc, args, CMP_GT, "string-cursor>?"); }
-static s7_pointer f_string_cursor_le (s7_scheme* sc, s7_pointer args) { return string_cursor_compare (sc, args, CMP_LE, "string-cursor<=?"); }
-static s7_pointer f_string_cursor_ge (s7_scheme* sc, s7_pointer args) { return string_cursor_compare (sc, args, CMP_GE, "string-cursor>=?"); }
+static s7_pointer
+f_string_cursor_eq (s7_scheme* sc, s7_pointer args) {
+  return string_cursor_compare (sc, args, CMP_EQ, "string-cursor=?");
+}
+static s7_pointer
+f_string_cursor_lt (s7_scheme* sc, s7_pointer args) {
+  return string_cursor_compare (sc, args, CMP_LT, "string-cursor<?");
+}
+static s7_pointer
+f_string_cursor_gt (s7_scheme* sc, s7_pointer args) {
+  return string_cursor_compare (sc, args, CMP_GT, "string-cursor>?");
+}
+static s7_pointer
+f_string_cursor_le (s7_scheme* sc, s7_pointer args) {
+  return string_cursor_compare (sc, args, CMP_LE, "string-cursor<=?");
+}
+static s7_pointer
+f_string_cursor_ge (s7_scheme* sc, s7_pointer args) {
+  return string_cursor_compare (sc, args, CMP_GE, "string-cursor>=?");
+}
 
 // ---- string-cursor-diff ----
 
 static s7_pointer
 f_string_cursor_diff (s7_scheme* sc, s7_pointer args) {
-  s7_pointer str= s7_car (args);
-  const char* s= check_string_arg (sc, str, "string-cursor-diff: first parameter must be string");
+  s7_pointer  str= s7_car (args);
+  const char* s  = check_string_arg (sc, str, "string-cursor-diff: first parameter must be string");
   if (!s) return NULL;
   s7_pointer a= s7_cadr (args), b= s7_caddr (args);
-  s7_int ia, ib;
-  bool ca= parse_cursor_arg (sc, a, "string-cursor-diff: start must be integer or cursor", &ia);
-  bool cb= parse_cursor_arg (sc, b, "string-cursor-diff: end must be integer or cursor", &ib);
-  if (ca != cb)
-    return liii_string_cursor_type_error (sc, "string-cursor-diff: cannot mix cursor and index", b);
+  s7_int     ia, ib;
+  bool       ca= parse_cursor_arg (sc, a, "string-cursor-diff: start must be integer or cursor", &ia);
+  bool       cb= parse_cursor_arg (sc, b, "string-cursor-diff: end must be integer or cursor", &ib);
+  if (ca != cb) return liii_string_cursor_type_error (sc, "string-cursor-diff: cannot mix cursor and index", b);
 
-  if (!ca)
-    return s7_make_integer (sc, ib - ia);
+  if (!ca) return s7_make_integer (sc, ib - ia);
 
   s7_int off1= cursor_to_offset (a), off2= cursor_to_offset (b);
   s7_int count= 0;
@@ -265,19 +289,18 @@ f_string_cursor_diff (s7_scheme* sc, s7_pointer args) {
 
 static s7_pointer
 f_string_cursor_to_index (s7_scheme* sc, s7_pointer args) {
-  s7_pointer str= s7_car (args);
-  const char* s= check_string_arg (sc, str, "string-cursor->index: first parameter must be string");
+  s7_pointer  str= s7_car (args);
+  const char* s  = check_string_arg (sc, str, "string-cursor->index: first parameter must be string");
   if (!s) return NULL;
   s7_pointer cur_arg= s7_cadr (args);
-  s7_int cur;
-  bool is_cursor= parse_cursor_arg (sc, cur_arg, "string-cursor->index: second parameter must be integer or cursor", &cur);
-  if (!is_cursor)
-    return s7_make_integer (sc, cur);
+  s7_int     cur;
+  bool       is_cursor=
+      parse_cursor_arg (sc, cur_arg, "string-cursor->index: second parameter must be integer or cursor", &cur);
+  if (!is_cursor) return s7_make_integer (sc, cur);
 
   s7_int off= cursor_to_offset (cur_arg);
   s7_int len= (s7_int) s7_string_length (str);
-  if (off > len)
-    return liii_string_cursor_value_error (sc, "string-cursor->index: cursor out of range");
+  if (off > len) return liii_string_cursor_value_error (sc, "string-cursor->index: cursor out of range");
   s7_int count= 0;
   while (off > 0) {
     off= utf8_retreat (s, off);
@@ -288,21 +311,19 @@ f_string_cursor_to_index (s7_scheme* sc, s7_pointer args) {
 
 static s7_pointer
 f_string_index_to_cursor (s7_scheme* sc, s7_pointer args) {
-  s7_pointer str= s7_car (args);
-  const char* s= check_string_arg (sc, str, "string-index->cursor: first parameter must be string");
+  s7_pointer  str= s7_car (args);
+  const char* s  = check_string_arg (sc, str, "string-index->cursor: first parameter must be string");
   if (!s) return NULL;
   s7_pointer idx_arg= s7_cadr (args);
-  s7_int idx;
-  bool is_cursor= parse_cursor_arg (sc, idx_arg, "string-index->cursor: second parameter must be integer or cursor", &idx);
-  if (is_cursor)
-    return idx_arg;
+  s7_int     idx;
+  bool       is_cursor=
+      parse_cursor_arg (sc, idx_arg, "string-index->cursor: second parameter must be integer or cursor", &idx);
+  if (is_cursor) return idx_arg;
 
-  if (idx < 0)
-    return liii_string_cursor_value_error (sc, "string-index->cursor: index out of range");
+  if (idx < 0) return liii_string_cursor_value_error (sc, "string-index->cursor: index out of range");
   s7_int off= 0, len= (s7_int) s7_string_length (str);
   for (s7_int i= 0; i < idx; i++) {
-    if (off >= len)
-      return liii_string_cursor_value_error (sc, "string-index->cursor: index out of range");
+    if (off >= len) return liii_string_cursor_value_error (sc, "string-index->cursor: index out of range");
     off= utf8_advance (s, off);
   }
   return offset_to_cursor (sc, off);
@@ -312,11 +333,11 @@ f_string_index_to_cursor (s7_scheme* sc, s7_pointer args) {
 
 static s7_pointer
 f_string_ref_cursor (s7_scheme* sc, s7_pointer args) {
-  s7_pointer str= s7_car (args);
-  const char* s= check_string_arg (sc, str, "string-ref/cursor: first parameter must be string");
+  s7_pointer  str= s7_car (args);
+  const char* s  = check_string_arg (sc, str, "string-ref/cursor: first parameter must be string");
   if (!s) return NULL;
   s7_pointer cur_arg= s7_cadr (args);
-  s7_int cur;
+  s7_int     cur;
   bool is_cursor= parse_cursor_arg (sc, cur_arg, "string-ref/cursor: second parameter must be integer or cursor", &cur);
   if (!is_cursor && cur < 0)
     return liii_string_cursor_value_error (sc, "string-ref/cursor: cursor at or past end of string");
@@ -325,27 +346,25 @@ f_string_ref_cursor (s7_scheme* sc, s7_pointer args) {
   s7_int off;
   if (is_cursor) {
     off= cursor_to_offset (cur_arg);
-    if (off >= len)
-      return liii_string_cursor_value_error (sc, "string-ref/cursor: cursor at or past end of string");
-  } else {
+    if (off >= len) return liii_string_cursor_value_error (sc, "string-ref/cursor: cursor at or past end of string");
+  }
+  else {
     off= 0;
     for (s7_int i= 0; i < cur; i++) {
-      if (off >= len)
-        return liii_string_cursor_value_error (sc, "string-ref/cursor: cursor at or past end of string");
+      if (off >= len) return liii_string_cursor_value_error (sc, "string-ref/cursor: cursor at or past end of string");
       off= utf8_advance (s, off);
     }
-    if (off >= len)
-      return liii_string_cursor_value_error (sc, "string-ref/cursor: cursor at or past end of string");
+    if (off >= len) return liii_string_cursor_value_error (sc, "string-ref/cursor: cursor at or past end of string");
   }
 
   // 解码 UTF-8 码点
   uint32_t cp;
-  uint8_t b0= (uint8_t) s[off];
-  s7_int n= utf8_seq_len (b0);
-  if (n == 1)      cp= b0;
+  uint8_t  b0= (uint8_t) s[off];
+  s7_int   n = utf8_seq_len (b0);
+  if (n == 1) cp= b0;
   else if (n == 2) cp= ((b0 & 0x1F) << 6) | (s[off + 1] & 0x3F);
   else if (n == 3) cp= ((b0 & 0x0F) << 12) | ((s[off + 1] & 0x3F) << 6) | (s[off + 2] & 0x3F);
-  else             cp= ((b0 & 0x07) << 18) | ((s[off + 1] & 0x3F) << 12) | ((s[off + 2] & 0x3F) << 6) | (s[off + 3] & 0x3F);
+  else cp= ((b0 & 0x07) << 18) | ((s[off + 1] & 0x3F) << 12) | ((s[off + 2] & 0x3F) << 6) | (s[off + 3] & 0x3F);
   return s7_make_character (sc, cp);
 }
 
@@ -353,26 +372,25 @@ f_string_ref_cursor (s7_scheme* sc, s7_pointer args) {
 
 static s7_pointer
 f_substring_cursors (s7_scheme* sc, s7_pointer args) {
-  s7_pointer str= s7_car (args);
-  const char* s= check_string_arg (sc, str, "substring/cursors: first parameter must be string");
+  s7_pointer  str= s7_car (args);
+  const char* s  = check_string_arg (sc, str, "substring/cursors: first parameter must be string");
   if (!s) return NULL;
   s7_pointer a= s7_cadr (args), b= s7_caddr (args);
-  s7_int ia, ib;
-  bool ca= parse_cursor_arg (sc, a, "substring/cursors: start must be integer or cursor", &ia);
-  bool cb= parse_cursor_arg (sc, b, "substring/cursors: end must be integer or cursor", &ib);
-  if (ca != cb)
-    return liii_string_cursor_type_error (sc, "substring/cursors: cannot mix cursor and index", b);
+  s7_int     ia, ib;
+  bool       ca= parse_cursor_arg (sc, a, "substring/cursors: start must be integer or cursor", &ia);
+  bool       cb= parse_cursor_arg (sc, b, "substring/cursors: end must be integer or cursor", &ib);
+  if (ca != cb) return liii_string_cursor_type_error (sc, "substring/cursors: cannot mix cursor and index", b);
 
   s7_int len= (s7_int) s7_string_length (str);
   s7_int byte_start, byte_end;
   if (ca) {
     byte_start= cursor_to_offset (a);
-    byte_end= cursor_to_offset (b);
-  } else {
+    byte_end  = cursor_to_offset (b);
+  }
+  else {
     byte_end= 0;
     for (s7_int i= 0; i < ib; i++) {
-      if (byte_end >= len)
-        return liii_string_cursor_value_error (sc, "substring/cursors: end index out of range");
+      if (byte_end >= len) return liii_string_cursor_value_error (sc, "substring/cursors: end index out of range");
       byte_end= utf8_advance (s, byte_end);
     }
     byte_start= 0;
@@ -391,22 +409,35 @@ f_substring_cursors (s7_scheme* sc, s7_pointer args) {
 
 void
 glue_liii_string_cursor (s7_scheme* sc) {
-  s7_define_function (sc, "g_string-cursor-start", f_string_cursor_start, 1, 0, false, "(g_string-cursor-start str) => start cursor");
-  s7_define_function (sc, "g_string-cursor-end", f_string_cursor_end, 1, 0, false, "(g_string-cursor-end str) => post-end cursor");
-  s7_define_function (sc, "g_string-cursor-next", f_string_cursor_next, 2, 0, false, "(g_string-cursor-next str cur) => next cursor");
-  s7_define_function (sc, "g_string-cursor-prev", f_string_cursor_prev, 2, 0, false, "(g_string-cursor-prev str cur) => previous cursor");
-  s7_define_function (sc, "g_string-cursor-forward", f_string_cursor_forward, 3, 0, false, "(g_string-cursor-forward str cur nchars) => cursor");
-  s7_define_function (sc, "g_string-cursor-back", f_string_cursor_back, 3, 0, false, "(g_string-cursor-back str cur nchars) => cursor");
+  s7_define_function (sc, "g_string-cursor-start", f_string_cursor_start, 1, 0, false,
+                      "(g_string-cursor-start str) => start cursor");
+  s7_define_function (sc, "g_string-cursor-end", f_string_cursor_end, 1, 0, false,
+                      "(g_string-cursor-end str) => post-end cursor");
+  s7_define_function (sc, "g_string-cursor-next", f_string_cursor_next, 2, 0, false,
+                      "(g_string-cursor-next str cur) => next cursor");
+  s7_define_function (sc, "g_string-cursor-prev", f_string_cursor_prev, 2, 0, false,
+                      "(g_string-cursor-prev str cur) => previous cursor");
+  s7_define_function (sc, "g_string-cursor-forward", f_string_cursor_forward, 3, 0, false,
+                      "(g_string-cursor-forward str cur nchars) => cursor");
+  s7_define_function (sc, "g_string-cursor-back", f_string_cursor_back, 3, 0, false,
+                      "(g_string-cursor-back str cur nchars) => cursor");
   s7_define_function (sc, "g_string-cursor=?", f_string_cursor_eq, 2, 0, false, "(g_string-cursor=? c1 c2) => boolean");
   s7_define_function (sc, "g_string-cursor<?", f_string_cursor_lt, 2, 0, false, "(g_string-cursor<? c1 c2) => boolean");
   s7_define_function (sc, "g_string-cursor>?", f_string_cursor_gt, 2, 0, false, "(g_string-cursor>? c1 c2) => boolean");
-  s7_define_function (sc, "g_string-cursor<=?", f_string_cursor_le, 2, 0, false, "(g_string-cursor<=? c1 c2) => boolean");
-  s7_define_function (sc, "g_string-cursor>=?", f_string_cursor_ge, 2, 0, false, "(g_string-cursor>=? c1 c2) => boolean");
-  s7_define_function (sc, "g_string-cursor-diff", f_string_cursor_diff, 3, 0, false, "(g_string-cursor-diff str start end) => nchars");
-  s7_define_function (sc, "g_string-cursor->index", f_string_cursor_to_index, 2, 0, false, "(g_string-cursor->index str cur) => index");
-  s7_define_function (sc, "g_string-index->cursor", f_string_index_to_cursor, 2, 0, false, "(g_string-index->cursor str idx) => cursor");
-  s7_define_function (sc, "g_string-ref/cursor", f_string_ref_cursor, 2, 0, false, "(g_string-ref/cursor str cur) => char");
-  s7_define_function (sc, "g_substring/cursors", f_substring_cursors, 3, 0, false, "(g_substring/cursors str start end) => string");
+  s7_define_function (sc, "g_string-cursor<=?", f_string_cursor_le, 2, 0, false,
+                      "(g_string-cursor<=? c1 c2) => boolean");
+  s7_define_function (sc, "g_string-cursor>=?", f_string_cursor_ge, 2, 0, false,
+                      "(g_string-cursor>=? c1 c2) => boolean");
+  s7_define_function (sc, "g_string-cursor-diff", f_string_cursor_diff, 3, 0, false,
+                      "(g_string-cursor-diff str start end) => nchars");
+  s7_define_function (sc, "g_string-cursor->index", f_string_cursor_to_index, 2, 0, false,
+                      "(g_string-cursor->index str cur) => index");
+  s7_define_function (sc, "g_string-index->cursor", f_string_index_to_cursor, 2, 0, false,
+                      "(g_string-index->cursor str idx) => cursor");
+  s7_define_function (sc, "g_string-ref/cursor", f_string_ref_cursor, 2, 0, false,
+                      "(g_string-ref/cursor str cur) => char");
+  s7_define_function (sc, "g_substring/cursors", f_substring_cursors, 3, 0, false,
+                      "(g_substring/cursors str start end) => string");
 }
 
 } // namespace goldfish

--- a/xmake.lua
+++ b/xmake.lua
@@ -113,6 +113,7 @@ target ("goldfish") do
     add_files ("src/liii_path.cpp")
     add_files ("src/liii_sort.cpp")
     add_files ("src/liii_string.cpp")
+    add_files ("src/liii_string_cursor.cpp")
     add_files ("src/liii_hashlib.cpp")
     add_files ("src/liii_base64.cpp")
     add_files ("src/liii_json.cpp")


### PR DESCRIPTION
## 概述

将 `(liii string-cursor)` 的核心游标原语从纯 Scheme 实现下沉到 C++（`src/liii_string_cursor.cpp`），大幅优化性能。

## 设计

- **游标表示**：负整数 `-(byte_offset+2)`，即字节 0 对应 -2，与字符索引（非负整数）不相交，比较为 O(1) 整数运算，无分配
- **-1 不是合法游标**，保留"负索引"错误语义，与旧实现的错误类型兼容
- C++ 直接在 `s7_string` 原始 UTF-8 字节上扫描：`start/end` O(1)，`substring/cursors` 为 memcpy
- 上层函数（fold/split/contains/trim 等）保持 Scheme 实现，改用公共原语重写

## 性能（bench/string-cursor.scm）

| 场景 | cursor 遍历 | string-fold | string-every |
|---|---|---|---|
| ASCII 50 字符 | 16x | 5.6x | 5.9x |
| UTF-8 20 汉字 | 22x | 8.0x | 6.3x |
| Emoji 10 个 | 21x | 8.3x | 8.8x |

cursor 遍历已与原生 `string-ref` 遍历同一量级。

## 测试

- `tests/liii/string-cursor/` 全部 14 个测试文件通过
- `tests/liii` 全量 150 个测试通过

详见 `devel/0127.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)