### PR TITLE
[0129] json-push 迁移到 C++ 实现并清理 (guenchi json) 历史接口

### DIFF
--- a/bench/json-ref-set-perf.scm
+++ b/bench/json-ref-set-perf.scm
@@ -153,6 +153,44 @@
   ) ;if
 ) ;define
 
+;; 历史 Scheme 实现（原 (guenchi json) 的 json-push 及 (liii json) 的包装），原样保留用于对比
+
+(define (g-json-push/scheme x k v)
+  (if (vector? x)
+    (if (= (vector-length x) 0)
+      (vector v)
+      (list->vector (let l
+                      ((x (vector->alist x)) (k k) (v v) (b #f))
+                      (if (null? x)
+                        (if b '() (cons v '()))
+                        (if (equal? (caar x) k)
+                          (cons v (cons (cdar x) (l (cdr x) k v #t)))
+                          (cons (cdar x) (l (cdr x) k v b))
+                        ) ;if
+                      ) ;if
+                    ) ;let
+      ) ;list->vector
+    ) ;if
+    (cons (cons k v) x)
+  ) ;if
+) ;define
+
+(define (json-push/scheme json key val . args)
+  (unless (or (json-object? json) (json-array? json))
+    (type-error "Value is not a JSON object or array" json)
+  ) ;unless
+  (if (null? args)
+    (if (and (json-object? json) (equal? json '(())))
+      (g-json-push/scheme '() key val)
+      (g-json-push/scheme json key val)
+    ) ;if
+    (json-set/scheme json
+      key
+      (lambda (x) (apply json-push/scheme (cons x (cons val args))))
+    ) ;json-set/scheme
+  ) ;if
+) ;define
+
 (define (build-json-string n)
   (let ((out (open-output-string)))
     (display "{" out)
@@ -208,6 +246,21 @@
         ) ;equal?
   (error 'value-error "array map-set mismatch")
 ) ;unless
+(unless (equal? (json-push bench-obj "newkey" 'new)
+          (json-push/scheme bench-obj "newkey" 'new)
+        ) ;equal?
+  (error 'value-error "object push mismatch")
+) ;unless
+(unless (equal? (json-push bench-arr 300 'new)
+          (json-push/scheme bench-arr 300 'new)
+        ) ;equal?
+  (error 'value-error "array push mismatch")
+) ;unless
+(unless (equal? (json-push bench-nested 'user 'profile 'weight 60)
+          (json-push/scheme bench-nested 'user 'profile 'weight 60)
+        ) ;equal?
+  (error 'value-error "nested push mismatch")
+) ;unless
 
 (define ref-iter 2000)
 
@@ -231,6 +284,8 @@
   (json-ref/scheme bench-obj bench-ref-key)
   (json-set bench-obj bench-ref-key 0)
   (json-set/scheme bench-obj bench-ref-key 0)
+  (json-push bench-obj "newkey" 'new)
+  (json-push/scheme bench-obj "newkey" 'new)
 ) ;do
 
 (display "=== json-ref / json-set C++ vs Scheme 性能对比 ===")
@@ -294,6 +349,41 @@
       ) ;t
      ) ;
   (report "数组全映射设置/Scheme" set-iter t)
+) ;let
+
+(let ((t (timeit (lambda () (json-push bench-obj "newkey" 'new)) '() set-iter)))
+  (report "对象单键前插/C++" set-iter t)
+) ;let
+(let ((t (timeit (lambda () (json-push/scheme bench-obj "newkey" 'new)) '() set-iter)
+     ) ;t
+     ) ;
+  (report "对象单键前插/Scheme" set-iter t)
+) ;let
+
+(let ((t (timeit (lambda () (json-push bench-arr 300 'new)) '() set-iter)))
+  (report "数组无匹配尾插/C++" set-iter t)
+) ;let
+(let ((t (timeit (lambda () (json-push/scheme bench-arr 300 'new)) '() set-iter)
+     ) ;t
+     ) ;
+  (report "数组无匹配尾插/Scheme" set-iter t)
+) ;let
+
+(let ((t (timeit (lambda () (json-push bench-nested 'user 'profile 'weight 60))
+           '()
+           set-iter
+         ) ;timeit
+      ) ;t
+     ) ;
+  (report "多键路径前插/C++" set-iter t)
+) ;let
+(let ((t (timeit (lambda () (json-push/scheme bench-nested 'user 'profile 'weight 60))
+           '()
+           set-iter
+         ) ;timeit
+      ) ;t
+     ) ;
+  (report "多键路径前插/Scheme" set-iter t)
 ) ;let
 
 (newline)

--- a/devel/0129.md
+++ b/devel/0129.md
@@ -1,0 +1,35 @@
+# [0129] json-push 的 C++ 实现与 (guenchi json) 历史接口清理
+
+## 任务相关的代码文件
+- src/liii_json.cpp
+- goldfish/liii/json.scm
+- goldfish/guenchi/json.scm
+- tests/liii/json/json-push-test.scm
+- bench/json-ref-set-perf.scm
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf tests/liii/json/json-push-test.scm
+bin/gf tests/liii/json-test.scm
+bin/gf bench/json-ref-set-perf.scm
+```
+
+## 2026-08-19 json-push 迁移到 C++，移除 (guenchi json) 中的历史实现
+
+### What
+1. `src/liii_json.cpp` 新增 `g_json_push`（变参多键路径），完整复刻 `(liii json)` 包装 `(guenchi json)` 的 Scheme 实现语义：
+   - 单键：对象 `(cons (cons k v) x)` 前插；空对象 `'(())` 退化为 `'((k . v))`；数组空时返回 `#(v)`，非空时按索引 `equal?` 匹配，首匹配处前插（仅一次），无匹配尾插
+   - 多键：等价于 `(json-set json key (lambda (x) (apply json-push x ...)))`，复用 `json_setter` 基础设施并新增 `is_push` 模式，叶层对旧值在 C++ 内递归 push，不经 Scheme 闭包回调；空对象 `'(())` 原样返回；每层先做结构校验
+2. `(liii json)` 的 `json-push` 直接绑定 `g_json_push`，删除 Scheme 包装
+3. `(guenchi json)` 移除 `json-ref`、`json-set`、`json-push` 及带 `*` 版本的定义与导出；仅保留私有的 `(define json-set g_json_set)` 供 `json-drop*` 内部使用
+4. `tests/liii/json/json-push-test.scm` 新增 10 个边界用例（单键对象/数组、空数组、无匹配尾插、首匹配前插、空对象单键/多键、中间键不存在、不可变性），先在旧实现上通过以锁定语义
+5. `bench/json-ref-set-perf.scm` 新增 json-push 的 C++/Scheme 对比项与 sanity check
+
+### Why
+`json-push` 是 `(liii json)` 中最后一个核心修改操作仍走 Scheme 实现，多键路径每层都要分配闭包并回调；数组分支还需 `vector->alist` → cons → `list->vector` 三次全量拷贝。同时 `g_json_ref`/`g_json_set` 均已支持变参多键路径，`(guenchi json)` 中保留的历史 Scheme 实现已无存在必要。
+
+### How
+- 多键路径复用 `json_set_dispatch` 的 `json_setter` 结构体，增加 `is_push`/`push_args` 字段：`json_setter_apply` 遇到 push 模式时对旧值递归 `json_push_dispatch`，避免构造 Scheme 闭包
+- 单键/多键判定：kvs 恰好为 `(k v)` 两个元素（即 `cddr` 为空）时是单键
+- bench 实测（500 次迭代）：对象单键前插 ~2.4×、数组无匹配尾插 ~13×、多键路径前插 ~11×

--- a/goldfish/guenchi/json.scm
+++ b/goldfish/guenchi/json.scm
@@ -27,8 +27,7 @@
     (liii string)
     (liii unicode)
   ) ;import
-  (export json-string-escape json-drop json-drop* json-reduce json-reduce*
-  ) ;export
+  (export json-string-escape json-drop json-drop* json-reduce json-reduce*)
   (begin
 
     (define (json-string-escape str)

--- a/goldfish/guenchi/json.scm
+++ b/goldfish/guenchi/json.scm
@@ -27,8 +27,7 @@
     (liii string)
     (liii unicode)
   ) ;import
-  (export json-string-escape json-ref json-ref* json-set json-set* json-push
-    json-push* json-drop json-drop* json-reduce json-reduce*
+  (export json-string-escape json-drop json-drop* json-reduce json-reduce*
   ) ;export
   (begin
 
@@ -74,141 +73,9 @@
       ) ;let
     ) ;define
 
-    (define json-ref
-      (lambda (x k)
-        (define return
-          (lambda (x)
-            (if (symbol? x)
-              (cond ((symbol=? x 'true) #t)
-                    ((symbol=? x 'false) #f)
-                    (else x)
-              ) ;cond
-              x
-            ) ;if
-          ) ;lambda
-        ) ;define
-        (if (vector? x)
-          (return (vector-ref x k))
-          (let loop
-            ((x x) (k k))
-            (if (null? x) '() (if (equal? (caar x) k) (return (cdar x)) (loop (cdr x) k)))
-          ) ;let
-        ) ;if
-      ) ;lambda
-    ) ;define
-    (define (json-ref* j . keys)
-      (let loop
-        ((expr j) (keys keys))
-        (if (null? keys) expr (loop (json-ref expr (car keys)) (cdr keys)))
-      ) ;let
-    ) ;define
-    (define json-set
-      (lambda (x v p)
-        (let ((x x) (v v) (p (if (procedure? p) p (lambda (x) p))))
-          (if (vector? x)
-            (list->vector (cond ((boolean? v)
-                                 (if v
-                                   (let l
-                                     ((x (vector->alist x)) (p p))
-                                     (if (null? x) '() (cons (p (cdar x)) (l (cdr x) p)))
-                                   ) ;let
-                                 ) ;if
-                                ) ;
-                                ((procedure? v)
-                                 (let l
-                                   ((x (vector->alist x)) (v v) (p p))
-                                   (if (null? x)
-                                     '()
-                                     (if (v (caar x))
-                                       (cons (p (cdar x)) (l (cdr x) v p))
-                                       (cons (cdar x) (l (cdr x) v p))
-                                     ) ;if
-                                   ) ;if
-                                 ) ;let
-                                ) ;
-                                (else (let l
-                                        ((x (vector->alist x)) (v v) (p p))
-                                        (if (null? x)
-                                          '()
-                                          (if (equal? (caar x) v)
-                                            (cons (p (cdar x)) (l (cdr x) v p))
-                                            (cons (cdar x) (l (cdr x) v p))
-                                          ) ;if
-                                        ) ;if
-                                      ) ;let
-                                ) ;else
-                          ) ;cond
-            ) ;list->vector
-            (cond ((boolean? v)
-                   (if v
-                     (let l
-                       ((x x) (p p))
-                       (if (null? x) '() (cons (cons (caar x) (p (cdar x))) (l (cdr x) p)))
-                     ) ;let
-                   ) ;if
-                  ) ;
-                  ((procedure? v)
-                   (let l
-                     ((x x) (v v) (p p))
-                     (if (null? x)
-                       '()
-                       (if (v (caar x))
-                         (cons (cons (caar x) (p (cdar x))) (l (cdr x) v p))
-                         (cons (car x) (l (cdr x) v p))
-                       ) ;if
-                     ) ;if
-                   ) ;let
-                  ) ;
-                  (else (let l
-                          ((x x) (v v) (p p))
-                          (if (null? x)
-                            '()
-                            (if (equal? (caar x) v)
-                              (cons (cons v (p (cdar x))) (l (cdr x) v p))
-                              (cons (car x) (l (cdr x) v p))
-                            ) ;if
-                          ) ;if
-                        ) ;let
-                  ) ;else
-            ) ;cond
-          ) ;if
-        ) ;let
-      ) ;lambda
-    ) ;define
-    (define (json-set* json k0 k1_or_v . ks_and_v)
-      (if (null? ks_and_v)
-        (json-set json k0 k1_or_v)
-        (json-set json
-          k0
-          (lambda (x) (apply json-set* (cons x (cons k1_or_v ks_and_v))))
-        ) ;json-set
-      ) ;if
-    ) ;define
-    (define (json-push x k v)
-      (if (vector? x)
-        (if (= (vector-length x) 0)
-          (vector v)
-          (list->vector (let l
-                          ((x (vector->alist x)) (k k) (v v) (b #f))
-                          (if (null? x)
-                            (if b '() (cons v '()))
-                            (if (equal? (caar x) k)
-                              (cons v (cons (cdar x) (l (cdr x) k v #t)))
-                              (cons (cdar x) (l (cdr x) k v b))
-                            ) ;if
-                          ) ;if
-                        ) ;let
-          ) ;list->vector
-        ) ;if
-        (cons (cons k v) x)
-      ) ;if
-    ) ;define
-    (define (json-push* json k0 v0 . rest)
-      (if (null? rest)
-        (json-push json k0 v0)
-        (json-set json k0 (lambda (x) (apply json-push* (cons x (cons v0 rest)))))
-      ) ;if
-    ) ;define
+    ;; json-set 由 C++ 实现（src/liii_json.cpp 中的 g_json_set，含变参多键路径，
+    ;; 语义覆盖历史上的 json-set 与 json-set*）；仅供本库的 json-drop* 内部使用，不导出
+    (define json-set g_json_set)
     (define json-drop
       (lambda (x v)
         (if (vector? x)

--- a/goldfish/liii/json.scm
+++ b/goldfish/liii/json.scm
@@ -2,8 +2,6 @@
   (import (liii base)
     (liii list)
     (rename (guenchi json)
-      (json-push g:json-push)
-      (json-push* g:json-push*)
       (json-drop g:json-drop)
       (json-drop* g:json-drop*)
       (json-reduce g:json-reduce)
@@ -58,21 +56,14 @@
     ;; json-set 由 C++ 实现（src/liii_json.cpp 中的 g_json_set）
     (define json-set g_json_set)
 
+    ;; json-push 由 C++ 实现（src/liii_json.cpp 中的 g_json_push，含变参多键路径，
+    ;; 语义覆盖历史上的 json-push 与 json-push*）
+    (define json-push g_json_push)
+
     (define (ensure-json-structure x)
       (unless (or (json-object? x) (json-array? x))
         (type-error "Value is not a JSON object or array" x)
       ) ;unless
-    ) ;define
-
-    (define (json-push json key val . args)
-      (ensure-json-structure json)
-      (if (null? args)
-        (if (and (json-object? json) (equal? json '(())))
-          (g:json-push '() key val)
-          (g:json-push json key val)
-        ) ;if
-        (json-set json key (lambda (x) (apply json-push (cons x (cons val args)))))
-      ) ;if
     ) ;define
 
     (define (json-drop json key . args)

--- a/src/liii_json.cpp
+++ b/src/liii_json.cpp
@@ -1018,7 +1018,7 @@ json_guenchi_push (s7_scheme* sc, s7_pointer x, s7_pointer k, s7_pointer v) {
     s7_int      n    = s7_vector_length (x);
     s7_pointer* elems= s7_vector_elements (x);
     if (n == 0) {
-      s7_pointer result= s7_make_vector (sc, 1);
+      s7_pointer result             = s7_make_vector (sc, 1);
       s7_vector_elements (result)[0]= v;
       return result;
     }
@@ -1033,7 +1033,7 @@ json_guenchi_push (s7_scheme* sc, s7_pointer x, s7_pointer k, s7_pointer v) {
     s7_pointer result= s7_make_vector (sc, n + 1);
     s7_gc_protect_via_stack (sc, result);
     s7_pointer* relems= s7_vector_elements (result);
-    s7_int at= 0;
+    s7_int      at    = 0;
     for (s7_int i= 0; i < n; i++) {
       if (i == match) relems[at++]= v;
       relems[at++]= elems[i];
@@ -1080,8 +1080,7 @@ f_json_push (s7_scheme* sc, s7_pointer args) {
 static void
 glue_json_push (s7_scheme* sc) {
   const char* name= "g_json_push";
-  const char* desc=
-      "(g_json_push json key val . keys) => data, push a value into Scheme-form JSON data by key path";
+  const char* desc= "(g_json_push json key val . keys) => data, push a value into Scheme-form JSON data by key path";
   s7_define_function (sc, name, f_json_push, 3, 0, true, desc);
 }
 

--- a/src/liii_json.cpp
+++ b/src/liii_json.cpp
@@ -869,17 +869,22 @@ glue_json_ref (s7_scheme* sc) {
 }
 
 // json-set 的叶层写入器：rest 非空表示多键路径（对旧值递归 json-set），
-// 否则写入叶层值（叶层值为过程时以旧值调用之）
+// 否则写入叶层值（叶层值为过程时以旧值调用之）；
+// is_push 表示 json-push 的多键路径（对旧值递归 json-push，kvs 为键值序列）
 struct json_setter {
   s7_pointer rest; // 剩余 (key val ...) 参数；'() 表示已到叶层
   s7_pointer leaf; // 叶层值（仅 rest 为 '() 时有效）
   bool       leaf_is_proc;
+  bool       is_push;   // json-push 多键模式
+  s7_pointer push_args; // (key ... val) 序列（仅 is_push 时有效）
 };
 
 static s7_pointer json_set_dispatch (s7_scheme* sc, s7_pointer x, s7_pointer kargs);
+static s7_pointer json_push_dispatch (s7_scheme* sc, s7_pointer x, s7_pointer kvs);
 
 static s7_pointer
 json_setter_apply (s7_scheme* sc, const json_setter& st, s7_pointer old) {
+  if (st.is_push) return json_push_dispatch (sc, old, st.push_args);
   if (!s7_is_null (sc, st.rest)) return json_set_dispatch (sc, old, st.rest);
   if (st.leaf_is_proc) return s7_call (sc, st.leaf, s7_list (sc, 1, old));
   return st.leaf;
@@ -968,6 +973,8 @@ json_set_dispatch (s7_scheme* sc, s7_pointer x, s7_pointer kargs) {
   s7_pointer  key = s7_car (kargs);
   s7_pointer  rest= s7_cdr (kargs);
   json_setter st;
+  st.is_push  = false;
+  st.push_args= NULL;
   if (s7_is_null (sc, s7_cdr (rest))) {
     st.rest        = s7_nil (sc);
     st.leaf        = s7_car (rest);
@@ -996,12 +1003,95 @@ glue_json_set (s7_scheme* sc) {
   s7_gc_protect (sc, cached_list_to_vector);
 }
 
+// json-push / json-push* 的 C++ 实现，语义与历史上 (liii json) 包装 (guenchi json)
+// 的 Scheme 实现完全一致：
+//   - 单键：对象 (cons (cons k v) x) 前插；空对象 '(()) 退化为对 '() 前插得 '((k . v))；
+//     数组空时返回 #(v)；非空时按索引 equal? 匹配，首匹配处前插 v（仅一次），无匹配尾插
+//   - 多键：等价于 (json-set json key (lambda (x) (apply json-push x ...)))，
+//     即经 json-set 的单层语义逐层下钻（中间键不存在时静默不生效），
+//     空对象 '(()) 原样返回；每层进入时先做结构校验
+
+// guenchi json-push 的单层语义：x 已校验为 JSON 对象（或 '()）或数组
+static s7_pointer
+json_guenchi_push (s7_scheme* sc, s7_pointer x, s7_pointer k, s7_pointer v) {
+  if (s7_is_vector (x)) {
+    s7_int      n    = s7_vector_length (x);
+    s7_pointer* elems= s7_vector_elements (x);
+    if (n == 0) {
+      s7_pointer result= s7_make_vector (sc, 1);
+      s7_vector_elements (result)[0]= v;
+      return result;
+    }
+    // 首个 equal? 匹配的索引处前插 v；无匹配则尾插
+    s7_int match= -1;
+    for (s7_int i= 0; i < n; i++) {
+      if (s7_is_equal (sc, s7_make_integer (sc, i), k)) {
+        match= i;
+        break;
+      }
+    }
+    s7_pointer result= s7_make_vector (sc, n + 1);
+    s7_gc_protect_via_stack (sc, result);
+    s7_pointer* relems= s7_vector_elements (result);
+    s7_int at= 0;
+    for (s7_int i= 0; i < n; i++) {
+      if (i == match) relems[at++]= v;
+      relems[at++]= elems[i];
+    }
+    if (match < 0) relems[at]= v;
+    s7_gc_unprotect_via_stack (sc, result);
+    return result;
+  }
+  // 对象：前插 (k . v)
+  return s7_cons (sc, s7_cons (sc, k, v), x);
+}
+
+// 对应 (liii json) 的 json-push 包装：结构校验 + 单键/多键分派
+// kvs 为 (key val) 或 (key ... val)（多键时 key 之后逐层下钻，末项为值）
+static s7_pointer
+json_push_dispatch (s7_scheme* sc, s7_pointer x, s7_pointer kvs) {
+  s7_int len= 0;
+  if (!s7_is_vector (x) && !json_is_object (sc, x, len)) {
+    return json_type_error (sc, "Value is not a JSON object or array", x);
+  }
+  if (s7_is_null (sc, s7_cdr (s7_cdr (kvs)))) {
+    // 单键：空对象 '(()) 退化为对 '() 前插
+    s7_pointer k= s7_car (kvs);
+    s7_pointer v= s7_cadr (kvs);
+    if (json_is_null_object (sc, x)) x= s7_nil (sc);
+    return json_guenchi_push (sc, x, k, v);
+  }
+  // 多键：空对象 '(()) 原样返回（json-set 语义）
+  if (json_is_null_object (sc, x)) return x;
+  json_setter st;
+  st.rest        = s7_nil (sc);
+  st.leaf        = NULL;
+  st.leaf_is_proc= false;
+  st.is_push     = true;
+  st.push_args   = s7_cdr (kvs);
+  return json_guenchi_set (sc, x, s7_car (kvs), len, st);
+}
+
+static s7_pointer
+f_json_push (s7_scheme* sc, s7_pointer args) {
+  return json_push_dispatch (sc, s7_car (args), s7_cdr (args));
+}
+
+static void
+glue_json_push (s7_scheme* sc) {
+  const char* name= "g_json_push";
+  const char* desc=
+      "(g_json_push json key val . keys) => data, push a value into Scheme-form JSON data by key path";
+  s7_define_function (sc, name, f_json_push, 3, 0, true, desc);
+}
+
 void
 glue_liii_json (s7_scheme* sc) {
   glue_json_to_string (sc);
   glue_string_to_json (sc);
   glue_json_ref (sc);
   glue_json_set (sc);
+  glue_json_push (sc);
 }
 
 } // namespace goldfish

--- a/tests/liii/json/json-push-test.scm
+++ b/tests/liii/json/json-push-test.scm
@@ -105,4 +105,31 @@
 (check-catch 'type-error (json-push "not-a-json" 'key "val"))
 (check-catch 'type-error (json-push 123 'key "val"))
 
+;; 单键：对象前插
+(let ((j0 '((a . 1) (b . 2))))
+  (check (json-push j0 'c 3) => '((c . 3) (a . 1) (b . 2))))
+
+;; 单键：数组（空数组、无匹配尾插、首匹配前插）
+(check (json-push '#() 0 'a) => #(a))
+(check (json-push '#(1 2 3) 5 'x) => #(1 2 3 x))
+(check (json-push '#(1 2 3) 1 'x) => #(1 x 2 3))
+;; 键为符号时数组无匹配，尾插
+(check (json-push '#(1 2 3) 'k 'x) => #(1 2 3 x))
+
+;; 单键：空对象 '(()) 退化为 '((k . v))
+(check (json-push '(()) 'k 'v) => '((k . v)))
+
+;; 多键：空对象 '(()) 原样返回（json-set 语义）
+(check (json-push '(()) 'a 'b 1) => '(()))
+
+;; 多键：中间层不存在时静默不生效（json-set 普通键无匹配的历史语义）
+(let ((j0 '((a . 1))))
+  (check (json-push j0 'missing 'k 1) => '((a . 1))))
+
+;; 多键：值已存在时返回新结构，原结构不变
+(let* ((j0 '((person (name . "Alice"))))
+       (j1 (json-push j0 'person 'city "Wonderland")))
+  (check (json-ref j0 'person 'city) => '())
+  (check (json-ref j1 'person 'city) => "Wonderland"))
+
 (check-report)


### PR DESCRIPTION
## 概述

`(liii json)` 的 `json-push` 迁移到 C++ 实现，并移除 `(guenchi json)` 中已被 C++ 覆盖的历史 Scheme 实现。

## 改动

### src/liii_json.cpp
- 新增 `g_json_push`（变参多键路径），完整复刻 `(liii json)` 包装 `(guenchi json)` 的语义：
  - 单键：对象 O(1) 前插；空对象 `'(())` 退化为 `'((k . v))`；数组空返回 `#(v)`、首匹配索引前插（仅一次）、无匹配尾插
  - 多键：复用 `json_setter` 基础设施新增 `is_push` 模式，叶层对旧值在 C++ 内递归，不经 Scheme 闭包回调

### goldfish/liii/json.scm
- `json-push` 直接绑定 `g_json_push`，删除 Scheme 包装

### goldfish/guenchi/json.scm
- 移除 `json-ref`、`json-set`、`json-push` 及全部带 `*` 版本的定义与导出
- 仅保留私有的 `(define json-set g_json_set)` 供 `json-drop*` 内部使用

### 测试与基准
- `tests/liii/json/json-push-test.scm` 新增 10 个边界用例（先在旧实现上通过锁定语义）
- `bench/json-ref-set-perf.scm` 新增 json-push 对比项与 sanity check

## 性能（bench 实测，500 次迭代）

| 场景 | C++ | Scheme | 提速 |
|---|---|---|---|
| 对象单键前插 | 0.00097s | 0.00233s | ~2.4× |
| 数组无匹配尾插 | 0.00092s | 0.01216s | ~13× |
| 多键路径前插 | 0.000059s | 0.00064s | ~11× |

## 测试

- [x] `xmake b goldfish` 构建通过
- [x] `tests/liii/json/json-push-test.scm` 23 项全过
- [x] `tests/liii/json-test.scm` + `tests/liii/json/` 全部通过
- [x] `tests/liii/njson-test.scm`、http 消费方测试通过
- [x] bench sanity check 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)