### PR TITLE
[0129] json-drop/json-reduce 迁移到 C++ 实现并清理 (guenchi json) 历史接口

### DIFF
--- a/bench/json-ref-set-perf.scm
+++ b/bench/json-ref-set-perf.scm
@@ -191,6 +191,60 @@
   ) ;if
 ) ;define
 
+;; 历史 Scheme 实现（原 (guenchi json) 的 json-drop 及 (liii json) 的包装），原样保留用于对比
+
+(define (g-json-drop/scheme x v)
+  (if (vector? x)
+    (if (zero? (vector-length x))
+      x
+      (list->vector (cond ((procedure? v)
+                           (let l
+                             ((x (vector->alist x)) (v v))
+                             (if (null? x) '() (if (v (caar x)) (l (cdr x) v) (cons (cdar x) (l (cdr x) v))))
+                           ) ;let
+                          ) ;
+                          (else (let l
+                                  ((x (vector->alist x)) (v v))
+                                  (if (null? x)
+                                    '()
+                                    (if (equal? (caar x) v) (l (cdr x) v) (cons (cdar x) (l (cdr x) v)))
+                                  ) ;if
+                                ) ;let
+                          ) ;else
+                    ) ;cond
+      ) ;list->vector
+    ) ;if
+    (cond ((procedure? v)
+           (let l
+             ((x x) (v v))
+             (if (null? x) '() (if (v (caar x)) (l (cdr x) v) (cons (car x) (l (cdr x) v))))
+           ) ;let
+          ) ;
+          (else (let l
+                  ((x x) (v v))
+                  (if (null? x)
+                    '()
+                    (if (equal? (caar x) v) (l (cdr x) v) (cons (car x) (l (cdr x) v)))
+                  ) ;if
+                ) ;let
+          ) ;else
+    ) ;cond
+  ) ;if
+) ;define
+
+(define (json-drop/scheme json key . args)
+  (unless (or (json-object? json) (json-array? json))
+    (type-error "Value is not a JSON object or array" json)
+  ) ;unless
+  (if (null? args)
+    (if (and (json-object? json) (equal? json '(())))
+      json
+      (g-json-drop/scheme json key)
+    ) ;if
+    (json-set/scheme json key (lambda (x) (apply json-drop/scheme (cons x args))))
+  ) ;if
+) ;define
+
 (define (build-json-string n)
   (let ((out (open-output-string)))
     (display "{" out)
@@ -251,15 +305,26 @@
         ) ;equal?
   (error 'value-error "object push mismatch")
 ) ;unless
-(unless (equal? (json-push bench-arr 300 'new)
-          (json-push/scheme bench-arr 300 'new)
-        ) ;equal?
+(unless (equal? (json-push bench-arr 300 'new) (json-push/scheme bench-arr 300 'new))
   (error 'value-error "array push mismatch")
 ) ;unless
 (unless (equal? (json-push bench-nested 'user 'profile 'weight 60)
           (json-push/scheme bench-nested 'user 'profile 'weight 60)
         ) ;equal?
   (error 'value-error "nested push mismatch")
+) ;unless
+(unless (equal? (json-drop bench-obj bench-ref-key)
+          (json-drop/scheme bench-obj bench-ref-key)
+        ) ;equal?
+  (error 'value-error "object drop mismatch")
+) ;unless
+(unless (equal? (json-drop bench-arr 100) (json-drop/scheme bench-arr 100))
+  (error 'value-error "array drop mismatch")
+) ;unless
+(unless (equal? (json-drop bench-nested 'user 'profile 'age)
+          (json-drop/scheme bench-nested 'user 'profile 'age)
+        ) ;equal?
+  (error 'value-error "nested drop mismatch")
 ) ;unless
 
 (define ref-iter 2000)
@@ -286,6 +351,8 @@
   (json-set/scheme bench-obj bench-ref-key 0)
   (json-push bench-obj "newkey" 'new)
   (json-push/scheme bench-obj "newkey" 'new)
+  (json-drop bench-obj bench-ref-key)
+  (json-drop/scheme bench-obj bench-ref-key)
 ) ;do
 
 (display "=== json-ref / json-set C++ vs Scheme 性能对比 ===")
@@ -354,8 +421,7 @@
 (let ((t (timeit (lambda () (json-push bench-obj "newkey" 'new)) '() set-iter)))
   (report "对象单键前插/C++" set-iter t)
 ) ;let
-(let ((t (timeit (lambda () (json-push/scheme bench-obj "newkey" 'new)) '() set-iter)
-     ) ;t
+(let ((t (timeit (lambda () (json-push/scheme bench-obj "newkey" 'new)) '() set-iter))
      ) ;
   (report "对象单键前插/Scheme" set-iter t)
 ) ;let
@@ -363,9 +429,7 @@
 (let ((t (timeit (lambda () (json-push bench-arr 300 'new)) '() set-iter)))
   (report "数组无匹配尾插/C++" set-iter t)
 ) ;let
-(let ((t (timeit (lambda () (json-push/scheme bench-arr 300 'new)) '() set-iter)
-     ) ;t
-     ) ;
+(let ((t (timeit (lambda () (json-push/scheme bench-arr 300 'new)) '() set-iter)))
   (report "数组无匹配尾插/Scheme" set-iter t)
 ) ;let
 
@@ -384,6 +448,35 @@
       ) ;t
      ) ;
   (report "多键路径前插/Scheme" set-iter t)
+) ;let
+
+(let ((t (timeit (lambda () (json-drop bench-obj bench-ref-key)) '() set-iter)))
+  (report "对象单键删除/C++" set-iter t)
+) ;let
+(let ((t (timeit (lambda () (json-drop/scheme bench-obj bench-ref-key)) '() set-iter))
+     ) ;
+  (report "对象单键删除/Scheme" set-iter t)
+) ;let
+
+(let ((t (timeit (lambda () (json-drop bench-arr 100)) '() set-iter)))
+  (report "数组索引删除/C++" set-iter t)
+) ;let
+(let ((t (timeit (lambda () (json-drop/scheme bench-arr 100)) '() set-iter)))
+  (report "数组索引删除/Scheme" set-iter t)
+) ;let
+
+(let ((t (timeit (lambda () (json-drop bench-nested 'user 'profile 'age)) '() set-iter)
+      ) ;t
+     ) ;
+  (report "多键路径删除/C++" set-iter t)
+) ;let
+(let ((t (timeit (lambda () (json-drop/scheme bench-nested 'user 'profile 'age))
+           '()
+           set-iter
+         ) ;timeit
+      ) ;t
+     ) ;
+  (report "多键路径删除/Scheme" set-iter t)
 ) ;let
 
 (newline)

--- a/bench/json-ref-set-perf.scm
+++ b/bench/json-ref-set-perf.scm
@@ -17,7 +17,7 @@
 ;; json-ref / json-set 性能对比基准：C++ 实现 (g_json_ref / g_json_set) vs 历史 Scheme 实现
 ;; 运行方式: bin/gf bench/json-ref-set-perf.scm
 
-(import (liii base) (liii json) (liii alist) (liii error) (liii timeit))
+(import (liii base) (liii json) (liii alist) (liii list) (liii error) (liii timeit))
 
 ;; 历史 Scheme 实现（原 (guenchi json) 的 json-ref/json-set 及 (liii json) 的包装），原样保留用于对比
 
@@ -245,6 +245,112 @@
   ) ;if
 ) ;define
 
+;; 历史 Scheme 实现（原 (guenchi json) 的 json-reduce 及 (liii json) 的包装），原样保留用于对比
+
+(define (g-json-reduce/scheme x v p)
+  (if (vector? x)
+    (list->vector (cond ((boolean? v)
+                         (if v
+                           (let l
+                             ((x (vector->alist x)) (p p))
+                             (if (null? x) '() (cons (p (caar x) (cdar x)) (l (cdr x) p)))
+                           ) ;let
+                           x
+                         ) ;if
+                        ) ;
+                        ((procedure? v)
+                         (let l
+                           ((x (vector->alist x)) (v v) (p p))
+                           (if (null? x)
+                             '()
+                             (if (v (caar x))
+                               (cons (p (caar x) (cdar x)) (l (cdr x) v p))
+                               (cons (cdar x) (l (cdr x) v p))
+                             ) ;if
+                           ) ;if
+                         ) ;let
+                        ) ;
+                        (else (let l
+                                ((x (vector->alist x)) (v v) (p p))
+                                (if (null? x)
+                                  '()
+                                  (if (equal? (caar x) v)
+                                    (cons (p (caar x) (cdar x)) (l (cdr x) v p))
+                                    (cons (cdar x) (l (cdr x) v p))
+                                  ) ;if
+                                ) ;if
+                              ) ;let
+                        ) ;else
+                  ) ;cond
+    ) ;list->vector
+    (cond ((boolean? v)
+           (if v
+             (let l
+               ((x x) (p p))
+               (if (null? x) '() (cons (cons (caar x) (p (caar x) (cdar x))) (l (cdr x) p)))
+             ) ;let
+             x
+           ) ;if
+          ) ;
+          ((procedure? v)
+           (let l
+             ((x x) (v v) (p p))
+             (if (null? x)
+               '()
+               (if (v (caar x))
+                 (cons (cons (caar x) (p (caar x) (cdar x))) (l (cdr x) v p))
+                 (cons (car x) (l (cdr x) v p))
+               ) ;if
+             ) ;if
+           ) ;let
+          ) ;
+          (else (let l
+                  ((x x) (v v) (p p))
+                  (if (null? x)
+                    '()
+                    (if (equal? (caar x) v)
+                      (cons (cons v (p v (cdar x))) (l (cdr x) v p))
+                      (cons (car x) (l (cdr x) v p))
+                    ) ;if
+                  ) ;if
+                ) ;let
+          ) ;else
+    ) ;cond
+  ) ;if
+) ;define
+
+(define (json-reduce/scheme json key . args)
+  (if (null? json)
+    '()
+    (begin
+      (unless (or (json-object? json) (json-array? json))
+        (type-error "Value is not a JSON object or array" json)
+      ) ;unless
+      (if (null? args)
+        (value-error "json-reduce: missing arguments")
+        (if (null? (cdr args))
+          (let ((proc (car args)))
+            (if (and (json-object? json) (equal? json '(())))
+              json
+              (g-json-reduce/scheme json key proc)
+            ) ;if
+          ) ;let
+          (let* ((keys (cons key (drop-right args 1)))
+                 (proc (last args))
+                 (top-key (car keys))
+                 (rest-keys (cdr keys))
+                ) ;
+            (json-reduce/scheme json
+              top-key
+              (lambda (k v) (apply json-reduce/scheme (append (list v) rest-keys (list proc))))
+            ) ;json-reduce/scheme
+          ) ;let*
+        ) ;if
+      ) ;if
+    ) ;begin
+  ) ;if
+) ;define
+
 (define (build-json-string n)
   (let ((out (open-output-string)))
     (display "{" out)
@@ -326,6 +432,21 @@
         ) ;equal?
   (error 'value-error "nested drop mismatch")
 ) ;unless
+(unless (equal? (json-reduce bench-obj bench-ref-key (lambda (k v) 0))
+          (json-reduce/scheme bench-obj bench-ref-key (lambda (k v) 0))
+        ) ;equal?
+  (error 'value-error "object reduce mismatch")
+) ;unless
+(unless (equal? (json-reduce bench-arr #t (lambda (k v) (* v 2)))
+          (json-reduce/scheme bench-arr #t (lambda (k v) (* v 2)))
+        ) ;equal?
+  (error 'value-error "array reduce mismatch")
+) ;unless
+(unless (equal? (json-reduce bench-nested 'user 'profile 'age (lambda (k v) (+ v 1)))
+          (json-reduce/scheme bench-nested 'user 'profile 'age (lambda (k v) (+ v 1)))
+        ) ;equal?
+  (error 'value-error "nested reduce mismatch")
+) ;unless
 
 (define ref-iter 2000)
 
@@ -353,6 +474,8 @@
   (json-push/scheme bench-obj "newkey" 'new)
   (json-drop bench-obj bench-ref-key)
   (json-drop/scheme bench-obj bench-ref-key)
+  (json-reduce bench-obj bench-ref-key (lambda (k v) 0))
+  (json-reduce/scheme bench-obj bench-ref-key (lambda (k v) 0))
 ) ;do
 
 (display "=== json-ref / json-set C++ vs Scheme 性能对比 ===")
@@ -477,6 +600,51 @@
       ) ;t
      ) ;
   (report "多键路径删除/Scheme" set-iter t)
+) ;let
+
+(let ((t (timeit (lambda () (json-reduce bench-obj bench-ref-key (lambda (k v) 0))) '() set-iter)
+      ) ;t
+     ) ;
+  (report "对象单键转换/C++" set-iter t)
+) ;let
+(let ((t (timeit (lambda () (json-reduce/scheme bench-obj bench-ref-key (lambda (k v) 0)))
+           '()
+           set-iter
+         ) ;timeit
+      ) ;t
+     ) ;
+  (report "对象单键转换/Scheme" set-iter t)
+) ;let
+
+(let ((t (timeit (lambda () (json-reduce bench-arr #t (lambda (k v) (* v 2)))) '() set-iter)
+      ) ;t
+     ) ;
+  (report "数组全映射转换/C++" set-iter t)
+) ;let
+(let ((t (timeit (lambda () (json-reduce/scheme bench-arr #t (lambda (k v) (* v 2))))
+           '()
+           set-iter
+         ) ;timeit
+      ) ;t
+     ) ;
+  (report "数组全映射转换/Scheme" set-iter t)
+) ;let
+
+(let ((t (timeit (lambda () (json-reduce bench-nested 'user 'profile 'age (lambda (k v) (+ v 1))))
+           '()
+           set-iter
+         ) ;timeit
+      ) ;t
+     ) ;
+  (report "多键路径转换/C++" set-iter t)
+) ;let
+(let ((t (timeit (lambda () (json-reduce/scheme bench-nested 'user 'profile 'age (lambda (k v) (+ v 1))))
+           '()
+           set-iter
+         ) ;timeit
+      ) ;t
+     ) ;
+  (report "多键路径转换/Scheme" set-iter t)
 ) ;let
 
 (newline)

--- a/devel/0129.md
+++ b/devel/0129.md
@@ -1,4 +1,4 @@
-# [0129] json-push / json-drop 的 C++ 实现与 (guenchi json) 历史接口清理
+# [0129] json-push / json-drop / json-reduce 的 C++ 实现与 (guenchi json) 历史接口清理
 
 ## 任务相关的代码文件
 - src/liii_json.cpp
@@ -6,6 +6,7 @@
 - goldfish/guenchi/json.scm
 - tests/liii/json/json-push-test.scm
 - tests/liii/json/json-drop-test.scm
+- tests/liii/json/json-reduce-test.scm
 - bench/json-ref-set-perf.scm
 
 ## 如何测试
@@ -13,10 +14,33 @@
 xmake b goldfish
 bin/gf tests/liii/json/json-push-test.scm
 bin/gf tests/liii/json/json-drop-test.scm
+bin/gf tests/liii/json/json-reduce-test.scm
 bin/gf bench/json-ref-set-perf.scm
 ```
 
-## 2026-08-19 json-drop 迁移到 C++，移除 (guenchi json) 中的历史实现
+## 2026-08-19 json-reduce 迁移到 C++，移除 (guenchi json) 中的历史实现
+
+### What
+1. `src/liii_json.cpp` 新增 `g_json_reduce`（变参多键路径），完整复刻 `(liii json)` 包装 `(guenchi json)` 的 Scheme 实现语义：
+   - 单层：键 `#t` 映射所有条目；键为过程表示按键（数组为索引）谓词筛选；普通键按 `equal?` 匹配；命中条目的新值 = `(proc key old-value)`，未命中的条目复用原序对；命中后新序对的键：`#t`/过程键保留原键，普通键用传入的键
+   - 键 `#f` 落入 guenchi `(if v ...)` 无 else 分支的历史怪癖原样保留：对象原样返回，数组被外层 `(list->vector x)` 抛 wrong-type-arg（与 json-set 的 `#f` 键一致）
+   - 多键：等价于 `(json-reduce json key (lambda (k v) (apply json-reduce v ...)))`，叶层对旧值在 C++ 内递归 reduce，不经 Scheme 闭包回调；`'()` 透传（安全导航）；空对象 `'(())` 原样返回；缺少转换函数抛 value-error（复刻 wrapper）
+2. `(liii json)` 的 `json-reduce` 直接绑定 `g_json_reduce`，删除 Scheme 包装
+3. `(guenchi json)` 的 `json-reduce` 改为绑定 `g_json_reduce`（仅供 `json-reduce*` 内部使用）；`json-reduce*`（多 v/p 对的独立接口）保持 Scheme 实现不变
+4. `tests/liii/json/json-reduce-test.scm` 新增 10 个边界用例（数组索引/谓词/`#t`/`#f` 键、对象 `#f` 键原样返回、多键首键不存在、空对象、不可变性、缺转换函数 value-error），先在旧实现上通过以锁定语义
+5. `bench/json-ref-set-perf.scm` 新增 json-reduce 的 C++/Scheme 对比项与 sanity check
+
+### Why
+`json-reduce` 是 `(liii json)` 中最后一个核心操作仍走 Scheme 实现：数组分支需 `vector->alist` → 转换 → `list->vector` 两次全量拷贝，多键路径每层都要分配闭包并回调。至此 json-ref/json-set/json-push/json-drop/json-reduce 五个核心操作全部由 C++ 实现。
+
+### How
+- 引入 `json_reducer` 结构体：单层模式直接调用叶层转换过程（`(k v) -> new`），多键模式对旧值递归 `json_reduce_dispatch`（`kargs` 为 `(key ... proc)`，恰好两个元素时是单层）
+- 对象分支沿用 `json_guenchi_set` 的等长骨架 + GC 保护技巧：骨架搭建期间不调用用户过程，转换结果写入已保护的骨架
+- bench 实测（500 次迭代）：对象单键转换 ~3×、数组全映射转换 ~2.2×、多键路径转换 ~8.6×
+
+## 2026-08-19 之前的提交和任务描述
+
+### json-drop 迁移到 C++，移除 (guenchi json) 中的历史实现
 
 ### What
 1. `src/liii_json.cpp` 新增 `g_json_drop`（变参多键路径），完整复刻 `(liii json)` 包装 `(guenchi json)` 的 Scheme 实现语义：

--- a/devel/0129.md
+++ b/devel/0129.md
@@ -26,7 +26,7 @@ bin/gf bench/json-ref-set-perf.scm
    - 键 `#f` 落入 guenchi `(if v ...)` 无 else 分支的历史怪癖原样保留：对象原样返回，数组被外层 `(list->vector x)` 抛 wrong-type-arg（与 json-set 的 `#f` 键一致）
    - 多键：等价于 `(json-reduce json key (lambda (k v) (apply json-reduce v ...)))`，叶层对旧值在 C++ 内递归 reduce，不经 Scheme 闭包回调；`'()` 透传（安全导航）；空对象 `'(())` 原样返回；缺少转换函数抛 value-error（复刻 wrapper）
 2. `(liii json)` 的 `json-reduce` 直接绑定 `g_json_reduce`，删除 Scheme 包装
-3. `(guenchi json)` 的 `json-reduce` 改为绑定 `g_json_reduce`；`json-reduce*`（多 v/p 对、p 收键路径列表的独立接口）与 `(liii json)` 的 `json-reduce` 多键模式语义不同且全仓库无使用者，直接删除
+3. `(guenchi json)` 移除 `json-reduce` 的定义与导出；`json-reduce*`（多 v/p 对、p 收键路径列表的独立接口）与 `(liii json)` 的 `json-reduce` 多键模式语义不同且全仓库无使用者，直接删除；至此 `(guenchi json)` 仅保留 `json-string-escape` 一个接口
 4. `tests/liii/json/json-reduce-test.scm` 新增 10 个边界用例（数组索引/谓词/`#t`/`#f` 键、对象 `#f` 键原样返回、多键首键不存在、空对象、不可变性、缺转换函数 value-error），先在旧实现上通过以锁定语义
 5. `bench/json-ref-set-perf.scm` 新增 json-reduce 的 C++/Scheme 对比项与 sanity check
 

--- a/devel/0129.md
+++ b/devel/0129.md
@@ -26,7 +26,7 @@ bin/gf bench/json-ref-set-perf.scm
    - 键 `#f` 落入 guenchi `(if v ...)` 无 else 分支的历史怪癖原样保留：对象原样返回，数组被外层 `(list->vector x)` 抛 wrong-type-arg（与 json-set 的 `#f` 键一致）
    - 多键：等价于 `(json-reduce json key (lambda (k v) (apply json-reduce v ...)))`，叶层对旧值在 C++ 内递归 reduce，不经 Scheme 闭包回调；`'()` 透传（安全导航）；空对象 `'(())` 原样返回；缺少转换函数抛 value-error（复刻 wrapper）
 2. `(liii json)` 的 `json-reduce` 直接绑定 `g_json_reduce`，删除 Scheme 包装
-3. `(guenchi json)` 的 `json-reduce` 改为绑定 `g_json_reduce`（仅供 `json-reduce*` 内部使用）；`json-reduce*`（多 v/p 对的独立接口）保持 Scheme 实现不变
+3. `(guenchi json)` 的 `json-reduce` 改为绑定 `g_json_reduce`；`json-reduce*`（多 v/p 对、p 收键路径列表的独立接口）与 `(liii json)` 的 `json-reduce` 多键模式语义不同且全仓库无使用者，直接删除
 4. `tests/liii/json/json-reduce-test.scm` 新增 10 个边界用例（数组索引/谓词/`#t`/`#f` 键、对象 `#f` 键原样返回、多键首键不存在、空对象、不可变性、缺转换函数 value-error），先在旧实现上通过以锁定语义
 5. `bench/json-ref-set-perf.scm` 新增 json-reduce 的 C++/Scheme 对比项与 sanity check
 

--- a/devel/0129.md
+++ b/devel/0129.md
@@ -1,21 +1,43 @@
-# [0129] json-push 的 C++ 实现与 (guenchi json) 历史接口清理
+# [0129] json-push / json-drop 的 C++ 实现与 (guenchi json) 历史接口清理
 
 ## 任务相关的代码文件
 - src/liii_json.cpp
 - goldfish/liii/json.scm
 - goldfish/guenchi/json.scm
 - tests/liii/json/json-push-test.scm
+- tests/liii/json/json-drop-test.scm
 - bench/json-ref-set-perf.scm
 
 ## 如何测试
 ```bash
 xmake b goldfish
 bin/gf tests/liii/json/json-push-test.scm
-bin/gf tests/liii/json-test.scm
+bin/gf tests/liii/json/json-drop-test.scm
 bin/gf bench/json-ref-set-perf.scm
 ```
 
-## 2026-08-19 json-push 迁移到 C++，移除 (guenchi json) 中的历史实现
+## 2026-08-19 json-drop 迁移到 C++，移除 (guenchi json) 中的历史实现
+
+### What
+1. `src/liii_json.cpp` 新增 `g_json_drop`（变参多键路径），完整复刻 `(liii json)` 包装 `(guenchi json)` 的 Scheme 实现语义：
+   - 单键：对象删除键 `equal?` 匹配或谓词命中键的条目（全部删空时退化为 `'()`，未命中的条目复用原序对）；空对象 `'(())` 原样返回；数组空时返回自身，非空时按键（即索引）`equal?` 匹配或谓词命中索引删除对应元素，无命中时原样返回
+   - 多键：等价于 `(json-set json key (lambda (x) (apply json-drop x ...)))`，复用 `json_setter` 基础设施并新增 `is_drop` 模式，叶层对旧值在 C++ 内递归 drop，不经 Scheme 闭包回调；空对象 `'(())` 原样返回；每层先做结构校验
+2. `(liii json)` 的 `json-drop` 直接绑定 `g_json_drop`，删除 Scheme 包装
+3. `(guenchi json)` 移除 `json-drop`、`json-drop*` 的定义与导出，以及仅供 `json-drop*` 内部使用的私有 `json-set` 绑定
+4. `tests/liii/json/json-drop-test.scm` 新增 9 个边界用例（对象删空退化为 `'()`、空对象单键/多键、数组索引/谓词删除、中间键不存在静默不生效、叶层标量抛 type-error、不可变性），先在旧实现上通过以锁定语义
+5. `bench/json-ref-set-perf.scm` 新增 json-drop 的 C++/Scheme 对比项与 sanity check
+
+### Why
+`json-drop` 是 `(liii json)` 中最后一个核心删除操作仍走 Scheme 实现：数组分支需 `vector->alist` → 过滤 → `list->vector` 两次全量拷贝，多键路径每层都要分配闭包并回调。至此 json-ref/json-set/json-push/json-drop 四个核心操作全部由 C++ 实现，`(guenchi json)` 中的历史 Scheme 实现已无存在必要。
+
+### How
+- 多键路径复用 `json_set_dispatch` 的 `json_setter` 结构体，增加 `is_drop`/`drop_args` 字段：`json_setter_apply` 遇到 drop 模式时对旧值递归 `json_drop_dispatch`
+- 数组删除分两遍：先调用谓词/`equal?` 判定并统计命中数（谓词可能触发 GC 或回调 Scheme，元素经原 vector 有根），再一次性分配结果 vector；命中数为 0 时直接原样返回
+- bench 实测（500 次迭代）：对象单键删除 ~2.3×、数组索引删除 ~12×、多键路径删除 ~2.7×
+
+## 2026-08-19 之前的提交和任务描述
+
+### json-push 迁移到 C++，移除 (guenchi json) 中的历史实现
 
 ### What
 1. `src/liii_json.cpp` 新增 `g_json_push`（变参多键路径），完整复刻 `(liii json)` 包装 `(guenchi json)` 的 Scheme 实现语义：

--- a/goldfish/guenchi/json.scm
+++ b/goldfish/guenchi/json.scm
@@ -75,79 +75,9 @@
     ;; json-set 与 json-drop 均由 C++ 实现（src/liii_json.cpp 中的
     ;; g_json_set / g_json_drop，含变参多键路径，语义覆盖历史上的
     ;; json-set / json-drop 及带 * 版本），本库不再保留对应 Scheme 实现
-    (define json-reduce
-      (lambda (x v p)
-        (if (vector? x)
-          (list->vector (cond ((boolean? v)
-                               (if v
-                                 (let l
-                                   ((x (vector->alist x)) (p p))
-                                   (if (null? x) '() (cons (p (caar x) (cdar x)) (l (cdr x) p)))
-                                 ) ;let
-                                 x
-                               ) ;if
-                              ) ;
-                              ((procedure? v)
-                               (let l
-                                 ((x (vector->alist x)) (v v) (p p))
-                                 (if (null? x)
-                                   '()
-                                   (if (v (caar x))
-                                     (cons (p (caar x) (cdar x)) (l (cdr x) v p))
-                                     (cons (cdar x) (l (cdr x) v p))
-                                   ) ;if
-                                 ) ;if
-                               ) ;let
-                              ) ;
-                              (else (let l
-                                      ((x (vector->alist x)) (v v) (p p))
-                                      (if (null? x)
-                                        '()
-                                        (if (equal? (caar x) v)
-                                          (cons (p (caar x) (cdar x)) (l (cdr x) v p))
-                                          (cons (cdar x) (l (cdr x) v p))
-                                        ) ;if
-                                      ) ;if
-                                    ) ;let
-                              ) ;else
-                        ) ;cond
-          ) ;list->vector
-          (cond ((boolean? v)
-                 (if v
-                   (let l
-                     ((x x) (p p))
-                     (if (null? x) '() (cons (cons (caar x) (p (caar x) (cdar x))) (l (cdr x) p)))
-                   ) ;let
-                   x
-                 ) ;if
-                ) ;
-                ((procedure? v)
-                 (let l
-                   ((x x) (v v) (p p))
-                   (if (null? x)
-                     '()
-                     (if (v (caar x))
-                       (cons (cons (caar x) (p (caar x) (cdar x))) (l (cdr x) v p))
-                       (cons (car x) (l (cdr x) v p))
-                     ) ;if
-                   ) ;if
-                 ) ;let
-                ) ;
-                (else (let l
-                        ((x x) (v v) (p p))
-                        (if (null? x)
-                          '()
-                          (if (equal? (caar x) v)
-                            (cons (cons v (p v (cdar x))) (l (cdr x) v p))
-                            (cons (car x) (l (cdr x) v p))
-                          ) ;if
-                        ) ;if
-                      ) ;let
-                ) ;else
-          ) ;cond
-        ) ;if
-      ) ;lambda
-    ) ;define
+    ;; json-reduce 由 C++ 实现（src/liii_json.cpp 中的 g_json_reduce，含变参多键路径，
+    ;; 语义覆盖 (liii json) 包装的历史 json-reduce）；仅供本库的 json-reduce* 内部使用
+    (define json-reduce g_json_reduce)
     (define (json-reduce* j v1 v2 . rest)
       (cond ((null? rest) (json-reduce j v1 v2))
             ((length=? 1 rest)

--- a/goldfish/guenchi/json.scm
+++ b/goldfish/guenchi/json.scm
@@ -27,7 +27,7 @@
     (liii string)
     (liii unicode)
   ) ;import
-  (export json-string-escape json-drop json-drop* json-reduce json-reduce*)
+  (export json-string-escape json-reduce json-reduce*)
   (begin
 
     (define (json-string-escape str)
@@ -72,57 +72,9 @@
       ) ;let
     ) ;define
 
-    ;; json-set 由 C++ 实现（src/liii_json.cpp 中的 g_json_set，含变参多键路径，
-    ;; 语义覆盖历史上的 json-set 与 json-set*）；仅供本库的 json-drop* 内部使用，不导出
-    (define json-set g_json_set)
-    (define json-drop
-      (lambda (x v)
-        (if (vector? x)
-          (if (zero? (vector-length x))
-            x
-            (list->vector (cond ((procedure? v)
-                                 (let l
-                                   ((x (vector->alist x)) (v v))
-                                   (if (null? x) '() (if (v (caar x)) (l (cdr x) v) (cons (cdar x) (l (cdr x) v))))
-                                 ) ;let
-                                ) ;
-                                (else (let l
-                                        ((x (vector->alist x)) (v v))
-                                        (if (null? x)
-                                          '()
-                                          (if (equal? (caar x) v) (l (cdr x) v) (cons (cdar x) (l (cdr x) v)))
-                                        ) ;if
-                                      ) ;let
-                                ) ;else
-                          ) ;cond
-            ) ;list->vector
-          ) ;if
-          (cond ((procedure? v)
-                 (let l
-                   ((x x) (v v))
-                   (if (null? x) '() (if (v (caar x)) (l (cdr x) v) (cons (car x) (l (cdr x) v))))
-                 ) ;let
-                ) ;
-                (else (let l
-                        ((x x) (v v))
-                        (if (null? x)
-                          '()
-                          (if (equal? (caar x) v) (l (cdr x) v) (cons (car x) (l (cdr x) v)))
-                        ) ;if
-                      ) ;let
-                ) ;else
-          ) ;cond
-        ) ;if
-      ) ;lambda
-    ) ;define
-    (define json-drop*
-      (lambda (json key . rest)
-        (if (null? rest)
-          (json-drop json key)
-          (json-set json key (lambda (x) (apply json-drop* (cons x rest))))
-        ) ;if
-      ) ;lambda
-    ) ;define
+    ;; json-set 与 json-drop 均由 C++ 实现（src/liii_json.cpp 中的
+    ;; g_json_set / g_json_drop，含变参多键路径，语义覆盖历史上的
+    ;; json-set / json-drop 及带 * 版本），本库不再保留对应 Scheme 实现
     (define json-reduce
       (lambda (x v p)
         (if (vector? x)

--- a/goldfish/guenchi/json.scm
+++ b/goldfish/guenchi/json.scm
@@ -27,7 +27,7 @@
     (liii string)
     (liii unicode)
   ) ;import
-  (export json-string-escape json-reduce json-reduce*)
+  (export json-string-escape json-reduce)
   (begin
 
     (define (json-string-escape str)
@@ -72,38 +72,10 @@
       ) ;let
     ) ;define
 
-    ;; json-set 与 json-drop 均由 C++ 实现（src/liii_json.cpp 中的
-    ;; g_json_set / g_json_drop，含变参多键路径，语义覆盖历史上的
-    ;; json-set / json-drop 及带 * 版本），本库不再保留对应 Scheme 实现
-    ;; json-reduce 由 C++ 实现（src/liii_json.cpp 中的 g_json_reduce，含变参多键路径，
-    ;; 语义覆盖 (liii json) 包装的历史 json-reduce）；仅供本库的 json-reduce* 内部使用
+    ;; json-set / json-drop / json-reduce 均由 C++ 实现（src/liii_json.cpp 中的
+    ;; g_json_set / g_json_drop / g_json_reduce，含变参多键路径，语义覆盖历史上的
+    ;; json-set / json-drop / json-reduce 及带 * 版本），本库不再保留对应 Scheme 实现。
+    ;; 历史上的 json-reduce*（多 v/p 对、p 收键路径列表的独立接口）无使用者，已删除
     (define json-reduce g_json_reduce)
-    (define (json-reduce* j v1 v2 . rest)
-      (cond ((null? rest) (json-reduce j v1 v2))
-            ((length=? 1 rest)
-             (json-reduce j
-               v1
-               (lambda (x y)
-                 (let* ((new-v1 v2) (p (last rest)))
-                   (json-reduce y new-v1 (lambda (n m) (p (list x n) m)))
-                 ) ;let*
-               ) ;lambda
-             ) ;json-reduce
-            ) ;
-            (else (json-reduce j
-                    v1
-                    (lambda (x y)
-                      (let* ((new-v1 v2) (p (last rest)))
-                        (apply json-reduce*
-                          (append (cons y (cons new-v1 (drop-right rest 1)))
-                            (list (lambda (n m) (p (cons x n) m)))
-                          ) ;append
-                        ) ;apply
-                      ) ;let*
-                    ) ;lambda
-                  ) ;json-reduce
-            ) ;else
-      ) ;cond
-    ) ;define
   ) ;begin
 ) ;define-library

--- a/goldfish/guenchi/json.scm
+++ b/goldfish/guenchi/json.scm
@@ -27,7 +27,7 @@
     (liii string)
     (liii unicode)
   ) ;import
-  (export json-string-escape json-reduce)
+  (export json-string-escape)
   (begin
 
     (define (json-string-escape str)
@@ -76,6 +76,5 @@
     ;; g_json_set / g_json_drop / g_json_reduce，含变参多键路径，语义覆盖历史上的
     ;; json-set / json-drop / json-reduce 及带 * 版本），本库不再保留对应 Scheme 实现。
     ;; 历史上的 json-reduce*（多 v/p 对、p 收键路径列表的独立接口）无使用者，已删除
-    (define json-reduce g_json_reduce)
   ) ;begin
 ) ;define-library

--- a/goldfish/liii/json.scm
+++ b/goldfish/liii/json.scm
@@ -1,10 +1,7 @@
 (define-library (liii json)
   (import (liii base)
     (liii list)
-    (rename (guenchi json)
-      (json-reduce g:json-reduce)
-      (json-reduce* g:json-reduce*)
-    ) ;rename
+    (rename (guenchi json) (json-reduce g:json-reduce))
   ) ;import
   (export json-string-escape
     string->json

--- a/goldfish/liii/json.scm
+++ b/goldfish/liii/json.scm
@@ -62,42 +62,14 @@
     ;; 语义覆盖历史上的 json-drop 与 json-drop*）
     (define json-drop g_json_drop)
 
+    ;; json-reduce 由 C++ 实现（src/liii_json.cpp 中的 g_json_reduce，含变参多键路径，
+    ;; 语义覆盖历史上的 json-reduce 多层路径模式）
+    (define json-reduce g_json_reduce)
+
     (define (ensure-json-structure x)
       (unless (or (json-object? x) (json-array? x))
         (type-error "Value is not a JSON object or array" x)
       ) ;unless
-    ) ;define
-
-    (define (json-reduce json key . args)
-      (if (null? json)
-        '()
-        (begin
-          (ensure-json-structure json)
-          (if (null? args)
-            (value-error "json-reduce: missing arguments")
-            (if (null? (cdr args))
-              ;; Single level: (json-reduce json key proc)
-              (let ((proc (car args)))
-                (if (and (json-object? json) (equal? json '(())))
-                  json
-                  (g:json-reduce json key proc)
-                ) ;if
-              ) ;let
-              ;; Multi level
-              (let* ((keys (cons key (drop-right args 1)))
-                     (proc (last args))
-                     (top-key (car keys))
-                     (rest-keys (cdr keys))
-                    ) ;
-                (json-reduce json
-                  top-key
-                  (lambda (k v) (apply json-reduce (append (list v) rest-keys (list proc))))
-                ) ;json-reduce
-              ) ;let*
-            ) ;if
-          ) ;if
-        ) ;begin
-      ) ;if
     ) ;define
 
     ;; ; ---------------------------------------------------------

--- a/goldfish/liii/json.scm
+++ b/goldfish/liii/json.scm
@@ -1,8 +1,5 @@
 (define-library (liii json)
-  (import (liii base)
-    (liii list)
-    (rename (guenchi json) (json-reduce g:json-reduce))
-  ) ;import
+  (import (liii base) (liii list) (guenchi json))
   (export json-string-escape
     string->json
     json->string

--- a/goldfish/liii/json.scm
+++ b/goldfish/liii/json.scm
@@ -2,8 +2,6 @@
   (import (liii base)
     (liii list)
     (rename (guenchi json)
-      (json-drop g:json-drop)
-      (json-drop* g:json-drop*)
       (json-reduce g:json-reduce)
       (json-reduce* g:json-reduce*)
     ) ;rename
@@ -60,18 +58,14 @@
     ;; 语义覆盖历史上的 json-push 与 json-push*）
     (define json-push g_json_push)
 
+    ;; json-drop 由 C++ 实现（src/liii_json.cpp 中的 g_json_drop，含变参多键路径，
+    ;; 语义覆盖历史上的 json-drop 与 json-drop*）
+    (define json-drop g_json_drop)
+
     (define (ensure-json-structure x)
       (unless (or (json-object? x) (json-array? x))
         (type-error "Value is not a JSON object or array" x)
       ) ;unless
-    ) ;define
-
-    (define (json-drop json key . args)
-      (ensure-json-structure json)
-      (if (null? args)
-        (if (and (json-object? json) (equal? json '(()))) json (g:json-drop json key))
-        (json-set json key (lambda (x) (apply json-drop (cons x args))))
-      ) ;if
     ) ;define
 
     (define (json-reduce json key . args)

--- a/src/liii_json.cpp
+++ b/src/liii_json.cpp
@@ -1113,16 +1113,16 @@ json_guenchi_drop (s7_scheme* sc, s7_pointer x, s7_pointer v) {
     if (n == 0) return x;
     // 谓词可能触发 GC 或回调 Scheme，先只判定再分配结果（ elems 经 x 有根）
     std::vector<bool> drop (n, false);
-    s7_int      count = 0;
+    s7_int            count= 0;
     for (s7_int i= 0; i < n; i++) {
       bool hit= use_pred ? (s7_call (sc, v, s7_list (sc, 1, s7_make_integer (sc, i))) != s7_f (sc))
                          : s7_is_equal (sc, s7_make_integer (sc, i), v);
-      drop[i]= hit;
+      drop[i] = hit;
       if (hit) count++;
     }
     if (count == 0) return x;
-    s7_pointer result= s7_make_vector (sc, n - count);
-    s7_int      at   = 0;
+    s7_pointer  result= s7_make_vector (sc, n - count);
+    s7_int      at    = 0;
     s7_pointer* relems= s7_vector_elements (result);
     for (s7_int i= 0; i < n; i++) {
       if (!drop[i]) relems[at++]= elems[i];
@@ -1162,13 +1162,13 @@ json_drop_dispatch (s7_scheme* sc, s7_pointer x, s7_pointer keys) {
   }
   // 多键：经 json-set 的单层语义逐层下钻，叶层对旧值在 C++ 内递归 drop
   json_setter st;
-  st.rest       = s7_nil (sc);
-  st.leaf       = NULL;
+  st.rest        = s7_nil (sc);
+  st.leaf        = NULL;
   st.leaf_is_proc= false;
-  st.is_push    = false;
-  st.push_args  = NULL;
-  st.is_drop    = true;
-  st.drop_args  = s7_cdr (keys);
+  st.is_push     = false;
+  st.push_args   = NULL;
+  st.is_drop     = true;
+  st.drop_args   = s7_cdr (keys);
   return json_guenchi_set (sc, x, s7_car (keys), len, st);
 }
 
@@ -1216,24 +1216,23 @@ json_reducer_apply (s7_scheme* sc, const json_reducer& r, s7_pointer k, s7_point
 // guenchi json-reduce 的单层语义：x 已校验为 JSON 对象（含 len 个条目）或数组
 static s7_pointer
 json_guenchi_reduce (s7_scheme* sc, s7_pointer x, s7_pointer v, const json_reducer& r, s7_int len) {
-  bool is_bool= s7_is_boolean (v);
-  bool truthy = is_bool && s7_boolean (sc, v);
+  bool is_bool = s7_is_boolean (v);
+  bool truthy  = is_bool && s7_boolean (sc, v);
   bool use_pred= s7_is_procedure (v);
   if (s7_is_vector (x)) {
     if (is_bool && !truthy) {
       // guenchi 的 (if v ...) 无 else 分支：(list->vector x) 对 vector 抛 wrong-type-arg
       return s7_call (sc, cached_list_to_vector, s7_list (sc, 1, x));
     }
-    s7_int      n    = s7_vector_length (x);
-    s7_pointer* elems= s7_vector_elements (x);
+    s7_int      n     = s7_vector_length (x);
+    s7_pointer* elems = s7_vector_elements (x);
     s7_pointer  result= s7_make_vector (sc, n);
     s7_gc_protect_via_stack (sc, result);
     s7_pointer* relems= s7_vector_elements (result);
     for (s7_int i= 0; i < n; i++) {
       s7_pointer idx= s7_make_integer (sc, i);
-      bool       hit= truthy ? true
-                             : (use_pred ? (s7_call (sc, v, s7_list (sc, 1, idx)) != s7_f (sc))
-                                         : s7_is_equal (sc, idx, v));
+      bool       hit=
+          truthy ? true : (use_pred ? (s7_call (sc, v, s7_list (sc, 1, idx)) != s7_f (sc)) : s7_is_equal (sc, idx, v));
       relems[i]= hit ? json_reducer_apply (sc, r, idx, elems[i]) : elems[i];
     }
     s7_gc_unprotect_via_stack (sc, result);
@@ -1254,9 +1253,7 @@ json_guenchi_reduce (s7_scheme* sc, s7_pointer x, s7_pointer v, const json_reduc
   while (s7_is_pair (p)) {
     s7_pointer entry= s7_car (p);
     s7_pointer k    = s7_car (entry);
-    bool       hit  = truthy ? true
-                             : (use_pred ? (s7_call (sc, v, s7_list (sc, 1, k)) != s7_f (sc))
-                                         : s7_is_equal (sc, k, v));
+    bool hit= truthy ? true : (use_pred ? (s7_call (sc, v, s7_list (sc, 1, k)) != s7_f (sc)) : s7_is_equal (sc, k, v));
     if (hit) {
       s7_pointer newkey= (is_bool || use_pred) ? k : v; // 普通键分支历史用传入的键构造新序对
       s7_set_car (tail, s7_cons (sc, newkey, json_reducer_apply (sc, r, newkey, s7_cdr (entry))));
@@ -1285,18 +1282,18 @@ json_reduce_dispatch (s7_scheme* sc, s7_pointer x, s7_pointer kargs) {
   }
   // 空对象 '(()) 原样返回（单层与多键均如此）
   if (json_is_null_object (sc, x)) return x;
-  s7_pointer rest= s7_cdr (kargs);
+  s7_pointer   rest= s7_cdr (kargs);
   json_reducer r;
   if (s7_is_null (sc, s7_cdr (rest))) {
     // 单层：(key proc)
-    r.p         = s7_car (rest);
-    r.is_reduce = false;
+    r.p          = s7_car (rest);
+    r.is_reduce  = false;
     r.reduce_args= NULL;
   }
   else {
     // 多键：(key k2 ... proc)
-    r.p         = NULL;
-    r.is_reduce = true;
+    r.p          = NULL;
+    r.is_reduce  = true;
     r.reduce_args= rest;
   }
   return json_guenchi_reduce (sc, x, s7_car (kargs), r, len);

--- a/src/liii_json.cpp
+++ b/src/liii_json.cpp
@@ -870,21 +870,26 @@ glue_json_ref (s7_scheme* sc) {
 
 // json-set 的叶层写入器：rest 非空表示多键路径（对旧值递归 json-set），
 // 否则写入叶层值（叶层值为过程时以旧值调用之）；
-// is_push 表示 json-push 的多键路径（对旧值递归 json-push，kvs 为键值序列）
+// is_push 表示 json-push 的多键路径（对旧值递归 json-push，kvs 为键值序列）；
+// is_drop 表示 json-drop 的多键路径（对旧值递归 json-drop，keys 为键序列）
 struct json_setter {
   s7_pointer rest; // 剩余 (key val ...) 参数；'() 表示已到叶层
   s7_pointer leaf; // 叶层值（仅 rest 为 '() 时有效）
   bool       leaf_is_proc;
   bool       is_push;   // json-push 多键模式
   s7_pointer push_args; // (key ... val) 序列（仅 is_push 时有效）
+  bool       is_drop;   // json-drop 多键模式
+  s7_pointer drop_args; // (key ...) 序列（仅 is_drop 时有效）
 };
 
 static s7_pointer json_set_dispatch (s7_scheme* sc, s7_pointer x, s7_pointer kargs);
 static s7_pointer json_push_dispatch (s7_scheme* sc, s7_pointer x, s7_pointer kvs);
+static s7_pointer json_drop_dispatch (s7_scheme* sc, s7_pointer x, s7_pointer keys);
 
 static s7_pointer
 json_setter_apply (s7_scheme* sc, const json_setter& st, s7_pointer old) {
   if (st.is_push) return json_push_dispatch (sc, old, st.push_args);
+  if (st.is_drop) return json_drop_dispatch (sc, old, st.drop_args);
   if (!s7_is_null (sc, st.rest)) return json_set_dispatch (sc, old, st.rest);
   if (st.leaf_is_proc) return s7_call (sc, st.leaf, s7_list (sc, 1, old));
   return st.leaf;
@@ -975,6 +980,8 @@ json_set_dispatch (s7_scheme* sc, s7_pointer x, s7_pointer kargs) {
   json_setter st;
   st.is_push  = false;
   st.push_args= NULL;
+  st.is_drop  = false;
+  st.drop_args= NULL;
   if (s7_is_null (sc, s7_cdr (rest))) {
     st.rest        = s7_nil (sc);
     st.leaf        = s7_car (rest);
@@ -1069,6 +1076,8 @@ json_push_dispatch (s7_scheme* sc, s7_pointer x, s7_pointer kvs) {
   st.leaf_is_proc= false;
   st.is_push     = true;
   st.push_args   = s7_cdr (kvs);
+  st.is_drop     = false;
+  st.drop_args   = NULL;
   return json_guenchi_set (sc, x, s7_car (kvs), len, st);
 }
 
@@ -1084,6 +1093,97 @@ glue_json_push (s7_scheme* sc) {
   s7_define_function (sc, name, f_json_push, 3, 0, true, desc);
 }
 
+// json-drop / json-drop* 的 C++ 实现，语义与历史上 (liii json) 包装 (guenchi json)
+// 的 Scheme 实现完全一致：
+//   - 单键：对象删除键 equal? 匹配或谓词命中键的条目（全部删空时退化为 '()）；
+//     空对象 '(()) 原样返回；数组空时返回自身，非空时按键（即索引）equal? 匹配
+//     或谓词命中索引删除对应元素
+//   - 多键：等价于 (json-set json key (lambda (x) (apply json-drop x ...)))，
+//     即经 json-set 的单层语义逐层下钻（中间键不存在时静默不生效），
+//     空对象 '(()) 原样返回；每层进入时先做结构校验
+
+// guenchi json-drop 的单层语义：x 已校验为 JSON 对象或数组
+// v 为过程时按键（数组为索引）谓词筛选，否则按 equal? 匹配键（数组为索引）
+static s7_pointer
+json_guenchi_drop (s7_scheme* sc, s7_pointer x, s7_pointer v) {
+  bool use_pred= s7_is_procedure (v);
+  if (s7_is_vector (x)) {
+    s7_int      n    = s7_vector_length (x);
+    s7_pointer* elems= s7_vector_elements (x);
+    if (n == 0) return x;
+    // 谓词可能触发 GC 或回调 Scheme，先只判定再分配结果（ elems 经 x 有根）
+    std::vector<bool> drop (n, false);
+    s7_int      count = 0;
+    for (s7_int i= 0; i < n; i++) {
+      bool hit= use_pred ? (s7_call (sc, v, s7_list (sc, 1, s7_make_integer (sc, i))) != s7_f (sc))
+                         : s7_is_equal (sc, s7_make_integer (sc, i), v);
+      drop[i]= hit;
+      if (hit) count++;
+    }
+    if (count == 0) return x;
+    s7_pointer result= s7_make_vector (sc, n - count);
+    s7_int      at   = 0;
+    s7_pointer* relems= s7_vector_elements (result);
+    for (s7_int i= 0; i < n; i++) {
+      if (!drop[i]) relems[at++]= elems[i];
+    }
+    return result;
+  }
+  // 对象（alist）：删除键命中的条目，未命中的条目复用原序对；命中后从尾向头 cons
+  std::vector<s7_pointer> kept;
+  kept.reserve (16);
+  s7_pointer p= x;
+  while (s7_is_pair (p)) {
+    s7_pointer entry= s7_car (p);
+    bool       hit  = use_pred ? (s7_call (sc, v, s7_list (sc, 1, s7_car (entry))) != s7_f (sc))
+                               : s7_is_equal (sc, s7_car (entry), v);
+    if (!hit) kept.push_back (entry);
+    p= s7_cdr (p);
+  }
+  s7_pointer lst= s7_nil (sc);
+  for (size_t i= kept.size (); i > 0; i--)
+    lst= s7_cons (sc, kept[i - 1], lst);
+  return lst;
+}
+
+// 对应 (liii json) 的 json-drop 包装：结构校验 + 空对象特判 + 单键/多键分派
+// keys 为 (key) 或 (key ...)（多键时 key 之后逐层下钻，末项为目标键或谓词）
+static s7_pointer
+json_drop_dispatch (s7_scheme* sc, s7_pointer x, s7_pointer keys) {
+  s7_int len= 0;
+  if (!s7_is_vector (x) && !json_is_object (sc, x, len)) {
+    return json_type_error (sc, "Value is not a JSON object or array", x);
+  }
+  // 空对象 '(()) 原样返回（单键与多键均如此）
+  if (json_is_null_object (sc, x)) return x;
+  if (s7_is_null (sc, s7_cdr (keys))) {
+    // 单键
+    return json_guenchi_drop (sc, x, s7_car (keys));
+  }
+  // 多键：经 json-set 的单层语义逐层下钻，叶层对旧值在 C++ 内递归 drop
+  json_setter st;
+  st.rest       = s7_nil (sc);
+  st.leaf       = NULL;
+  st.leaf_is_proc= false;
+  st.is_push    = false;
+  st.push_args  = NULL;
+  st.is_drop    = true;
+  st.drop_args  = s7_cdr (keys);
+  return json_guenchi_set (sc, x, s7_car (keys), len, st);
+}
+
+static s7_pointer
+f_json_drop (s7_scheme* sc, s7_pointer args) {
+  return json_drop_dispatch (sc, s7_car (args), s7_cdr (args));
+}
+
+static void
+glue_json_drop (s7_scheme* sc) {
+  const char* name= "g_json_drop";
+  const char* desc= "(g_json_drop json key . keys) => data, drop values from Scheme-form JSON data by key path";
+  s7_define_function (sc, name, f_json_drop, 2, 0, true, desc);
+}
+
 void
 glue_liii_json (s7_scheme* sc) {
   glue_json_to_string (sc);
@@ -1091,6 +1191,7 @@ glue_liii_json (s7_scheme* sc) {
   glue_json_ref (sc);
   glue_json_set (sc);
   glue_json_push (sc);
+  glue_json_drop (sc);
 }
 
 } // namespace goldfish

--- a/src/liii_json.cpp
+++ b/src/liii_json.cpp
@@ -1184,6 +1184,141 @@ glue_json_drop (s7_scheme* sc) {
   s7_define_function (sc, name, f_json_drop, 2, 0, true, desc);
 }
 
+// json-reduce / json-reduce* 的 C++ 实现，语义与历史上 (liii json) 包装 (guenchi json)
+// 的 Scheme 实现完全一致：
+//   - 单层：(json-reduce json key proc)；
+//     键 #t 映射所有条目；键为过程表示按键（数组为索引）谓词筛选命中后转换；
+//     普通键按 equal? 匹配；命中条目的新值 = (proc key old-value)，未命中条目复用原序对
+//     （对象分支命中后新序对的键：#t/过程键保留原键，普通键用传入的键）；
+//     键 #f 落入 guenchi (if v ...) 无 else 分支的历史怪癖原样保留
+//     （对象返回 x，数组被外层 (list->vector x) 抛 wrong-type-arg）
+//   - 多键：等价于 (json-reduce json key (lambda (k v) (apply json-reduce v ...)))，
+//     即经 json-reduce 的单层语义逐层下钻（中间键不存在时静默不生效），
+//     叶层对旧值在 C++ 内递归 reduce，不经 Scheme 闭包回调；
+//     '() 透传（安全导航）；空对象 '(()) 原样返回；每层先做结构校验
+
+// json-reduce 的叶层转换器：p 为转换过程 ((key val) -> new)，
+// is_reduce 表示多键路径（对旧值递归 json-reduce，rest 为 (key ... proc) 序列）
+struct json_reducer {
+  s7_pointer p;         // 叶层转换过程（仅非 is_reduce 时有效）
+  bool       is_reduce; // 多键模式
+  s7_pointer reduce_args;
+};
+
+static s7_pointer json_reduce_dispatch (s7_scheme* sc, s7_pointer x, s7_pointer kargs);
+
+static s7_pointer
+json_reducer_apply (s7_scheme* sc, const json_reducer& r, s7_pointer k, s7_pointer old) {
+  if (r.is_reduce) return json_reduce_dispatch (sc, old, r.reduce_args);
+  return s7_call (sc, r.p, s7_list (sc, 2, k, old));
+}
+
+// guenchi json-reduce 的单层语义：x 已校验为 JSON 对象（含 len 个条目）或数组
+static s7_pointer
+json_guenchi_reduce (s7_scheme* sc, s7_pointer x, s7_pointer v, const json_reducer& r, s7_int len) {
+  bool is_bool= s7_is_boolean (v);
+  bool truthy = is_bool && s7_boolean (sc, v);
+  bool use_pred= s7_is_procedure (v);
+  if (s7_is_vector (x)) {
+    if (is_bool && !truthy) {
+      // guenchi 的 (if v ...) 无 else 分支：(list->vector x) 对 vector 抛 wrong-type-arg
+      return s7_call (sc, cached_list_to_vector, s7_list (sc, 1, x));
+    }
+    s7_int      n    = s7_vector_length (x);
+    s7_pointer* elems= s7_vector_elements (x);
+    s7_pointer  result= s7_make_vector (sc, n);
+    s7_gc_protect_via_stack (sc, result);
+    s7_pointer* relems= s7_vector_elements (result);
+    for (s7_int i= 0; i < n; i++) {
+      s7_pointer idx= s7_make_integer (sc, i);
+      bool       hit= truthy ? true
+                             : (use_pred ? (s7_call (sc, v, s7_list (sc, 1, idx)) != s7_f (sc))
+                                         : s7_is_equal (sc, idx, v));
+      relems[i]= hit ? json_reducer_apply (sc, r, idx, elems[i]) : elems[i];
+    }
+    s7_gc_unprotect_via_stack (sc, result);
+    return result;
+  }
+  // 对象（alist）：#f 原样返回；命中的条目换新序对，未命中的条目复用原序对
+  if (is_bool && !truthy) return x;
+  // 先搭建与输入等长的结果骨架并 GC 保护（搭建期间不调用用户过程）
+  s7_pointer head= s7_cons (sc, s7_nil (sc), s7_nil (sc));
+  s7_gc_protect_via_stack (sc, head);
+  s7_pointer tail= head;
+  for (s7_int i= 1; i < len; i++) {
+    s7_set_cdr (tail, s7_cons (sc, s7_nil (sc), s7_nil (sc)));
+    tail= s7_cdr (tail);
+  }
+  s7_pointer p= x;
+  tail        = head;
+  while (s7_is_pair (p)) {
+    s7_pointer entry= s7_car (p);
+    s7_pointer k    = s7_car (entry);
+    bool       hit  = truthy ? true
+                             : (use_pred ? (s7_call (sc, v, s7_list (sc, 1, k)) != s7_f (sc))
+                                         : s7_is_equal (sc, k, v));
+    if (hit) {
+      s7_pointer newkey= (is_bool || use_pred) ? k : v; // 普通键分支历史用传入的键构造新序对
+      s7_set_car (tail, s7_cons (sc, newkey, json_reducer_apply (sc, r, newkey, s7_cdr (entry))));
+    }
+    else {
+      s7_set_car (tail, entry);
+    }
+    tail= s7_cdr (tail);
+    p   = s7_cdr (p);
+  }
+  s7_gc_unprotect_via_stack (sc, head);
+  return head;
+}
+
+// 对应 (liii json) 的 json-reduce 包装：'() 透传 + 结构校验 + 空对象特判 + 单层/多键分派
+// kargs 为 (key proc) 或 (key ... proc)：恰好两个元素时是单层（p 为转换函数），
+// 否则多键（等价于以 (lambda (k v) (apply json-reduce v rest)) 作转换函数逐层下钻，
+// rest 为 (k2 ... proc) 序列，与递归调用的 kargs 结构一致）
+static s7_pointer
+json_reduce_dispatch (s7_scheme* sc, s7_pointer x, s7_pointer kargs) {
+  // '() 透传：安全导航
+  if (s7_is_null (sc, x)) return s7_nil (sc);
+  s7_int len= 0;
+  if (!s7_is_vector (x) && !json_is_object (sc, x, len)) {
+    return json_type_error (sc, "Value is not a JSON object or array", x);
+  }
+  // 空对象 '(()) 原样返回（单层与多键均如此）
+  if (json_is_null_object (sc, x)) return x;
+  s7_pointer rest= s7_cdr (kargs);
+  json_reducer r;
+  if (s7_is_null (sc, s7_cdr (rest))) {
+    // 单层：(key proc)
+    r.p         = s7_car (rest);
+    r.is_reduce = false;
+    r.reduce_args= NULL;
+  }
+  else {
+    // 多键：(key k2 ... proc)
+    r.p         = NULL;
+    r.is_reduce = true;
+    r.reduce_args= rest;
+  }
+  return json_guenchi_reduce (sc, x, s7_car (kargs), r, len);
+}
+
+static s7_pointer
+f_json_reduce (s7_scheme* sc, s7_pointer args) {
+  if (s7_is_null (sc, s7_cdr (s7_cdr (args)))) {
+    return s7_error (sc, s7_make_symbol (sc, "value-error"),
+                     s7_list (sc, 1, s7_make_string (sc, "json-reduce: missing arguments")));
+  }
+  return json_reduce_dispatch (sc, s7_car (args), s7_cdr (args));
+}
+
+static void
+glue_json_reduce (s7_scheme* sc) {
+  const char* name= "g_json_reduce";
+  const char* desc=
+      "(g_json_reduce json key proc . keys) => data, transform values in Scheme-form JSON data by key path";
+  s7_define_function (sc, name, f_json_reduce, 2, 0, true, desc);
+}
+
 void
 glue_liii_json (s7_scheme* sc) {
   glue_json_to_string (sc);
@@ -1192,6 +1327,7 @@ glue_liii_json (s7_scheme* sc) {
   glue_json_set (sc);
   glue_json_push (sc);
   glue_json_drop (sc);
+  glue_json_reduce (sc);
 }
 
 } // namespace goldfish

--- a/tests/liii/json/json-drop-test.scm
+++ b/tests/liii/json/json-drop-test.scm
@@ -111,6 +111,47 @@
   (check j1 => #())
 ) ;let*
 
+;; 边界用例（0129 json-drop 迁移 C++ 前锁定语义）
+
+;; 全部删空的对象退化为 '()（历史行为）
+(let* ((j0 '((a . 1))) (j1 (json-drop j0 'a)))
+  (check j1 => '())
+) ;let*
+
+;; 空对象 '(()) 单键原样返回
+(let ((j0 '(())))
+  (check (json-drop j0 'a) => '(()))
+) ;let
+
+;; 空对象 '(()) 多键原样返回
+(let ((j0 '(())))
+  (check (json-drop j0 'a 'b) => '(()))
+) ;let
+
+;; 非空数组按索引删除
+(let* ((j0 #(10 20 30)) (j1 (json-drop j0 1)))
+  (check j1 => #(10 30))
+) ;let*
+
+;; 非空数组按索引谓词删除
+(let* ((j0 #(10 20 30 40)) (j1 (json-drop j0 (lambda (k) (even? k)))))
+  (check j1 => #(20 40))
+) ;let*
+
+;; 多键路径中间键不存在时静默不生效
+(let* ((j0 '((a . 1) (b . 2))) (j1 (json-drop j0 'not-exist 'x)))
+  (check j1 => j0)
+) ;let*
+
+;; 多键路径叶层为标量时抛 type-error
+(check-catch 'type-error (json-drop '((a . 1)) 'a 'b))
+
+;; 不可变性：原对象不被修改
+(let* ((j0 '((a . 1) (b . 2))) (j1 (json-drop j0 'a)))
+  (check j0 => '((a . 1) (b . 2)))
+  (check j1 => '((b . 2)))
+) ;let*
+
 (check-catch 'type-error (json-drop "not-a-json" 'key))
 (check-catch 'type-error (json-drop 123 'key))
 

--- a/tests/liii/json/json-reduce-test.scm
+++ b/tests/liii/json/json-reduce-test.scm
@@ -151,6 +151,52 @@
 ) ;let
 
 
+;; 边界用例（0129 json-reduce 迁移 C++ 前锁定语义）
+
+;; 数组按索引转换（p 收到索引和值两个参数）
+(let* ((j0 #(10 20 30)) (j1 (json-reduce j0 1 (lambda (k v) (* v 10)))))
+  (check j1 => #(10 200 30))
+) ;let*
+
+;; 数组谓词键
+(let* ((j0 #(10 20 30 40))
+       (j1 (json-reduce j0 (lambda (k) (odd? k)) (lambda (k v) (* v 100))))
+      ) ;
+  (check j1 => #(10 2000 30 4000))
+) ;let*
+
+;; 数组 #t 键：全映射，p 收到索引和值两个参数
+(let* ((j0 #(1 2 3)) (j1 (json-reduce j0 #t (lambda (k v) (* v 10)))))
+  (check j1 => #(10 20 30))
+) ;let*
+
+;; 数组 #f 键：历史怪癖，(list->vector x) 抛 wrong-type-arg（与 json-set 的 #f 键一致）
+(check-catch 'wrong-type-arg (json-reduce #(1 2 3) #f (lambda (k v) v)))
+
+;; 对象 #f 键原样返回
+(let* ((j0 '((a . 1))))
+  (check (json-reduce j0 #f (lambda (k v) 99)) => '((a . 1)))
+) ;let*
+
+;; 多键路径首键不存在时原样返回
+(let* ((j0 '((a . 1))) (j1 (json-reduce j0 'not-exist 'x (lambda (k v) v))))
+  (check j1 => '((a . 1)))
+) ;let*
+
+;; 空对象 '(()) 原样返回
+(let ((j0 '(())))
+  (check (json-reduce j0 'a (lambda (k v) v)) => '(()))
+) ;let
+
+;; 不可变性：原对象不被修改
+(let* ((j0 '((a . 1) (b . 2))) (j1 (json-reduce j0 'a (lambda (k v) (+ v 1)))))
+  (check j0 => '((a . 1) (b . 2)))
+  (check j1 => '((a . 2) (b . 2)))
+) ;let*
+
+;; 缺少转换函数时 value-error
+(check-catch 'value-error (json-reduce '((a . 1)) 'a))
+
 (check-catch 'type-error (json-reduce "not-a-json" 'key (lambda (k v) v)))
 (check-catch 'type-error (json-reduce 123 'key (lambda (k v) v)))
 


### PR DESCRIPTION
## 概述

延续 0129 任务（json-push 迁移 C++），本 PR 将 (liii json) 剩余两个核心操作迁移到 C++ 实现，并完成 (guenchi json) 历史接口清理。

## 改动

- `src/liii_json.cpp` 新增 `g_json_drop` 与 `g_json_reduce`（变参多键路径），完整复刻历史 Scheme 语义：
  - json-drop：对象删除键匹配/谓词命中的条目；数组按键（索引）删除；多键路径经 json-set 单层语义逐层下钻
  - json-reduce：键 #t 全映射、谓词键、equal? 键；命中条目新值 = (proc key old-value)；#f 键历史怪癖原样保留
- `(liii json)` 的 `json-drop`/`json-reduce` 直接绑定 C++ 实现，删除 Scheme 包装
- `(guenchi json)` 移除 json-drop/json-drop*/json-reduce* 的定义与导出（json-reduce* 为无使用者的独立接口，直接删除）
- `tests/liii/json/json-drop-test.scm` / `json-reduce-test.scm` 新增边界用例（TDD：先在旧实现上通过锁定语义）
- `bench/json-ref-set-perf.scm` 新增 drop/reduce 的 C++/Scheme 对比项与 sanity check

## 性能（500 次迭代）

| 场景 | 加速比 |
|---|---|
| 对象单键删除 | ~2.3x |
| 数组索引删除 | ~12x |
| 多键路径删除 | ~2.7x |
| 对象单键转换 | ~3x |
| 数组全映射转换 | ~2.2x |
| 多键路径转换 | ~8.6x |

## 测试

- [x] `bin/gf tests/liii/json/` 全部 20 个测试文件通过
- [x] `bin/gf bench/json-ref-set-perf.scm` sanity check 通过
- [x] `bin/gf fmt` 已格式化

🤖 Generated with [Claude Code](https://claude.com/claude-code)