### PR TITLE
[0130] 将 c[ad]+r 优化器特化函数从 s7.c 拆分到 s7_scheme_cxr.c

### DIFF
--- a/devel/0130.md
+++ b/devel/0130.md
@@ -1,0 +1,47 @@
+# [0130] 从 s7.c 拆分 c[ad]+r 优化器特化函数
+
+## 任务相关的代码文件
+- src/s7.c
+- src/s7_scheme_cxr.h（新增）
+- src/s7_scheme_cxr.c（新增）
+- src/s7_internal_helpers.h
+- xmake.lua
+- tests/scheme/base/caaar-test.scm 等新增测试
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf tests/scheme/base/caar-test.scm
+bin/gf tests/scheme/base/cadr-test.scm
+# ... 以及新增的 c[ad]+r 测试
+```
+
+## 2026-08-19 拆分 c[ad]+r 的 _p_p 函数
+
+### What
+1. 将 s7.c 中 19 个 c[ad]+r 优化器特化函数（`caar_p_p`、`cadr_p_p`、
+   `cdar_p_p`、`cddr_p_p`、`caaar_p_p`、`caadr_p_p`、`cadar_p_p`、`cdaar_p_p`、
+   `caddr_p_p`、`cdddr_p_p`、`cdadr_p_p`、`cddar_p_p`、`caaddr_p_p`、`cadddr_p_p`、
+   `cadadr_p_p`、`caddar_p_p`、`cddddr_p_p`、`cddadr_p_p`、`cdddar_p_p`）
+   迁移到新文件 `src/s7_scheme_cxr.c`。
+2. 对应的 `g_caar` 等通用函数此前已在 `src/s7_liii_list.c` 中。
+3. 新增 `src/s7_scheme_cxr.h` 导出这些函数，s7.c 顶部 include；
+   xmake.lua 增加编译单元。
+4. 为缺少测试的 15 个 c[ad]+r 函数新增 tests/scheme/base/ 下的测试文件。
+
+### Why
+s7.c 有 8 万余行，继续按既有 unit-include/独立编译单元模式拆分。
+c[ad]+r 特化函数是纯 car/cdr 链，无全局栈状态依赖，是风险最小的拆分对象。
+
+### How
+- 原函数是 s7.c 内 `static`，且被优化器按函数指针比较（如
+  `q_func1(opc).p_p_f == cadr_p_p`）。改为 extern 函数放在独立编译单元后，
+  跨编译单元符号唯一，指针比较语义不变。
+- 宏依赖替换为已有 API：
+  - `is_pair` → `s7_is_pair`
+  - `caar(x)` 等宏 → `s7_caar(x)` 等（s7.h 已有全部 24 个）
+  - `sole_arg_method_or_bust` + `set_plist_1` → `s7i_sole_arg_method_or_bust` + `s7i_set_plist_1`
+  - `sole_arg_wrong_type_error_nr`（s7.c 中本为非 static）→ 在
+    s7_internal_helpers.h 中补充声明，新文件直接调用
+  - `sc->caar_symbol` → `s7_make_symbol`（符号驻留，同一对象）
+  - `car_a_list_string` 等错误串常量 → `s7i_wrap_string` 字面量（仅错误路径）

--- a/src/s7.c
+++ b/src/s7.c
@@ -409,6 +409,7 @@
 #include "s7_liii_hash_table.h"
 #include "s7_liii_list.h"
 #include "s7_liii_vector.h"
+#include "s7_scheme_cxr.h"
 #include "s7_module.h"
 #include "s7_dtoa.h"
 #include "s7_scheme_let.h"
@@ -26124,12 +26125,7 @@ static s7_pointer set_cdr_p_pp(s7_scheme *sc, s7_pointer lst, s7_pointer value) 
 #define Q_caar sc->pl_p
 /* g_caar is now defined in s7_liii_list.c */
 
-static s7_pointer caar_p_p(s7_scheme *sc, s7_pointer lst)
-{
-  if ((is_pair(lst)) && (is_pair(car(lst)))) return(caar(lst));
-  if (is_pair(lst)) sole_arg_wrong_type_error_nr(sc, sc->caar_symbol, lst, car_a_list_string);
-  return(sole_arg_method_or_bust(sc, lst, sc->caar_symbol, set_plist_1(sc, lst), sc->type_names[T_PAIR]));
-}
+/* caar_p_p is now defined in s7_scheme_cxr.c */
 
 
 /* -------- cadr --------*/
@@ -26137,12 +26133,7 @@ static s7_pointer caar_p_p(s7_scheme *sc, s7_pointer lst)
 #define Q_cadr sc->pl_p
 /* g_cadr is now defined in s7_liii_list.c */
 
-static s7_pointer cadr_p_p(s7_scheme *sc, s7_pointer lst)
-{
-  if ((is_pair(lst)) && (is_pair(cdr(lst)))) return(cadr(lst));
-  if (is_pair(lst)) sole_arg_wrong_type_error_nr(sc, sc->cadr_symbol, lst, cdr_a_list_string);
-  return(sole_arg_method_or_bust(sc, lst, sc->cadr_symbol, set_plist_1(sc, lst), sc->type_names[T_PAIR]));
-}
+/* cadr_p_p is now defined in s7_scheme_cxr.c */
 
 static s7_pointer g_list_ref_at_1(s7_scheme *sc, s7_pointer args)
 {
@@ -26158,12 +26149,7 @@ static s7_pointer g_list_ref_at_1(s7_scheme *sc, s7_pointer args)
 #define Q_cdar sc->pl_p
 /* g_cdar is now defined in s7_liii_list.c */
 
-static s7_pointer cdar_p_p(s7_scheme *sc, s7_pointer lst)
-{
-  if ((is_pair(lst)) && (is_pair(car(lst)))) return(cdar(lst));
-  if (!is_pair(lst)) sole_arg_wrong_type_error_nr(sc, sc->cdar_symbol, lst, car_a_list_string);
-  return(sole_arg_method_or_bust(sc, lst, sc->cdar_symbol, set_plist_1(sc, lst), sc->type_names[T_PAIR]));
-}
+/* cdar_p_p is now defined in s7_scheme_cxr.c */
 
 
 /* -------- cddr -------- */
@@ -26171,36 +26157,17 @@ static s7_pointer cdar_p_p(s7_scheme *sc, s7_pointer lst)
 #define Q_cddr sc->pl_p
 /* g_cddr is now defined in s7_liii_list.c */
 
-static s7_pointer cddr_p_p(s7_scheme *sc, s7_pointer lst)
-{
-  if ((is_pair(lst)) && (is_pair(cdr(lst)))) return(cddr(lst));
-  if (is_pair(lst)) sole_arg_wrong_type_error_nr(sc, sc->cddr_symbol, lst, cdr_a_list_string);
-  return(sole_arg_method_or_bust(sc, lst, sc->cddr_symbol, set_plist_1(sc, lst), sc->type_names[T_PAIR]));
-}
+/* cddr_p_p is now defined in s7_scheme_cxr.c */
 
 /* -------- caaar -------- */
-static s7_pointer caaar_p_p(s7_scheme *sc, s7_pointer lst)
-{
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->caaar_symbol, set_plist_1(sc, lst), sc->type_names[T_PAIR]));
-  if (!is_pair(car(lst))) sole_arg_wrong_type_error_nr(sc, sc->caaar_symbol, lst, car_a_list_string);
-  if (!is_pair(caar(lst))) sole_arg_wrong_type_error_nr(sc, sc->caaar_symbol, lst, caar_a_list_string);
-  if (!is_pair(caar(lst))) sole_arg_wrong_type_error_nr(sc, sc->caaar_symbol, lst, caar_a_list_string);
-  return(caaar(lst));
-}
+/* caaar_p_p is now defined in s7_scheme_cxr.c */
 
 #define H_caaar "(caaar lst) returns (car (car (car lst))): (caaar '(((1 2)))) -> 1"
 #define Q_caaar sc->pl_p
 /* g_caaar is now defined in s7_liii_list.c */
 
 /* -------- caadr -------- */
-static s7_pointer caadr_p_p(s7_scheme *sc, s7_pointer lst)
-{
-  if ((is_pair(lst)) && (is_pair(cdr(lst))) && (is_pair(cadr(lst)))) return(caadr(lst));
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->caadr_symbol, set_plist_1(sc, lst), sc->type_names[T_PAIR]));
-  if (!is_pair(cdr(lst))) sole_arg_wrong_type_error_nr(sc, sc->caadr_symbol, lst, cdr_a_list_string);
-  sole_arg_wrong_type_error_nr(sc, sc->caadr_symbol, lst, cadr_a_list_string);
-  return(NULL);
-}
+/* caadr_p_p is now defined in s7_scheme_cxr.c */
 
 #define H_caadr "(caadr lst) returns (car (car (cdr lst))): (caadr '(1 (2 3))) -> 2"
 #define Q_caadr sc->pl_p
@@ -26211,23 +26178,10 @@ static s7_pointer caadr_p_p(s7_scheme *sc, s7_pointer lst)
 #define Q_cadar sc->pl_p
 /* g_cadar is now defined in s7_liii_list.c */
 
-static s7_pointer cadar_p_p(s7_scheme *sc, s7_pointer lst)
-{
-  if ((is_pair(lst)) && (is_pair(car(lst))) && (is_pair(cdar(lst)))) return(cadar(lst));
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->cadar_symbol, set_plist_1(sc, lst), sc->type_names[T_PAIR]));
-  if (!is_pair(car(lst))) sole_arg_wrong_type_error_nr(sc, sc->cadar_symbol, lst, car_a_list_string);
-  sole_arg_wrong_type_error_nr(sc, sc->cadar_symbol, lst, cdar_a_list_string);
-  return(NULL);
-}
+/* cadar_p_p is now defined in s7_scheme_cxr.c */
 
 /* -------- cdaar -------- */
-static s7_pointer cdaar_p_p(s7_scheme *sc, s7_pointer lst)
-{
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->cdaar_symbol, set_plist_1(sc, lst), sc->type_names[T_PAIR]));
-  if (!is_pair(car(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdaar_symbol, lst, car_a_list_string);
-  if (!is_pair(caar(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdaar_symbol, lst, caar_a_list_string);
-  return(cdaar(lst));
-}
+/* cdaar_p_p is now defined in s7_scheme_cxr.c */
 
 #define H_cdaar "(cdaar lst) returns (cdr (car (car lst))): (cdaar '(((1 2 3)))) -> '(2 3)"
 #define Q_cdaar sc->pl_p
@@ -26238,14 +26192,7 @@ static s7_pointer cdaar_p_p(s7_scheme *sc, s7_pointer lst)
 #define Q_caddr sc->pl_p
 /* g_caddr is now defined in s7_liii_list.c */
 
-static s7_pointer caddr_p_p(s7_scheme *sc, s7_pointer lst)
-{
-  if ((is_pair(lst)) && (is_pair(cdr(lst))) && (is_pair(cddr(lst)))) return(caddr(lst));
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->caddr_symbol, set_plist_1(sc, lst), sc->type_names[T_PAIR]));
-  if (!is_pair(cdr(lst))) sole_arg_wrong_type_error_nr(sc, sc->caddr_symbol, lst, cdr_a_list_string);
-  sole_arg_wrong_type_error_nr(sc, sc->caddr_symbol, lst, cddr_a_list_string);
-  return(NULL);
-}
+/* caddr_p_p is now defined in s7_scheme_cxr.c */
 
 static s7_pointer g_list_ref_at_2(s7_scheme *sc, s7_pointer args)
 {
@@ -26258,39 +26205,21 @@ static s7_pointer g_list_ref_at_2(s7_scheme *sc, s7_pointer args)
 }
 
 /* -------- cdddr -------- */
-static s7_pointer cdddr_p_p(s7_scheme *sc, s7_pointer lst)
-{
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->cdddr_symbol, set_plist_1(sc, lst), sc->type_names[T_PAIR]));
-  if (!is_pair(cdr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdddr_symbol, lst, cdr_a_list_string);
-  if (!is_pair(cddr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdddr_symbol, lst, cddr_a_list_string);
-  return(cdddr(lst));
-}
+/* cdddr_p_p is now defined in s7_scheme_cxr.c */
 
 #define H_cdddr "(cdddr lst) returns (cdr (cdr (cdr lst))): (cdddr '(1 2 3 4)) -> '(4)"
 #define Q_cdddr sc->pl_p
 /* g_cdddr is now defined in s7_liii_list.c */
 
 /* -------- cdadr -------- */
-static s7_pointer cdadr_p_p(s7_scheme *sc, s7_pointer lst)
-{
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->cdadr_symbol, set_plist_1(sc, lst), sc->type_names[T_PAIR]));
-  if (!is_pair(cdr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdadr_symbol, lst, cdr_a_list_string);
-  if (!is_pair(cadr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdadr_symbol, lst, cadr_a_list_string);
-  return(cdadr(lst));
-}
+/* cdadr_p_p is now defined in s7_scheme_cxr.c */
 
 #define H_cdadr "(cdadr lst) returns (cdr (car (cdr lst))): (cdadr '(1 (2 3 4))) -> '(3 4)"
 #define Q_cdadr sc->pl_p
 /* g_cdadr is now defined in s7_liii_list.c */
 
 /* -------- cddar -------- */
-static s7_pointer cddar_p_p(s7_scheme *sc, s7_pointer lst)
-{
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->cddar_symbol, set_plist_1(sc, lst), sc->type_names[T_PAIR]));
-  if (!is_pair(car(lst))) sole_arg_wrong_type_error_nr(sc, sc->cddar_symbol, lst, car_a_list_string);
-  if (!is_pair(cdar(lst))) sole_arg_wrong_type_error_nr(sc, sc->cddar_symbol, lst, cdar_a_list_string);
-  return(cddar(lst));
-}
+/* cddar_p_p is now defined in s7_scheme_cxr.c */
 
 #define H_cddar "(cddar lst) returns (cdr (cdr (car lst))): (cddar '((1 2 3 4))) -> '(3 4)"
 #define Q_cddar sc->pl_p
@@ -26318,56 +26247,28 @@ static s7_pointer cddar_p_p(s7_scheme *sc, s7_pointer lst)
 
 /* -------- caaddr -------- */
 
-static s7_pointer caaddr_p_p(s7_scheme *sc, s7_pointer lst)
-{
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->caaddr_symbol, set_plist_1(sc, lst), sc->type_names[T_PAIR]));
-  if (!is_pair(cdr(lst))) sole_arg_wrong_type_error_nr(sc, sc->caaddr_symbol, lst, cdr_a_list_string);
-  if (!is_pair(cddr(lst))) sole_arg_wrong_type_error_nr(sc, sc->caaddr_symbol, lst, cddr_a_list_string);
-  if (!is_pair(caddr(lst))) sole_arg_wrong_type_error_nr(sc, sc->caaddr_symbol, lst, caddr_a_list_string);
-  return(caaddr(lst));
-}
+/* caaddr_p_p is now defined in s7_scheme_cxr.c */
 
 #define H_caaddr "(caaddr lst) returns (car (car (cdr (cdr lst)))): (caaddr '(1 2 (3 4))) -> 3"
 #define Q_caaddr sc->pl_p
 /* g_caaddr is now defined in s7_liii_list.c */
 
 /* -------- cadddr -------- */
-static s7_pointer cadddr_p_p(s7_scheme *sc, s7_pointer lst)
-{
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->cadddr_symbol, set_plist_1(sc, lst), sc->type_names[T_PAIR]));
-  if (!is_pair(cdr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cadddr_symbol, lst, cdr_a_list_string);
-  if (!is_pair(cddr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cadddr_symbol, lst, cddr_a_list_string);
-  if (!is_pair(cdddr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cadddr_symbol, lst, cdddr_a_list_string);
-  return(cadddr(lst));
-}
+/* cadddr_p_p is now defined in s7_scheme_cxr.c */
 
 #define H_cadddr "(cadddr lst) returns (car (cdr (cdr (cdr lst)))): (cadddr '(1 2 3 4 5)) -> 4"
 #define Q_cadddr sc->pl_p
 /* g_cadddr is now defined in s7_liii_list.c */
 
 /* -------- cadadr -------- */
-static s7_pointer cadadr_p_p(s7_scheme *sc, s7_pointer lst)
-{
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->cadadr_symbol, set_plist_1(sc, lst), sc->type_names[T_PAIR]));
-  if (!is_pair(cdr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cadadr_symbol, lst, cdr_a_list_string);
-  if (!is_pair(cadr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cadadr_symbol, lst, cadr_a_list_string);
-  if (!is_pair(cdadr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cadadr_symbol, lst, cdadr_a_list_string);
-  return(cadadr(lst));
-}
+/* cadadr_p_p is now defined in s7_scheme_cxr.c */
 
 #define H_cadadr "(cadadr lst) returns (car (cdr (car (cdr lst)))): (cadadr '(1 (2 3 4))) -> 3"
 #define Q_cadadr sc->pl_p
 /* g_cadadr is now defined in s7_liii_list.c */
 
 /* -------- caddar -------- */
-static s7_pointer caddar_p_p(s7_scheme *sc, s7_pointer lst)
-{
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->caddar_symbol, set_plist_1(sc, lst), sc->type_names[T_PAIR]));
-  if (!is_pair(car(lst))) sole_arg_wrong_type_error_nr(sc, sc->caddar_symbol, lst, car_a_list_string);
-  if (!is_pair(cdar(lst))) sole_arg_wrong_type_error_nr(sc, sc->caddar_symbol, lst, cdar_a_list_string);
-  if (!is_pair(cddar(lst))) sole_arg_wrong_type_error_nr(sc, sc->caddar_symbol, lst, cddar_a_list_string);
-  return(caddar(lst));
-}
+/* caddar_p_p is now defined in s7_scheme_cxr.c */
 
 #define H_caddar "(caddar lst) returns (car (cdr (cdr (car lst)))): (caddar '((1 2 3 4))) -> 3"
 #define Q_caddar sc->pl_p
@@ -26400,28 +26301,14 @@ static s7_pointer caddar_p_p(s7_scheme *sc, s7_pointer lst)
 
 /* -------- cddddr -------- */
 
-static s7_pointer cddddr_p_p(s7_scheme *sc, s7_pointer lst)
-{
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->cddddr_symbol, set_plist_1(sc, lst), sc->type_names[T_PAIR]));
-  if (!is_pair(cdr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cddddr_symbol, lst, cdr_a_list_string);
-  if (!is_pair(cddr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cddddr_symbol, lst, cddr_a_list_string);
-  if (!is_pair(cdddr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cddddr_symbol, lst, cdddr_a_list_string);
-  return(cddddr(lst));
-}
+/* cddddr_p_p is now defined in s7_scheme_cxr.c */
 
 #define H_cddddr "(cddddr lst) returns (cdr (cdr (cdr (cdr lst)))): (cddddr '(1 2 3 4 5)) -> '(5)"
 #define Q_cddddr sc->pl_p
 /* g_cddddr is now defined in s7_liii_list.c */
 
 /* -------- cddadr -------- */
-static s7_pointer cddadr_p_p(s7_scheme *sc, s7_pointer lst)
-{
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->cddadr_symbol, set_plist_1(sc, lst), sc->type_names[T_PAIR]));
-  if (!is_pair(cdr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cddadr_symbol, lst, cdr_a_list_string);
-  if (!is_pair(cadr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cddadr_symbol, lst, cadr_a_list_string);
-  if (!is_pair(cdadr(lst))) sole_arg_wrong_type_error_nr(sc, sc->cddadr_symbol, lst, cdadr_a_list_string);
-  return(cddadr(lst));
-}
+/* cddadr_p_p is now defined in s7_scheme_cxr.c */
 
 #define H_cddadr "(cddadr lst) returns (cdr (cdr (car (cdr lst)))): (cddadr '(1 (2 3 4 5))) -> '(4 5)"
 #define Q_cddadr sc->pl_p
@@ -26429,14 +26316,7 @@ static s7_pointer cddadr_p_p(s7_scheme *sc, s7_pointer lst)
 
 /* -------- cdddar -------- */
 
-static s7_pointer cdddar_p_p(s7_scheme *sc, s7_pointer lst)
-{
-  if (!is_pair(lst)) return(sole_arg_method_or_bust(sc, lst, sc->cdddar_symbol, set_plist_1(sc, lst), sc->type_names[T_PAIR]));
-  if (!is_pair(car(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdddar_symbol, lst, car_a_list_string);
-  if (!is_pair(cdar(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdddar_symbol, lst, cdar_a_list_string);
-  if (!is_pair(cddar(lst))) sole_arg_wrong_type_error_nr(sc, sc->cdddar_symbol, lst, cddar_a_list_string);
-  return(cdddar(lst));
-}
+/* cdddar_p_p is now defined in s7_scheme_cxr.c */
 
 #define H_cdddar "(cdddar lst) returns (cdr (cdr (cdr (car lst)))): (cdddar '((1 2 3 4 5))) -> '(4 5)"
 #define Q_cdddar sc->pl_p

--- a/src/s7_internal_helpers.h
+++ b/src/s7_internal_helpers.h
@@ -78,6 +78,7 @@ bool s7i_has_active_methods(s7_scheme *sc, s7_pointer obj);
 /* boolean method dispatch for type predicate migration */
 s7_pointer s7i_apply_boolean_method(s7_scheme *sc, s7_pointer obj, s7_pointer method);
 void s7i_wrong_type_error_nr(s7_scheme *sc, s7_pointer caller, s7_int arg_num, s7_pointer arg, s7_pointer typ);
+void sole_arg_wrong_type_error_nr(s7_scheme *sc, s7_pointer caller, s7_pointer arg, s7_pointer typ);
 s7_pointer s7i_copy_1(s7_scheme *sc, s7_pointer caller, s7_pointer args);
 s7_pointer s7i_copy_proper_list(s7_scheme *sc, s7_pointer lst);
 s7_int s7i_position_of(const s7_pointer p, s7_pointer args);

--- a/src/s7_scheme_cxr.c
+++ b/src/s7_scheme_cxr.c
@@ -1,0 +1,218 @@
+/* s7_scheme_cxr.c - c[ad]+r optimizer function implementations for s7 Scheme interpreter
+ *
+ * derived from s7, a Scheme interpreter
+ * SPDX-License-Identifier: 0BSD
+ *
+ * Bill Schottstaedt, bil@ccrma.stanford.edu
+ */
+
+#include "s7_scheme_cxr.h"
+#include "s7_internal_helpers.h"
+
+#include <stddef.h>
+
+/* the corresponding g_caar etc are in s7_liii_list.c; these are the
+   typed-arg (pl_p) versions used by the optimizer */
+
+#define CXR_A_LIST_STRING(sc, nm)                                                                                      \
+  s7i_wrap_string (sc, "a pair whose " nm " is also a pair", (s7_int) (28 + sizeof (nm) - 1))
+#define CXR_METHOD_OR_BUST(sc, nm, lst) s7i_sole_arg_method_or_bust (sc, lst, nm, s7i_set_plist_1 (sc, lst), "a pair")
+#define CXR_WRONG_TYPE_ERROR_NR(sc, nm, lst)                                                                           \
+  sole_arg_wrong_type_error_nr (sc, s7_make_symbol (sc, nm), lst, CXR_A_LIST_STRING (sc, nm))
+
+/* -------- caar -------- */
+
+s7_pointer
+caar_p_p (s7_scheme* sc, s7_pointer lst) {
+  if ((s7_is_pair (lst)) && (s7_is_pair (s7_car (lst)))) return (s7_caar (lst));
+  if (s7_is_pair (lst)) CXR_WRONG_TYPE_ERROR_NR (sc, "caar", lst);
+  return (CXR_METHOD_OR_BUST (sc, "caar", lst));
+}
+
+/* -------- cadr -------- */
+
+s7_pointer
+cadr_p_p (s7_scheme* sc, s7_pointer lst) {
+  if ((s7_is_pair (lst)) && (s7_is_pair (s7_cdr (lst)))) return (s7_cadr (lst));
+  if (s7_is_pair (lst)) CXR_WRONG_TYPE_ERROR_NR (sc, "cdr", lst);
+  return (CXR_METHOD_OR_BUST (sc, "cadr", lst));
+}
+
+/* -------- cdar -------- */
+
+s7_pointer
+cdar_p_p (s7_scheme* sc, s7_pointer lst) {
+  if ((s7_is_pair (lst)) && (s7_is_pair (s7_car (lst)))) return (s7_cdar (lst));
+  if (!s7_is_pair (lst)) CXR_WRONG_TYPE_ERROR_NR (sc, "car", lst);
+  return (CXR_METHOD_OR_BUST (sc, "cdar", lst));
+}
+
+/* -------- cddr -------- */
+
+s7_pointer
+cddr_p_p (s7_scheme* sc, s7_pointer lst) {
+  if ((s7_is_pair (lst)) && (s7_is_pair (s7_cdr (lst)))) return (s7_cddr (lst));
+  if (s7_is_pair (lst)) CXR_WRONG_TYPE_ERROR_NR (sc, "cdr", lst);
+  return (CXR_METHOD_OR_BUST (sc, "cddr", lst));
+}
+
+/* -------- caaar -------- */
+
+s7_pointer
+caaar_p_p (s7_scheme* sc, s7_pointer lst) {
+  if (!s7_is_pair (lst)) return (CXR_METHOD_OR_BUST (sc, "caaar", lst));
+  if (!s7_is_pair (s7_car (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "car", lst);
+  if (!s7_is_pair (s7_caar (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "caar", lst);
+  if (!s7_is_pair (s7_caar (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "caar", lst);
+  return (s7_caaar (lst));
+}
+
+/* -------- caadr -------- */
+
+s7_pointer
+caadr_p_p (s7_scheme* sc, s7_pointer lst) {
+  if ((s7_is_pair (lst)) && (s7_is_pair (s7_cdr (lst))) && (s7_is_pair (s7_cadr (lst)))) return (s7_caadr (lst));
+  if (!s7_is_pair (lst)) return (CXR_METHOD_OR_BUST (sc, "caadr", lst));
+  if (!s7_is_pair (s7_cdr (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cdr", lst);
+  CXR_WRONG_TYPE_ERROR_NR (sc, "cadr", lst);
+  return (NULL);
+}
+
+/* -------- cadar -------- */
+
+s7_pointer
+cadar_p_p (s7_scheme* sc, s7_pointer lst) {
+  if ((s7_is_pair (lst)) && (s7_is_pair (s7_car (lst))) && (s7_is_pair (s7_cdar (lst)))) return (s7_cadar (lst));
+  if (!s7_is_pair (lst)) return (CXR_METHOD_OR_BUST (sc, "cadar", lst));
+  if (!s7_is_pair (s7_car (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "car", lst);
+  CXR_WRONG_TYPE_ERROR_NR (sc, "cdar", lst);
+  return (NULL);
+}
+
+/* -------- cdaar -------- */
+
+s7_pointer
+cdaar_p_p (s7_scheme* sc, s7_pointer lst) {
+  if (!s7_is_pair (lst)) return (CXR_METHOD_OR_BUST (sc, "cdaar", lst));
+  if (!s7_is_pair (s7_car (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "car", lst);
+  if (!s7_is_pair (s7_caar (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "caar", lst);
+  return (s7_cdaar (lst));
+}
+
+/* -------- caddr -------- */
+
+s7_pointer
+caddr_p_p (s7_scheme* sc, s7_pointer lst) {
+  if ((s7_is_pair (lst)) && (s7_is_pair (s7_cdr (lst))) && (s7_is_pair (s7_cddr (lst)))) return (s7_caddr (lst));
+  if (!s7_is_pair (lst)) return (CXR_METHOD_OR_BUST (sc, "caddr", lst));
+  if (!s7_is_pair (s7_cdr (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cdr", lst);
+  CXR_WRONG_TYPE_ERROR_NR (sc, "cddr", lst);
+  return (NULL);
+}
+
+/* -------- cdddr -------- */
+
+s7_pointer
+cdddr_p_p (s7_scheme* sc, s7_pointer lst) {
+  if (!s7_is_pair (lst)) return (CXR_METHOD_OR_BUST (sc, "cdddr", lst));
+  if (!s7_is_pair (s7_cdr (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cdr", lst);
+  if (!s7_is_pair (s7_cddr (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cddr", lst);
+  return (s7_cdddr (lst));
+}
+
+/* -------- cdadr -------- */
+
+s7_pointer
+cdadr_p_p (s7_scheme* sc, s7_pointer lst) {
+  if (!s7_is_pair (lst)) return (CXR_METHOD_OR_BUST (sc, "cdadr", lst));
+  if (!s7_is_pair (s7_cdr (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cdr", lst);
+  if (!s7_is_pair (s7_cadr (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cadr", lst);
+  return (s7_cdadr (lst));
+}
+
+/* -------- cddar -------- */
+
+s7_pointer
+cddar_p_p (s7_scheme* sc, s7_pointer lst) {
+  if (!s7_is_pair (lst)) return (CXR_METHOD_OR_BUST (sc, "cddar", lst));
+  if (!s7_is_pair (s7_car (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "car", lst);
+  if (!s7_is_pair (s7_cdar (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cdar", lst);
+  return (s7_cddar (lst));
+}
+
+/* -------- caaddr -------- */
+
+s7_pointer
+caaddr_p_p (s7_scheme* sc, s7_pointer lst) {
+  if (!s7_is_pair (lst)) return (CXR_METHOD_OR_BUST (sc, "caaddr", lst));
+  if (!s7_is_pair (s7_cdr (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cdr", lst);
+  if (!s7_is_pair (s7_cddr (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cddr", lst);
+  if (!s7_is_pair (s7_caddr (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "caddr", lst);
+  return (s7_caaddr (lst));
+}
+
+/* -------- cadddr -------- */
+
+s7_pointer
+cadddr_p_p (s7_scheme* sc, s7_pointer lst) {
+  if (!s7_is_pair (lst)) return (CXR_METHOD_OR_BUST (sc, "cadddr", lst));
+  if (!s7_is_pair (s7_cdr (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cdr", lst);
+  if (!s7_is_pair (s7_cddr (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cddr", lst);
+  if (!s7_is_pair (s7_cdddr (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cdddr", lst);
+  return (s7_cadddr (lst));
+}
+
+/* -------- cadadr -------- */
+
+s7_pointer
+cadadr_p_p (s7_scheme* sc, s7_pointer lst) {
+  if (!s7_is_pair (lst)) return (CXR_METHOD_OR_BUST (sc, "cadadr", lst));
+  if (!s7_is_pair (s7_cdr (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cdr", lst);
+  if (!s7_is_pair (s7_cadr (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cadr", lst);
+  if (!s7_is_pair (s7_cdadr (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cdadr", lst);
+  return (s7_cadadr (lst));
+}
+
+/* -------- caddar -------- */
+
+s7_pointer
+caddar_p_p (s7_scheme* sc, s7_pointer lst) {
+  if (!s7_is_pair (lst)) return (CXR_METHOD_OR_BUST (sc, "caddar", lst));
+  if (!s7_is_pair (s7_car (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "car", lst);
+  if (!s7_is_pair (s7_cdar (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cdar", lst);
+  if (!s7_is_pair (s7_cddar (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cddar", lst);
+  return (s7_caddar (lst));
+}
+
+/* -------- cddddr -------- */
+
+s7_pointer
+cddddr_p_p (s7_scheme* sc, s7_pointer lst) {
+  if (!s7_is_pair (lst)) return (CXR_METHOD_OR_BUST (sc, "cddddr", lst));
+  if (!s7_is_pair (s7_cdr (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cdr", lst);
+  if (!s7_is_pair (s7_cddr (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cddr", lst);
+  if (!s7_is_pair (s7_cdddr (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cdddr", lst);
+  return (s7_cddddr (lst));
+}
+
+/* -------- cddadr -------- */
+
+s7_pointer
+cddadr_p_p (s7_scheme* sc, s7_pointer lst) {
+  if (!s7_is_pair (lst)) return (CXR_METHOD_OR_BUST (sc, "cddadr", lst));
+  if (!s7_is_pair (s7_cdr (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cdr", lst);
+  if (!s7_is_pair (s7_cadr (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cadr", lst);
+  if (!s7_is_pair (s7_cdadr (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cdadr", lst);
+  return (s7_cddadr (lst));
+}
+
+/* -------- cdddar -------- */
+
+s7_pointer
+cdddar_p_p (s7_scheme* sc, s7_pointer lst) {
+  if (!s7_is_pair (lst)) return (CXR_METHOD_OR_BUST (sc, "cdddar", lst));
+  if (!s7_is_pair (s7_car (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "car", lst);
+  if (!s7_is_pair (s7_cdar (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cdar", lst);
+  if (!s7_is_pair (s7_cddar (lst))) CXR_WRONG_TYPE_ERROR_NR (sc, "cddar", lst);
+  return (s7_cdddar (lst));
+}

--- a/src/s7_scheme_cxr.h
+++ b/src/s7_scheme_cxr.h
@@ -1,0 +1,48 @@
+/* s7_scheme_cxr.h - c[ad]+r optimizer function declarations for s7 Scheme interpreter
+ *
+ * derived from s7, a Scheme interpreter
+ * SPDX-License-Identifier: 0BSD
+ *
+ * Bill Schottstaedt, bil@ccrma.stanford.edu
+ */
+
+#ifndef S7_SCHEME_CXR_H
+#define S7_SCHEME_CXR_H
+
+#include "s7.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* typed-arg (pl_p) versions of the c[ad]+r functions, used by the
+   s7 optimizer via function pointer comparison, so they must be
+   extern (single definition in s7_scheme_cxr.c) */
+
+s7_pointer caar_p_p(s7_scheme *sc, s7_pointer lst);
+s7_pointer cadr_p_p(s7_scheme *sc, s7_pointer lst);
+s7_pointer cdar_p_p(s7_scheme *sc, s7_pointer lst);
+s7_pointer cddr_p_p(s7_scheme *sc, s7_pointer lst);
+
+s7_pointer caaar_p_p(s7_scheme *sc, s7_pointer lst);
+s7_pointer caadr_p_p(s7_scheme *sc, s7_pointer lst);
+s7_pointer cadar_p_p(s7_scheme *sc, s7_pointer lst);
+s7_pointer cdaar_p_p(s7_scheme *sc, s7_pointer lst);
+s7_pointer caddr_p_p(s7_scheme *sc, s7_pointer lst);
+s7_pointer cdddr_p_p(s7_scheme *sc, s7_pointer lst);
+s7_pointer cdadr_p_p(s7_scheme *sc, s7_pointer lst);
+s7_pointer cddar_p_p(s7_scheme *sc, s7_pointer lst);
+
+s7_pointer caaddr_p_p(s7_scheme *sc, s7_pointer lst);
+s7_pointer cadddr_p_p(s7_scheme *sc, s7_pointer lst);
+s7_pointer cadadr_p_p(s7_scheme *sc, s7_pointer lst);
+s7_pointer caddar_p_p(s7_scheme *sc, s7_pointer lst);
+s7_pointer cddddr_p_p(s7_scheme *sc, s7_pointer lst);
+s7_pointer cddadr_p_p(s7_scheme *sc, s7_pointer lst);
+s7_pointer cdddar_p_p(s7_scheme *sc, s7_pointer lst);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* S7_SCHEME_CXR_H */

--- a/tests/scheme/base/caaar-test.scm
+++ b/tests/scheme/base/caaar-test.scm
@@ -1,0 +1,34 @@
+(import (liii check))
+(import (scheme base))
+(check-set-mode! 'report-failed)
+;; caaar
+;; caaar 是 Scheme 内置函数，等价于 (car (car (car pair)))。
+;;
+;; 语法
+;; ----
+;; (caaar pair)
+;;
+;; 参数
+;; ----
+;; pair : pair?
+;; 三层嵌套的序对或列表，如 (((a b) c) d)。
+;;
+;; 返回值
+;; ------
+;; 任意类型
+;; 返回 (car (car (car pair)))。
+;;
+;; 错误处理
+;; --------
+;; wrong-type-arg
+;; 参数不是序对，或者 car 链上的某一层不是序对时抛出错误。
+(check (caaar '(((1 2)))) => 1)
+(check (caaar '(((a b) c) d)) => 'a)
+(check (caaar (cons (cons (cons 1 2) 3) 4)) => 1)
+(check (caaar '(((() 5)) 6)) => '())
+(check-catch 'wrong-type-arg (caaar '((1 2))))
+(check-catch 'wrong-type-arg (caaar '(1 (2 3))))
+(check-catch 'wrong-type-arg (caaar 'a))
+(check-catch 'wrong-type-arg (caaar 123))
+(check-catch 'wrong-type-arg (caaar '()))
+(check-report)

--- a/tests/scheme/base/caaddr-test.scm
+++ b/tests/scheme/base/caaddr-test.scm
@@ -1,0 +1,33 @@
+(import (liii check))
+(import (scheme base))
+(check-set-mode! 'report-failed)
+;; caaddr
+;; caaddr 是 Scheme 内置函数，等价于 (car (car (cdr (cdr pair))))。
+;;
+;; 语法
+;; ----
+;; (caaddr pair)
+;;
+;; 参数
+;; ----
+;; pair : pair?
+;; 嵌套的序对或列表，如 (1 2 (a b))。
+;;
+;; 返回值
+;; ------
+;; 任意类型
+;; 返回 (car (car (cdr (cdr pair))))。
+;;
+;; 错误处理
+;; --------
+;; wrong-type-arg
+;; 参数不是序对，或者 cdr/car 链上的某一层不是序对时抛出错误。
+(check (caaddr '(1 2 (3 4))) => 3)
+(check (caaddr '(a b (c d) e)) => 'c)
+(check (caaddr (cons 1 (cons 2 (cons (cons 'x 'y) 3)))) => 'x)
+(check-catch 'wrong-type-arg (caaddr '(1 2 3)))
+(check-catch 'wrong-type-arg (caaddr '(1 2 ())))
+(check-catch 'wrong-type-arg (caaddr '(1 2)))
+(check-catch 'wrong-type-arg (caaddr 'a))
+(check-catch 'wrong-type-arg (caaddr '()))
+(check-report)

--- a/tests/scheme/base/caadr-test.scm
+++ b/tests/scheme/base/caadr-test.scm
@@ -1,0 +1,34 @@
+(import (liii check))
+(import (scheme base))
+(check-set-mode! 'report-failed)
+;; caadr
+;; caadr 是 Scheme 内置函数，等价于 (car (car (cdr pair)))。
+;;
+;; 语法
+;; ----
+;; (caadr pair)
+;;
+;; 参数
+;; ----
+;; pair : pair?
+;; 二层以上嵌套的序对或列表，如 (1 (a b))。
+;;
+;; 返回值
+;; ------
+;; 任意类型
+;; 返回 (car (car (cdr pair)))。
+;;
+;; 错误处理
+;; --------
+;; wrong-type-arg
+;; 参数不是序对，或者 cdr/car 链上的某一层不是序对时抛出错误。
+(check (caadr '(1 (2 3))) => 2)
+(check (caadr '(1 (a b) c)) => 'a)
+(check (caadr (cons 0 (cons (cons 'x 'y) 2))) => 'x)
+(check-catch 'wrong-type-arg (caadr '(1 ())))
+(check-catch 'wrong-type-arg (caadr '(1 2)))
+(check-catch 'wrong-type-arg (caadr '((1 2))))
+(check-catch 'wrong-type-arg (caadr 'a))
+(check-catch 'wrong-type-arg (caadr "hello"))
+(check-catch 'wrong-type-arg (caadr '()))
+(check-report)

--- a/tests/scheme/base/cadadr-test.scm
+++ b/tests/scheme/base/cadadr-test.scm
@@ -1,0 +1,32 @@
+(import (liii check))
+(import (scheme base))
+(check-set-mode! 'report-failed)
+;; cadadr
+;; cadadr 是 Scheme 内置函数，等价于 (car (cdr (car (cdr pair))))。
+;;
+;; 语法
+;; ----
+;; (cadadr pair)
+;;
+;; 参数
+;; ----
+;; pair : pair?
+;; 嵌套的序对或列表，如 (1 (a b c))。
+;;
+;; 返回值
+;; ------
+;; 任意类型
+;; 返回 (car (cdr (car (cdr pair))))。
+;;
+;; 错误处理
+;; --------
+;; wrong-type-arg
+;; 参数不是序对，或者 cdr/car 链上的某一层不是序对时抛出错误。
+(check (cadadr '(1 (2 3 4))) => 3)
+(check (cadadr '(a (b c) d)) => 'c)
+(check (cadadr (cons 0 (cons (cons 1 (cons 2 3)) 4))) => 2)
+(check-catch 'wrong-type-arg (cadadr '(1 (2))))
+(check-catch 'wrong-type-arg (cadadr '(1 2)))
+(check-catch 'wrong-type-arg (cadadr 'a))
+(check-catch 'wrong-type-arg (cadadr '()))
+(check-report)

--- a/tests/scheme/base/cadar-test.scm
+++ b/tests/scheme/base/cadar-test.scm
@@ -1,0 +1,33 @@
+(import (liii check))
+(import (scheme base))
+(check-set-mode! 'report-failed)
+;; cadar
+;; cadar 是 Scheme 内置函数，等价于 (car (cdr (car pair)))。
+;;
+;; 语法
+;; ----
+;; (cadar pair)
+;;
+;; 参数
+;; ----
+;; pair : pair?
+;; 二层以上嵌套的序对或列表，如 ((a b c) d)。
+;;
+;; 返回值
+;; ------
+;; 任意类型
+;; 返回 (car (cdr (car pair)))。
+;;
+;; 错误处理
+;; --------
+;; wrong-type-arg
+;; 参数不是序对，或者 car/cdr 链上的某一层不是序对时抛出错误。
+(check (cadar '((1 2 3))) => 2)
+(check (cadar '((a b c) d)) => 'b)
+(check (cadar (cons (cons 1 (cons 2 3)) 4)) => 2)
+(check-catch 'wrong-type-arg (cadar '((1))))
+(check-catch 'wrong-type-arg (cadar '(1 2 3)))
+(check-catch 'wrong-type-arg (cadar 'a))
+(check-catch 'wrong-type-arg (cadar 123))
+(check-catch 'wrong-type-arg (cadar '()))
+(check-report)

--- a/tests/scheme/base/caddar-test.scm
+++ b/tests/scheme/base/caddar-test.scm
@@ -1,0 +1,32 @@
+(import (liii check))
+(import (scheme base))
+(check-set-mode! 'report-failed)
+;; caddar
+;; caddar 是 Scheme 内置函数，等价于 (car (cdr (cdr (car pair))))。
+;;
+;; 语法
+;; ----
+;; (caddar pair)
+;;
+;; 参数
+;; ----
+;; pair : pair?
+;; 嵌套的序对或列表，如 ((a b c d))。
+;;
+;; 返回值
+;; ------
+;; 任意类型
+;; 返回 (car (cdr (cdr (car pair))))。
+;;
+;; 错误处理
+;; --------
+;; wrong-type-arg
+;; 参数不是序对，或者 car/cdr 链上的某一层不是序对时抛出错误。
+(check (caddar '((1 2 3 4))) => 3)
+(check (caddar '((a b c) d)) => 'c)
+(check (caddar (cons (cons 1 (cons 2 (cons 3 4))) 5)) => 3)
+(check-catch 'wrong-type-arg (caddar '((1 2))))
+(check-catch 'wrong-type-arg (caddar '(1 2 3)))
+(check-catch 'wrong-type-arg (caddar 'a))
+(check-catch 'wrong-type-arg (caddar '()))
+(check-report)

--- a/tests/scheme/base/cadddr-test.scm
+++ b/tests/scheme/base/cadddr-test.scm
@@ -1,0 +1,32 @@
+(import (liii check))
+(import (scheme base))
+(check-set-mode! 'report-failed)
+;; cadddr
+;; cadddr 是 Scheme 内置函数，等价于 (car (cdr (cdr (cdr pair))))。
+;;
+;; 语法
+;; ----
+;; (cadddr pair)
+;;
+;; 参数
+;; ----
+;; pair : pair?
+;; 至少含有四个元素的序对或列表。
+;;
+;; 返回值
+;; ------
+;; 任意类型
+;; 返回 (car (cdr (cdr (cdr pair))))，即列表的第四个元素。
+;;
+;; 错误处理
+;; --------
+;; wrong-type-arg
+;; 参数不是序对，或者 cdr 链上的某一层不是序对时抛出错误。
+(check (cadddr '(1 2 3 4 5)) => 4)
+(check (cadddr '(a b c d)) => 'd)
+(check (cadddr (cons 1 (cons 2 (cons 3 (cons 'x 'y))))) => 'x)
+(check-catch 'wrong-type-arg (cadddr '(1 2 3)))
+(check-catch 'wrong-type-arg (cadddr '(1 2)))
+(check-catch 'wrong-type-arg (cadddr 'a))
+(check-catch 'wrong-type-arg (cadddr '()))
+(check-report)

--- a/tests/scheme/base/caddr-test.scm
+++ b/tests/scheme/base/caddr-test.scm
@@ -1,0 +1,33 @@
+(import (liii check))
+(import (scheme base))
+(check-set-mode! 'report-failed)
+;; caddr
+;; caddr 是 Scheme 内置函数，等价于 (car (cdr (cdr pair)))。
+;;
+;; 语法
+;; ----
+;; (caddr pair)
+;;
+;; 参数
+;; ----
+;; pair : pair?
+;; 至少含有两个元素的序对或列表。
+;;
+;; 返回值
+;; ------
+;; 任意类型
+;; 返回 (car (cdr (cdr pair)))，即列表的第三个元素。
+;;
+;; 错误处理
+;; --------
+;; wrong-type-arg
+;; 参数不是序对，或者 cdr 链上的某一层不是序对时抛出错误。
+(check (caddr '(1 2 3 4)) => 3)
+(check (caddr '(a b c)) => 'c)
+(check (caddr (cons 1 (cons 2 (cons 'x 'y)))) => 'x)
+(check-catch 'wrong-type-arg (caddr '(1 2)))
+(check-catch 'wrong-type-arg (caddr '(1)))
+(check-catch 'wrong-type-arg (caddr 'a))
+(check-catch 'wrong-type-arg (caddr 123))
+(check-catch 'wrong-type-arg (caddr '()))
+(check-report)

--- a/tests/scheme/base/cdaar-test.scm
+++ b/tests/scheme/base/cdaar-test.scm
@@ -1,0 +1,32 @@
+(import (liii check))
+(import (scheme base))
+(check-set-mode! 'report-failed)
+;; cdaar
+;; cdaar 是 Scheme 内置函数，等价于 (cdr (car (car pair)))。
+;;
+;; 语法
+;; ----
+;; (cdaar pair)
+;;
+;; 参数
+;; ----
+;; pair : pair?
+;; 三层嵌套的序对或列表，如 (((a b c)) d)。
+;;
+;; 返回值
+;; ------
+;; 任意类型
+;; 返回 (cdr (car (car pair)))。
+;;
+;; 错误处理
+;; --------
+;; wrong-type-arg
+;; 参数不是序对，或者 car 链上的某一层不是序对时抛出错误。
+(check (cdaar '(((1 2 3)))) => '(2 3))
+(check (cdaar '(((a b c) d) e)) => '(b c))
+(check (cdaar (cons (cons (cons 1 2) 3) 4)) => 2)
+(check-catch 'wrong-type-arg (cdaar '((1 2))))
+(check-catch 'wrong-type-arg (cdaar '(1 2 3)))
+(check-catch 'wrong-type-arg (cdaar 'a))
+(check-catch 'wrong-type-arg (cdaar '()))
+(check-report)

--- a/tests/scheme/base/cdadr-test.scm
+++ b/tests/scheme/base/cdadr-test.scm
@@ -1,0 +1,32 @@
+(import (liii check))
+(import (scheme base))
+(check-set-mode! 'report-failed)
+;; cdadr
+;; cdadr 是 Scheme 内置函数，等价于 (cdr (car (cdr pair)))。
+;;
+;; 语法
+;; ----
+;; (cdadr pair)
+;;
+;; 参数
+;; ----
+;; pair : pair?
+;; 二层以上嵌套的序对或列表，如 (1 (a b c))。
+;;
+;; 返回值
+;; ------
+;; 任意类型
+;; 返回 (cdr (car (cdr pair)))。
+;;
+;; 错误处理
+;; --------
+;; wrong-type-arg
+;; 参数不是序对，或者 cdr/car 链上的某一层不是序对时抛出错误。
+(check (cdadr '(1 (2 3 4))) => '(3 4))
+(check (cdadr '(a (b c) d)) => '(c))
+(check (cdadr (cons 0 (cons (cons 1 2) 3))) => 2)
+(check (cdadr '(1 (2))) => '())
+(check-catch 'wrong-type-arg (cdadr '(1 2)))
+(check-catch 'wrong-type-arg (cdadr 'a))
+(check-catch 'wrong-type-arg (cdadr '()))
+(check-report)

--- a/tests/scheme/base/cddadr-test.scm
+++ b/tests/scheme/base/cddadr-test.scm
@@ -1,0 +1,32 @@
+(import (liii check))
+(import (scheme base))
+(check-set-mode! 'report-failed)
+;; cddadr
+;; cddadr 是 Scheme 内置函数，等价于 (cdr (cdr (car (cdr pair))))。
+;;
+;; 语法
+;; ----
+;; (cddadr pair)
+;;
+;; 参数
+;; ----
+;; pair : pair?
+;; 嵌套的序对或列表，如 (1 (a b c d))。
+;;
+;; 返回值
+;; ------
+;; 任意类型
+;; 返回 (cdr (cdr (car (cdr pair))))。
+;;
+;; 错误处理
+;; --------
+;; wrong-type-arg
+;; 参数不是序对，或者 cdr/car 链上的某一层不是序对时抛出错误。
+(check (cddadr '(1 (2 3 4 5))) => '(4 5))
+(check (cddadr '(a (b c d) e)) => '(d))
+(check (cddadr (cons 0 (cons (cons 1 (cons 2 (cons 3 4))) 5))) => '(3 . 4))
+(check (cddadr '(1 (2 3))) => '())
+(check-catch 'wrong-type-arg (cddadr '(1 2)))
+(check-catch 'wrong-type-arg (cddadr 'a))
+(check-catch 'wrong-type-arg (cddadr '()))
+(check-report)

--- a/tests/scheme/base/cddar-test.scm
+++ b/tests/scheme/base/cddar-test.scm
@@ -1,0 +1,32 @@
+(import (liii check))
+(import (scheme base))
+(check-set-mode! 'report-failed)
+;; cddar
+;; cddar 是 Scheme 内置函数，等价于 (cdr (cdr (car pair)))。
+;;
+;; 语法
+;; ----
+;; (cddar pair)
+;;
+;; 参数
+;; ----
+;; pair : pair?
+;; 二层以上嵌套的序对或列表，如 ((a b c d))。
+;;
+;; 返回值
+;; ------
+;; 任意类型
+;; 返回 (cdr (cdr (car pair)))。
+;;
+;; 错误处理
+;; --------
+;; wrong-type-arg
+;; 参数不是序对，或者 car/cdr 链上的某一层不是序对时抛出错误。
+(check (cddar '((1 2 3 4))) => '(3 4))
+(check (cddar '((a b c) d)) => '(c))
+(check (cddar (cons (cons 1 (cons 2 3)) 4)) => 3)
+(check (cddar '((1 2))) => '())
+(check-catch 'wrong-type-arg (cddar '(1 2 3)))
+(check-catch 'wrong-type-arg (cddar 'a))
+(check-catch 'wrong-type-arg (cddar '()))
+(check-report)

--- a/tests/scheme/base/cdddar-test.scm
+++ b/tests/scheme/base/cdddar-test.scm
@@ -1,0 +1,32 @@
+(import (liii check))
+(import (scheme base))
+(check-set-mode! 'report-failed)
+;; cdddar
+;; cdddar 是 Scheme 内置函数，等价于 (cdr (cdr (cdr (car pair))))。
+;;
+;; 语法
+;; ----
+;; (cdddar pair)
+;;
+;; 参数
+;; ----
+;; pair : pair?
+;; 嵌套的序对或列表，如 ((a b c d e))。
+;;
+;; 返回值
+;; ------
+;; 任意类型
+;; 返回 (cdr (cdr (cdr (car pair))))。
+;;
+;; 错误处理
+;; --------
+;; wrong-type-arg
+;; 参数不是序对，或者 car/cdr 链上的某一层不是序对时抛出错误。
+(check (cdddar '((1 2 3 4 5))) => '(4 5))
+(check (cdddar '((a b c d) e)) => '(d))
+(check (cdddar (cons (cons 1 (cons 2 (cons 3 (cons 4 5)))) 6)) => '(4 . 5))
+(check (cdddar '((1 2 3))) => '())
+(check-catch 'wrong-type-arg (cdddar '(1 2 3)))
+(check-catch 'wrong-type-arg (cdddar 'a))
+(check-catch 'wrong-type-arg (cdddar '()))
+(check-report)

--- a/tests/scheme/base/cddddr-test.scm
+++ b/tests/scheme/base/cddddr-test.scm
@@ -1,0 +1,33 @@
+(import (liii check))
+(import (scheme base))
+(check-set-mode! 'report-failed)
+;; cddddr
+;; cddddr 是 Scheme 内置函数，等价于 (cdr (cdr (cdr (cdr pair))))。
+;;
+;; 语法
+;; ----
+;; (cddddr pair)
+;;
+;; 参数
+;; ----
+;; pair : pair?
+;; 至少含有四个元素的序对或列表。
+;;
+;; 返回值
+;; ------
+;; 任意类型
+;; 返回 (cdr (cdr (cdr (cdr pair))))，即列表第四个元素之后的部分。
+;;
+;; 错误处理
+;; --------
+;; wrong-type-arg
+;; 参数不是序对，或者 cdr 链上的某一层不是序对时抛出错误。
+(check (cddddr '(1 2 3 4 5)) => '(5))
+(check (cddddr '(a b c d e f)) => '(e f))
+(check (cddddr (cons 1 (cons 2 (cons 3 (cons 4 5))))) => 5)
+(check (cddddr '(1 2 3 4)) => '())
+(check-catch 'wrong-type-arg (cddddr '(1 2 3)))
+(check-catch 'wrong-type-arg (cddddr '(1 2)))
+(check-catch 'wrong-type-arg (cddddr 'a))
+(check-catch 'wrong-type-arg (cddddr '()))
+(check-report)

--- a/tests/scheme/base/cdddr-test.scm
+++ b/tests/scheme/base/cdddr-test.scm
@@ -1,0 +1,33 @@
+(import (liii check))
+(import (scheme base))
+(check-set-mode! 'report-failed)
+;; cdddr
+;; cdddr 是 Scheme 内置函数，等价于 (cdr (cdr (cdr pair)))。
+;;
+;; 语法
+;; ----
+;; (cdddr pair)
+;;
+;; 参数
+;; ----
+;; pair : pair?
+;; 至少含有三个元素的序对或列表。
+;;
+;; 返回值
+;; ------
+;; 任意类型
+;; 返回 (cdr (cdr (cdr pair)))，即列表第三个元素之后的部分。
+;;
+;; 错误处理
+;; --------
+;; wrong-type-arg
+;; 参数不是序对，或者 cdr 链上的某一层不是序对时抛出错误。
+(check (cdddr '(1 2 3 4)) => '(4))
+(check (cdddr '(a b c d e)) => '(d e))
+(check (cdddr (cons 1 (cons 2 (cons 3 4)))) => 4)
+(check (cdddr '(1 2 3)) => '())
+(check-catch 'wrong-type-arg (cdddr '(1 2)))
+(check-catch 'wrong-type-arg (cdddr '(1)))
+(check-catch 'wrong-type-arg (cdddr 'a))
+(check-catch 'wrong-type-arg (cdddr '()))
+(check-report)

--- a/xmake.lua
+++ b/xmake.lua
@@ -128,6 +128,7 @@ target ("goldfish") do
     add_files ("src/s7_liii_string.c", {languages = "c11"})
     add_files ("src/s7_liii_hash_table.c", {languages = "c11"})
     add_files ("src/s7_liii_list.c", {languages = "c11"})
+    add_files ("src/s7_scheme_cxr.c", {languages = "c11"})
     add_files ("src/s7_liii_record.c", {languages = "c11"})
     add_files ("src/s7_liii_vector.c", {languages = "c11"})
     add_files ("src/s7_module.c", {languages = "c11"})


### PR DESCRIPTION
## 概述
将 s7.c 中 c[ad]+r 系列优化器特化函数拆分到新的独立编译单元 s7_scheme_cxr.c / s7_scheme_cxr.h。

## 测试
- xmake b goldfish
- bin/gf tests/ 相关测试

🤖 Generated with [Claude Code](https://claude.com/claude-code)