### PR TITLE
[0132] 将 vector 优化器特化函数从 s7.c 迁移到 s7_liii_vector.c

### DIFF
--- a/devel/0132.md
+++ b/devel/0132.md
@@ -1,0 +1,52 @@
+# [0132] 将 vector 优化器特化函数从 s7.c 迁移到 s7_liii_vector.c
+
+## 任务相关的代码文件
+- src/s7.c
+- src/s7_liii_vector.c
+- src/s7_liii_vector.h
+- src/s7_internal_helpers.h
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf tests/scheme/base/vector-append-test.scm
+bin/gf tests/scheme/base/vector-ref-test.scm
+bin/gf tests/scheme/base/vector-set-bang-test.scm
+bin/gf tests/scheme/base/vector-to-list-test.scm
+# 以及 tests/ 下整体回归
+```
+
+## 2026-08-19 迁移核心 vector _p_p 特化函数
+
+### What
+1. 将 s7.c 中 19 个（无类型）vector 优化器特化函数迁移到 `src/s7_liii_vector.c`：
+   - `vector_append_p_pp`、`vector_append_p_ppp`
+   - `vector_to_list_p_p`
+   - `vector_ref_p_pi`、`vector_ref_p_pi_unchecked`、`t_vector_ref_p_pi_unchecked`、
+     `vector_ref_p_pii`、`vector_ref_p_pii_direct`、`t_vector_ref_p_pi_direct`
+   - `vector_set_p_pip`、`vector_set_p_pip_unchecked`、`vector_set_p_piip`、
+     `vector_set_p_piip_direct`、`typed_vector_set_p_pip_unchecked`、
+     `typed_vector_set_p_piip_direct`、`t_vector_set_p_pip_direct`、
+     `typed_t_vector_set_p_pip_direct`、`vector_set_p_ppp`
+   - `byte_vector_ref_p_pi_direct`、`byte_vector_set_p_pip_direct`
+2. complex/float/int vector 的 _p_p 家族因依赖 `univect_ref/set`、`c_complex_to_s7`
+   等深层纠缠，本次未迁，留待后续任务。
+
+### Why
+延续 0130/0131 的 s7.c 拆分：vector _p_p 群与 s7_liii_vector.c 已有的
+g_vector_ref/g_vector_set 等主题一致。
+
+### How
+- 被优化器按函数指针比较的函数保持 extern 单一定义。
+- vector 内部结构访问宏（`vector_element`、`vector_getter/setter`、
+  `vector_offset`、`is_any/t/typed_vector`、`is_immutable_vector`、
+  `byte_vector`、`small_int` 等）通过新增 s7i_ 桥接函数访问：
+  `s7i_vector_element(_set)`、`s7i_vector_getter_ref`、`s7i_vector_setter_set`、
+  `s7i_typed_vector_setter`、`s7i_vector_offset`、`s7i_small_int`、
+  `s7i_byte_vector_element(_set)` 等。
+- `vector_append_p_pp/_ppp` 的 temp7 gc-temp 逻辑整体留在 s7.c 桥接
+  （`s7i_vector_append_2/3`）中，迁移侧仅一行转发。
+- `immutable_object_error_nr`（原本已非 static）与 `immutable_error_string`
+  常量经 helpers/extern 共享。
+- 宏依赖替换：`vector_length/rank/dimension` → 公有 `s7_vector_length/rank/dimension`；
+  `make_integer_unchecked` → `s7_make_integer`（仅错误/回退路径）。

--- a/src/s7.c
+++ b/src/s7.c
@@ -27886,25 +27886,7 @@ static s7_pointer g_vector_append(s7_scheme *sc, s7_pointer args)
   return(s7i_vector_append(sc, args, type(car(args)), sc->vector_append_symbol));
 }
 
-static s7_pointer vector_append_p_pp(s7_scheme *sc, s7_pointer v1, s7_pointer v2)
-{
-  s7_pointer val;
-  sc->temp7 = list_2(sc, v1, v2); /* ideally this list would be gc_protected, avoiding temp7 (method call above) */
-  val = g_vector_append(sc, sc->temp7);
-  if ((S7_DEBUGGING) && (!is_pair(sc->temp7))) fprintf(stderr, "%s[%d]: temp7: %s\n", __func__, __LINE__, display(sc->temp7));
-  sc->temp7 = sc->unused;
-  return(val);
-}
-
-static s7_pointer vector_append_p_ppp(s7_scheme *sc, s7_pointer v1, s7_pointer v2, s7_pointer v3)
-{
-  s7_pointer val;
-  sc->temp7 = list_3(sc, v1, v2, v3);
-  val = g_vector_append(sc, sc->temp7);
-  if ((S7_DEBUGGING) && (!is_pair(sc->temp7))) fprintf(stderr, "%s[%d]: temp7: %s\n", __func__, __LINE__, display(sc->temp7));
-  sc->temp7 = sc->unused;
-  return(val);
-}
+/* vector_append_p_pp, vector_append_p_ppp migrated to s7_liii_vector.c */
 #endif
 
 
@@ -28120,12 +28102,7 @@ static s7_pointer g_vector_to_list(s7_scheme *sc, s7_pointer args)
   return_with_end_temp(sc->temp6);
 }
 
-static s7_pointer vector_to_list_p_p(s7_scheme *sc, s7_pointer vec)
-{
-  if (!is_any_vector(vec))
-    return(method_or_bust_p(sc, vec, sc->vector_to_list_symbol, sc->type_names[T_VECTOR]));
-  return(s7_vector_to_list(sc, vec));
-}
+/* vector_to_list_p_p migrated to s7_liii_vector.c */
 #endif
 
 
@@ -28437,48 +28414,9 @@ s7_pointer s7i_vector_ref_1(s7_scheme *sc, s7_pointer vect, s7_pointer indices)
 
 /* g_vector_ref is now defined in s7_liii_vector.c */
 
-static s7_pointer vector_ref_p_pi(s7_scheme *sc, s7_pointer vec, s7_int index)
-{
-  if ((!is_t_vector(vec)) ||
-      (vector_rank(vec) > 1) ||
-      (index < 0) || (index >= vector_length(vec)))
-    return(g_vector_ref(sc, set_plist_2(sc, vec, make_integer(sc, index))));
-  return(vector_element(vec, index));
-}
-
-static s7_pointer vector_ref_p_pi_unchecked(s7_scheme *sc, s7_pointer vec, s7_int index) /* callable but just barely (tgsl.scm) */
-{
-  if ((index < 0) || (index >= vector_length(vec)))
-    out_of_range_error_nr(sc, sc->vector_ref_symbol, int_two, wrap_integer(sc, index), (index < 0) ? it_is_negative_string : it_is_too_large_string);
-  return(vector_getter(vec)(sc, vec, index));
-}
-
-static s7_pointer t_vector_ref_p_pi_unchecked(s7_scheme *sc, s7_pointer vec, s7_int index)
-{
-  if ((index < 0) || (index >= vector_length(vec)))
-    out_of_range_error_nr(sc, sc->vector_ref_symbol, int_two, wrap_integer(sc, index), (index < 0) ? it_is_negative_string : it_is_too_large_string);
-  return(vector_element(vec, index));
-}
-
-static s7_pointer vector_ref_p_pii(s7_scheme *sc, s7_pointer vec, s7_int i1, s7_int i2)
-{
-  if ((!is_any_vector(vec)) ||
-      (vector_rank(vec) != 2) ||
-      (i1 < 0) || (i2 < 0) ||
-      (i1 >= vector_dimension(vec, 0)) || (i2 >= vector_dimension(vec, 1)))
-    return(g_vector_ref(sc, set_plist_3(sc, vec, make_integer(sc, i1), make_integer_unchecked(sc, i2))));
-  return(vector_getter(vec)(sc, vec, i2 + (i1 * vector_offset(vec, 0))));
-}
-
-static s7_pointer vector_ref_p_pii_direct(s7_scheme *sc, s7_pointer vec, s7_int i1, s7_int i2)
-{
-  if ((i1 < 0) || (i2 < 0) ||
-      (i1 >= vector_dimension(vec, 0)) || (i2 >= vector_dimension(vec, 1)))
-    return(g_vector_ref(sc, set_plist_3(sc, vec, make_integer(sc, i1), make_integer_unchecked(sc, i2))));
-  return(vector_element(vec, i2 + (i1 * vector_offset(vec, 0))));
-}
-
-static s7_pointer t_vector_ref_p_pi_direct(s7_scheme *unused_sc, s7_pointer vec, s7_int index) {return(vector_element(vec, index));}
+/* vector_ref_p_pi, vector_ref_p_pi_unchecked, t_vector_ref_p_pi_unchecked,
+   vector_ref_p_pii, vector_ref_p_pii_direct, t_vector_ref_p_pi_direct
+   migrated to s7_liii_vector.c */
 
 s7_pointer s7i_vector_ref_p_pp(s7_scheme *sc, s7_pointer vec, s7_pointer ind)
 {
@@ -28494,6 +28432,40 @@ s7_pointer s7i_vector_ref_p_pp(s7_scheme *sc, s7_pointer vec, s7_pointer ind)
 }
 
 /* g_vector_ref_2 is now defined in s7_liii_vector.c */
+
+/* -------- s7i_ bridges for vector p_p migration to s7_liii_vector.c -------- */
+static s7_pointer g_vector_set(s7_scheme *sc, s7_pointer args);
+bool s7i_is_any_vector(s7_pointer p) {return(is_any_vector(p));}
+bool s7i_is_t_vector(s7_pointer p) {return(is_t_vector(p));}
+bool s7i_is_typed_vector(s7_pointer p) {return(is_typed_vector(p));}
+bool s7i_is_immutable_vector(s7_pointer p) {return(is_immutable_vector(p));}
+s7_pointer s7i_vector_element(s7_pointer p, s7_int i) {return(vector_element(p, i));}
+void s7i_vector_element_set(s7_pointer p, s7_int i, s7_pointer v) {vector_element(p, i) = v;}
+s7_pointer s7i_vector_getter_ref(s7_scheme *sc, s7_pointer p, s7_int i) {return(vector_getter(p)(sc, p, i));}
+s7_pointer s7i_vector_setter_set(s7_scheme *sc, s7_pointer p, s7_int i, s7_pointer v) {vector_setter(p)(sc, p, i, v);}
+s7_pointer s7i_typed_vector_setter(s7_scheme *sc, s7_pointer p, s7_int i, s7_pointer v) {return(typed_vector_setter(sc, p, i, v));}
+s7_int s7i_vector_offset(s7_pointer p, s7_int i) {return(vector_offset(p, i));}
+s7_pointer s7i_small_int(s7_int val) {return(small_int(val));}
+uint8_t s7i_byte_vector_element(s7_pointer p, s7_int i) {return(byte_vector(p, i));}
+void s7i_byte_vector_element_set(s7_pointer p, s7_int i, uint8_t v) {byte_vector(p, i) = v;}
+s7_pointer s7i_g_vector_set(s7_scheme *sc, s7_pointer plist) {return(g_vector_set(sc, plist));}
+s7_pointer s7i_set_plist_4(s7_scheme *sc, s7_pointer x1, s7_pointer x2, s7_pointer x3, s7_pointer x4) {return(set_plist_4(sc, x1, x2, x3, x4));}
+s7_pointer s7i_vector_append_2(s7_scheme *sc, s7_pointer v1, s7_pointer v2)
+{
+  s7_pointer val;
+  sc->temp7 = list_2(sc, v1, v2); /* ideally this list would be gc_protected, avoiding temp7 (method call above) */
+  val = g_vector_append(sc, sc->temp7);
+  sc->temp7 = sc->unused;
+  return(val);
+}
+s7_pointer s7i_vector_append_3(s7_scheme *sc, s7_pointer v1, s7_pointer v2, s7_pointer v3)
+{
+  s7_pointer val;
+  sc->temp7 = list_3(sc, v1, v2, v3);
+  val = g_vector_append(sc, sc->temp7);
+  sc->temp7 = sc->unused;
+  return(val);
+}
 
 static s7_pointer g_vector_ref_3(s7_scheme *sc, s7_pointer args)
 {
@@ -28598,77 +28570,10 @@ static s7_pointer g_vector_set(s7_scheme *sc, s7_pointer args)
   return(val);
 }
 
-static s7_pointer vector_set_p_pip(s7_scheme *sc, s7_pointer vec, s7_int index, s7_pointer value) /* almost never called -- see one case in s7test.scm[13736] */
-{
-  if ((!is_any_vector(vec)) || (vector_rank(vec) > 1) || (index < 0) || (index >= vector_length(vec)))
-    return(g_vector_set(sc, set_plist_3(sc, vec, make_integer(sc, index), value)));
-  if (is_t_vector(vec))
-    {
-      if (is_typed_vector(vec)) return(typed_vector_setter(sc, vec, index, value));
-      vector_element(vec, index) = value;
-    }
-  else vector_setter(vec)(sc, vec, index, value);
-  return(value);
-}
-
-static s7_pointer vector_set_p_pip_unchecked(s7_scheme *sc, s7_pointer vec, s7_int index, s7_pointer value)
-{
-  if ((index >= 0) && (index < vector_length(vec)))
-    vector_element(vec, index) = value;
-  else out_of_range_error_nr(sc, sc->vector_set_symbol, int_two, wrap_integer(sc, index), (index < 0) ? it_is_negative_string : it_is_too_large_string);
-  return(value);
-}
-
-static s7_pointer vector_set_p_piip(s7_scheme *sc, s7_pointer vec, s7_int i1, s7_int i2, s7_pointer value)
-{
-  if ((!is_any_vector(vec)) ||
-      (vector_rank(vec) != 2) ||
-      (i1 < 0) || (i2 < 0) ||
-      (i1 >= vector_dimension(vec, 0)) || (i2 >= vector_dimension(vec, 1)))
-    return(g_vector_set(sc, set_plist_4(sc, vec, make_integer(sc, i1), make_integer_unchecked(sc, i2), value)));
-  if (is_t_vector(vec))
-    {
-      if (is_typed_vector(vec))
-	return(typed_vector_setter(sc, vec, i2 + (i1 * vector_offset(vec, 0)), value));
-      vector_element(vec, i2 + (i1 * vector_offset(vec, 0))) = value;
-    }
-  else vector_setter(vec)(sc, vec, i2 + (i1 * vector_offset(vec, 0)), value);
-  return(value);
-}
-
-static s7_pointer vector_set_p_piip_direct(s7_scheme *sc, s7_pointer vec, s7_int i1, s7_int i2, s7_pointer value)
-{
-  /* normal untyped vector, rank == 2 */
-  if ((i1 < 0) || (i2 < 0) ||
-      (i1 >= vector_dimension(vec, 0)) || (i2 >= vector_dimension(vec, 1)))
-    return(g_vector_set(sc, set_plist_4(sc, vec, make_integer(sc, i1), make_integer_unchecked(sc, i2), value)));
-  vector_element(vec, i2 + (i1 * vector_offset(vec, 0))) = value;
-  return(value);
-}
-
-static s7_pointer typed_vector_set_p_pip_unchecked(s7_scheme *sc, s7_pointer vec, s7_int index, s7_pointer value)
-{
-  if ((index >= 0) && (index < vector_length(vec)))
-    typed_vector_setter(sc, vec, index, value);
-  else out_of_range_error_nr(sc, sc->vector_set_symbol, int_two, wrap_integer(sc, index), (index < 0) ? it_is_negative_string : it_is_too_large_string);
-  return(value);
-}
-
-static s7_pointer typed_vector_set_p_piip_direct(s7_scheme *sc, s7_pointer vec, s7_int i1, s7_int i2, s7_pointer value)
-{
-  if ((i1 < 0) || (i2 < 0) ||
-      (i1 >= vector_dimension(vec, 0)) || (i2 >= vector_dimension(vec, 1)))
-    return(g_vector_set(sc, set_plist_4(sc, vec, make_integer(sc, i1), make_integer_unchecked(sc, i2), value)));
-  return(typed_vector_setter(sc, vec, i2 + (i1 * vector_offset(vec, 0)), value));
-}
-
-static s7_pointer t_vector_set_p_pip_direct(s7_scheme *unused_sc, s7_pointer vec, s7_int index, s7_pointer value) {vector_element(vec, index) = value; return(value);}
-
-static s7_pointer typed_t_vector_set_p_pip_direct(s7_scheme *sc, s7_pointer vec, s7_int index, s7_pointer value)
-{
-  typed_vector_setter(sc, vec, index, value);
-  return(value);
-}
+/* vector_set_p_pip, vector_set_p_pip_unchecked, vector_set_p_piip,
+   vector_set_p_piip_direct, typed_vector_set_p_pip_unchecked,
+   typed_vector_set_p_piip_direct, t_vector_set_p_pip_direct,
+   typed_t_vector_set_p_pip_direct migrated to s7_liii_vector.c */
 
 static s7_pointer g_vector_set_3(s7_scheme *sc, s7_pointer args)
 {
@@ -28701,27 +28606,7 @@ static s7_pointer g_vector_set_3(s7_scheme *sc, s7_pointer args)
   }
 }
 
-static s7_pointer vector_set_p_ppp(s7_scheme *sc, s7_pointer vec, s7_pointer ind, s7_pointer val)
-{
-  s7_int index;
-  /* if ((S7_DEBUGGING) && (is_mutable(ind)) && (is_t_integer(ind))) ind = make_integer(sc, integer(ind)); */
-  /* if ((S7_DEBUGGING) && (is_mutable(ind)) && (is_t_integer(ind))) fprintf(stderr, "%s[%d]: skipping make-integer\n", __func__, __LINE__); */
-
-  if ((!is_t_vector(vec)) || (vector_rank(vec) > 1))
-    return(g_vector_set(sc, set_plist_3(sc, vec, ind, val)));
-  if (is_immutable_vector(vec))
-    immutable_object_error_nr(sc, set_elist_3(sc, immutable_error_string, sc->vector_set_symbol, vec));
-  if (!s7_is_integer(ind))
-    return(g_vector_set(sc, set_plist_3(sc, vec, ind, val)));
-  index = s7_integer_clamped_if_gmp(sc, ind);
-  if ((index < 0) || (index >= vector_length(vec)))
-    out_of_range_error_nr(sc, sc->vector_set_symbol, int_two, wrap_integer(sc, index), (index < 0) ? it_is_negative_string : it_is_too_large_string);
-
-  if (is_typed_vector(vec))
-    return(typed_vector_setter(sc, vec, index, val));
-  vector_element(vec, index) = val;
-  return(val);
-}
+/* vector_set_p_ppp migrated to s7_liii_vector.c */
 
 static s7_pointer g_vector_set_4(s7_scheme *sc, s7_pointer args)
 {
@@ -30202,7 +30087,7 @@ static s7_int byte_vector_ref_i_7pii(s7_scheme *sc, s7_pointer vec, s7_int index
   return((s7_int)byte_vector(vec, index2 + (index1 * vector_offset(vec, 0))));
 }
 
-static s7_pointer byte_vector_ref_p_pi_direct(s7_scheme *unused_sc, s7_pointer vec, s7_int index) {return(small_int((byte_vector(vec, index))));}
+/* byte_vector_ref_p_pi_direct migrated to s7_liii_vector.c */
 static s7_int byte_vector_ref_i_7pi_direct(s7_scheme *unused_sc, s7_pointer vec, s7_int index)    {return(byte_vector(vec, index));}
 
 static s7_pointer g_bv_ref_2(s7_scheme *sc, s7_pointer args)
@@ -30280,11 +30165,7 @@ static s7_int byte_vector_set_i_7pii_direct(s7_scheme *unused_sc, s7_pointer vec
   return(byte);
 }
 
-static s7_pointer byte_vector_set_p_pip_direct(s7_scheme *unused_sc, s7_pointer vec, s7_int index, s7_pointer byte)
-{
-  byte_vector(vec, index) = (uint8_t)s7_integer(byte);
-  return(byte);
-}
+/* byte_vector_set_p_pip_direct migrated to s7_liii_vector.c */
 
 static s7_int byte_vector_set_i_7piii(s7_scheme *sc, s7_pointer vec, s7_int index1, s7_int index2, s7_int byte)
 {

--- a/src/s7_internal_helpers.h
+++ b/src/s7_internal_helpers.h
@@ -112,6 +112,26 @@ s7_pointer s7i_character_type_name(s7_scheme *sc);
 no_return void out_of_range_error_nr(s7_scheme *sc, s7_pointer caller, s7_pointer arg_n, s7_pointer arg, s7_pointer descr);
 void s7i_check_free_heap_size(s7_scheme *sc, s7_int size);
 s7_pointer cons_unchecked(s7_scheme *sc, s7_pointer a, s7_pointer b);
+no_return void immutable_object_error_nr(s7_scheme *sc, s7_pointer info);
+
+/* vector bridges for s7_liii_vector.c migration */
+bool s7i_is_any_vector(s7_pointer p);
+bool s7i_is_t_vector(s7_pointer p);
+bool s7i_is_typed_vector(s7_pointer p);
+bool s7i_is_immutable_vector(s7_pointer p);
+s7_pointer s7i_vector_element(s7_pointer p, s7_int i);
+void s7i_vector_element_set(s7_pointer p, s7_int i, s7_pointer v);
+s7_pointer s7i_vector_getter_ref(s7_scheme *sc, s7_pointer p, s7_int i);
+s7_pointer s7i_vector_setter_set(s7_scheme *sc, s7_pointer p, s7_int i, s7_pointer v);
+s7_pointer s7i_typed_vector_setter(s7_scheme *sc, s7_pointer p, s7_int i, s7_pointer v);
+s7_int s7i_vector_offset(s7_pointer p, s7_int i);
+s7_pointer s7i_small_int(s7_int val);
+uint8_t s7i_byte_vector_element(s7_pointer p, s7_int i);
+void s7i_byte_vector_element_set(s7_pointer p, s7_int i, uint8_t v);
+s7_pointer s7i_g_vector_set(s7_scheme *sc, s7_pointer plist);
+s7_pointer s7i_set_plist_4(s7_scheme *sc, s7_pointer x1, s7_pointer x2, s7_pointer x3, s7_pointer x4);
+s7_pointer s7i_vector_append_2(s7_scheme *sc, s7_pointer v1, s7_pointer v2);
+s7_pointer s7i_vector_append_3(s7_scheme *sc, s7_pointer v1, s7_pointer v2, s7_pointer v3);
 s7_pointer s7i_string_eq_symbol(s7_scheme *sc);
 s7_pointer s7i_string_lt_symbol(s7_scheme *sc);
 s7_pointer s7i_string_gt_symbol(s7_scheme *sc);

--- a/src/s7_liii_vector.c
+++ b/src/s7_liii_vector.c
@@ -10,6 +10,9 @@
 #include "s7_internal_helpers.h"
 #include <string.h>
 
+/* Externally defined in s7.c - permanent error description strings */
+extern s7_pointer it_is_negative_string, it_is_too_large_string, it_is_too_small_string, immutable_error_string;
+
 #ifndef WITH_PURE_S7
 #define WITH_PURE_S7 0
 s7_pointer g_make_vector(s7_scheme *sc, s7_pointer args)
@@ -411,6 +414,183 @@ s7_pointer vector_length_p_p(s7_scheme *sc, s7_pointer vec)
   if (!s7_is_vector(vec))
     return(s7i_method_or_bust_p(sc, vec, "vector-length", "a vector"));
   return(s7_make_integer(sc, s7_vector_length(vec)));
+}
+
+/* -------- optimizer typed-arg (p_p) functions, migrated from s7.c -------- */
+
+/* the optimizer compares these function pointers directly
+   (e.g. q_func(opc).p_pi_f == vector_ref_p_pi_unchecked), so each must
+   have a single extern definition in this compilation unit */
+
+s7_pointer vector_append_p_pp(s7_scheme *sc, s7_pointer v1, s7_pointer v2)
+{
+  return(s7i_vector_append_2(sc, v1, v2));
+}
+
+s7_pointer vector_append_p_ppp(s7_scheme *sc, s7_pointer v1, s7_pointer v2, s7_pointer v3)
+{
+  return(s7i_vector_append_3(sc, v1, v2, v3));
+}
+
+s7_pointer vector_to_list_p_p(s7_scheme *sc, s7_pointer vec)
+{
+  if (!s7i_is_any_vector(vec))
+    return(s7i_method_or_bust_p(sc, vec, "vector->list", "vector"));
+  return(s7_vector_to_list(sc, vec));
+}
+
+s7_pointer vector_ref_p_pi(s7_scheme *sc, s7_pointer vec, s7_int index)
+{
+  if ((!s7i_is_t_vector(vec)) ||
+      (s7_vector_rank(vec) > 1) ||
+      (index < 0) || (index >= s7_vector_length(vec)))
+    return(g_vector_ref(sc, s7i_set_plist_2(sc, vec, s7_make_integer(sc, index))));
+  return(s7i_vector_element(vec, index));
+}
+
+s7_pointer vector_ref_p_pi_unchecked(s7_scheme *sc, s7_pointer vec, s7_int index) /* callable but just barely (tgsl.scm) */
+{
+  if ((index < 0) || (index >= s7_vector_length(vec)))
+    out_of_range_error_nr(sc, s7_make_symbol(sc, "vector-ref"), s7i_wrap_integer(sc, 2), s7i_wrap_integer(sc, index),
+                          (index < 0) ? it_is_negative_string : it_is_too_large_string);
+  return(s7i_vector_getter_ref(sc, vec, index));
+}
+
+s7_pointer t_vector_ref_p_pi_unchecked(s7_scheme *sc, s7_pointer vec, s7_int index)
+{
+  if ((index < 0) || (index >= s7_vector_length(vec)))
+    out_of_range_error_nr(sc, s7_make_symbol(sc, "vector-ref"), s7i_wrap_integer(sc, 2), s7i_wrap_integer(sc, index),
+                          (index < 0) ? it_is_negative_string : it_is_too_large_string);
+  return(s7i_vector_element(vec, index));
+}
+
+s7_pointer vector_ref_p_pii(s7_scheme *sc, s7_pointer vec, s7_int i1, s7_int i2)
+{
+  if ((!s7i_is_any_vector(vec)) ||
+      (s7_vector_rank(vec) != 2) ||
+      (i1 < 0) || (i2 < 0) ||
+      (i1 >= s7_vector_dimension(vec, 0)) || (i2 >= s7_vector_dimension(vec, 1)))
+    return(g_vector_ref(sc, s7i_set_plist_3(sc, vec, s7_make_integer(sc, i1), s7_make_integer(sc, i2))));
+  return(s7i_vector_getter_ref(sc, vec, i2 + (i1 * s7i_vector_offset(vec, 0))));
+}
+
+s7_pointer vector_ref_p_pii_direct(s7_scheme *sc, s7_pointer vec, s7_int i1, s7_int i2)
+{
+  if ((i1 < 0) || (i2 < 0) ||
+      (i1 >= s7_vector_dimension(vec, 0)) || (i2 >= s7_vector_dimension(vec, 1)))
+    return(g_vector_ref(sc, s7i_set_plist_3(sc, vec, s7_make_integer(sc, i1), s7_make_integer(sc, i2))));
+  return(s7i_vector_element(vec, i2 + (i1 * s7i_vector_offset(vec, 0))));
+}
+
+s7_pointer t_vector_ref_p_pi_direct(s7_scheme *unused_sc, s7_pointer vec, s7_int index) {return(s7i_vector_element(vec, index));}
+
+s7_pointer vector_set_p_pip(s7_scheme *sc, s7_pointer vec, s7_int index, s7_pointer value) /* almost never called -- see one case in s7test.scm[13736] */
+{
+  if ((!s7i_is_any_vector(vec)) || (s7_vector_rank(vec) > 1) || (index < 0) || (index >= s7_vector_length(vec)))
+    return(s7i_g_vector_set(sc, s7i_set_plist_3(sc, vec, s7_make_integer(sc, index), value)));
+  if (s7i_is_t_vector(vec))
+    {
+      if (s7i_is_typed_vector(vec)) return(s7i_typed_vector_setter(sc, vec, index, value));
+      s7i_vector_element_set(vec, index, value);
+    }
+  else s7i_vector_setter_set(sc, vec, index, value);
+  return(value);
+}
+
+s7_pointer vector_set_p_pip_unchecked(s7_scheme *sc, s7_pointer vec, s7_int index, s7_pointer value)
+{
+  if ((index >= 0) && (index < s7_vector_length(vec)))
+    s7i_vector_element_set(vec, index, value);
+  else out_of_range_error_nr(sc, s7_make_symbol(sc, "vector-set!"), s7i_wrap_integer(sc, 2), s7i_wrap_integer(sc, index),
+                             (index < 0) ? it_is_negative_string : it_is_too_large_string);
+  return(value);
+}
+
+s7_pointer vector_set_p_piip(s7_scheme *sc, s7_pointer vec, s7_int i1, s7_int i2, s7_pointer value)
+{
+  if ((!s7i_is_any_vector(vec)) ||
+      (s7_vector_rank(vec) != 2) ||
+      (i1 < 0) || (i2 < 0) ||
+      (i1 >= s7_vector_dimension(vec, 0)) || (i2 >= s7_vector_dimension(vec, 1)))
+    return(s7i_g_vector_set(sc, s7i_set_plist_4(sc, vec, s7_make_integer(sc, i1), s7_make_integer(sc, i2), value)));
+  if (s7i_is_t_vector(vec))
+    {
+      if (s7i_is_typed_vector(vec))
+	return(s7i_typed_vector_setter(sc, vec, i2 + (i1 * s7i_vector_offset(vec, 0)), value));
+      s7i_vector_element_set(vec, i2 + (i1 * s7i_vector_offset(vec, 0)), value);
+    }
+  else s7i_vector_setter_set(sc, vec, i2 + (i1 * s7i_vector_offset(vec, 0)), value);
+  return(value);
+}
+
+s7_pointer vector_set_p_piip_direct(s7_scheme *sc, s7_pointer vec, s7_int i1, s7_int i2, s7_pointer value)
+{
+  /* normal untyped vector, rank == 2 */
+  if ((i1 < 0) || (i2 < 0) ||
+      (i1 >= s7_vector_dimension(vec, 0)) || (i2 >= s7_vector_dimension(vec, 1)))
+    return(s7i_g_vector_set(sc, s7i_set_plist_4(sc, vec, s7_make_integer(sc, i1), s7_make_integer(sc, i2), value)));
+  s7i_vector_element_set(vec, i2 + (i1 * s7i_vector_offset(vec, 0)), value);
+  return(value);
+}
+
+s7_pointer typed_vector_set_p_pip_unchecked(s7_scheme *sc, s7_pointer vec, s7_int index, s7_pointer value)
+{
+  if ((index >= 0) && (index < s7_vector_length(vec)))
+    s7i_typed_vector_setter(sc, vec, index, value);
+  else out_of_range_error_nr(sc, s7_make_symbol(sc, "vector-set!"), s7i_wrap_integer(sc, 2), s7i_wrap_integer(sc, index),
+                             (index < 0) ? it_is_negative_string : it_is_too_large_string);
+  return(value);
+}
+
+s7_pointer typed_vector_set_p_piip_direct(s7_scheme *sc, s7_pointer vec, s7_int i1, s7_int i2, s7_pointer value)
+{
+  if ((i1 < 0) || (i2 < 0) ||
+      (i1 >= s7_vector_dimension(vec, 0)) || (i2 >= s7_vector_dimension(vec, 1)))
+    return(s7i_g_vector_set(sc, s7i_set_plist_4(sc, vec, s7_make_integer(sc, i1), s7_make_integer(sc, i2), value)));
+  return(s7i_typed_vector_setter(sc, vec, i2 + (i1 * s7i_vector_offset(vec, 0)), value));
+}
+
+s7_pointer t_vector_set_p_pip_direct(s7_scheme *unused_sc, s7_pointer vec, s7_int index, s7_pointer value)
+{
+  s7i_vector_element_set(vec, index, value);
+  return(value);
+}
+
+s7_pointer typed_t_vector_set_p_pip_direct(s7_scheme *sc, s7_pointer vec, s7_int index, s7_pointer value)
+{
+  s7i_typed_vector_setter(sc, vec, index, value);
+  return(value);
+}
+
+s7_pointer vector_set_p_ppp(s7_scheme *sc, s7_pointer vec, s7_pointer ind, s7_pointer val)
+{
+  s7_int index;
+  if ((!s7i_is_t_vector(vec)) || (s7_vector_rank(vec) > 1))
+    return(s7i_g_vector_set(sc, s7i_set_plist_3(sc, vec, ind, val)));
+  if (s7i_is_immutable_vector(vec))
+    immutable_object_error_nr(sc, s7i_set_elist_3(sc, immutable_error_string, s7_make_symbol(sc, "vector-set!"), vec));
+  if (!s7_is_integer(ind))
+    return(s7i_g_vector_set(sc, s7i_set_plist_3(sc, vec, ind, val)));
+  index = s7i_integer_clamped_if_gmp(sc, ind);
+  if ((index < 0) || (index >= s7_vector_length(vec)))
+    out_of_range_error_nr(sc, s7_make_symbol(sc, "vector-set!"), s7i_wrap_integer(sc, 2), s7i_wrap_integer(sc, index),
+                          (index < 0) ? it_is_negative_string : it_is_too_large_string);
+
+  if (s7i_is_typed_vector(vec))
+    return(s7i_typed_vector_setter(sc, vec, index, val));
+  s7i_vector_element_set(vec, index, val);
+  return(val);
+}
+
+s7_pointer byte_vector_ref_p_pi_direct(s7_scheme *unused_sc, s7_pointer vec, s7_int index)
+{
+  return(s7i_small_int(s7i_byte_vector_element(vec, index)));
+}
+
+s7_pointer byte_vector_set_p_pip_direct(s7_scheme *unused_sc, s7_pointer vec, s7_int index, s7_pointer byte)
+{
+  s7i_byte_vector_element_set(vec, index, (uint8_t)s7_integer(byte));
+  return(byte);
 }
 
 #endif

--- a/src/s7_liii_vector.h
+++ b/src/s7_liii_vector.h
@@ -51,6 +51,30 @@ s7_pointer g_make_vector(s7_scheme *sc, s7_pointer args);
 s7_pointer g_vector_fill(s7_scheme *sc, s7_pointer args);
 s7_int vector_length_i_7p(s7_scheme *sc, s7_pointer vec);
 s7_pointer vector_length_p_p(s7_scheme *sc, s7_pointer vec);
+
+/* optimizer typed-arg (p_p) functions, migrated from s7.c;
+   the optimizer compares these pointers, so each has a single
+   extern definition in s7_liii_vector.c */
+s7_pointer vector_append_p_pp(s7_scheme *sc, s7_pointer v1, s7_pointer v2);
+s7_pointer vector_append_p_ppp(s7_scheme *sc, s7_pointer v1, s7_pointer v2, s7_pointer v3);
+s7_pointer vector_to_list_p_p(s7_scheme *sc, s7_pointer vec);
+s7_pointer vector_ref_p_pi(s7_scheme *sc, s7_pointer vec, s7_int index);
+s7_pointer vector_ref_p_pi_unchecked(s7_scheme *sc, s7_pointer vec, s7_int index);
+s7_pointer t_vector_ref_p_pi_unchecked(s7_scheme *sc, s7_pointer vec, s7_int index);
+s7_pointer vector_ref_p_pii(s7_scheme *sc, s7_pointer vec, s7_int i1, s7_int i2);
+s7_pointer vector_ref_p_pii_direct(s7_scheme *sc, s7_pointer vec, s7_int i1, s7_int i2);
+s7_pointer t_vector_ref_p_pi_direct(s7_scheme *sc, s7_pointer vec, s7_int index);
+s7_pointer vector_set_p_pip(s7_scheme *sc, s7_pointer vec, s7_int index, s7_pointer value);
+s7_pointer vector_set_p_pip_unchecked(s7_scheme *sc, s7_pointer vec, s7_int index, s7_pointer value);
+s7_pointer vector_set_p_piip(s7_scheme *sc, s7_pointer vec, s7_int i1, s7_int i2, s7_pointer value);
+s7_pointer vector_set_p_piip_direct(s7_scheme *sc, s7_pointer vec, s7_int i1, s7_int i2, s7_pointer value);
+s7_pointer typed_vector_set_p_pip_unchecked(s7_scheme *sc, s7_pointer vec, s7_int index, s7_pointer value);
+s7_pointer typed_vector_set_p_piip_direct(s7_scheme *sc, s7_pointer vec, s7_int i1, s7_int i2, s7_pointer value);
+s7_pointer t_vector_set_p_pip_direct(s7_scheme *sc, s7_pointer vec, s7_int index, s7_pointer value);
+s7_pointer typed_t_vector_set_p_pip_direct(s7_scheme *sc, s7_pointer vec, s7_int index, s7_pointer value);
+s7_pointer vector_set_p_ppp(s7_scheme *sc, s7_pointer vec, s7_pointer ind, s7_pointer val);
+s7_pointer byte_vector_ref_p_pi_direct(s7_scheme *sc, s7_pointer vec, s7_int index);
+s7_pointer byte_vector_set_p_pip_direct(s7_scheme *sc, s7_pointer vec, s7_int index, s7_pointer byte);
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
## 概述

延续 0130/0131 的 s7.c 拆分，将 19 个无类型 vector 优化器特化函数迁移到 `src/s7_liii_vector.c`：

- `vector_append_p_pp / _ppp`、`vector_to_list_p_p`
- `vector_ref_p_pi / _pi_unchecked / _pii / _pii_direct`、`t_vector_ref_p_pi_unchecked / _direct`
- `vector_set_p_pip / _pip_unchecked / _piip / _piip_direct / _ppp`、`typed_vector_set_p_pip_unchecked / _piip_direct`、`t_vector_set_p_pip_direct`、`typed_t_vector_set_p_pip_direct`
- `byte_vector_ref_p_pi_direct`、`byte_vector_set_p_pip_direct`

complex/float/int vector 的 _p_p 家族依赖 `univect_ref/set`、`c_complex_to_s7` 等深层纠缠，本次未迁，留待后续任务。

## 要点

- 被优化器按函数指针比较的函数保持 extern 单一定义
- vector 内部结构访问宏通过新增 s7i_ 桥接访问（`s7i_vector_element(_set)`、`s7i_vector_getter_ref`、`s7i_vector_setter_set`、`s7i_typed_vector_setter`、`s7i_vector_offset`、`s7i_small_int`、`s7i_byte_vector_element(_set)` 等）
- `vector_append_p_pp/_ppp` 的 temp7 gc-temp 逻辑留在 s7.c 桥接中，迁移侧仅一行转发
- `vector_length/rank/dimension` 改用公有 API

## 测试

- `xmake b goldfish` 构建通过（含 rebase 到最新 main 后）
- vector/bytevector 相关测试全部通过
- 全量回归 1513 个测试文件，无新增失败

详见 `devel/0132.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)