### PR TITLE
[0135] Windows 上 load/read 使用整体读入快路径

### DIFF
--- a/bench/read-perf.scm
+++ b/bench/read-perf.scm
@@ -14,35 +14,34 @@
 ;; under the License.
 ;;
 
-(import (liii base) (liii timeit))
+(import (liii base)
+  (liii os)
+  (liii path)
+  (liii timeit)
+  (only (srfi srfi-13) string-suffix? string-contains)
+) ;import
 
-(define bench-file "bench/read-perf-data.scm")
+;; 递归收集目录下所有 .scm 文件
 
-;; 生成一个较大的测试文件：若干个 define 与列表/字符串/数字混合的 form
-
-(define (build-bench-file n)
-  (let ((out (open-output-string)))
-    (do ((i 0 (+ i 1)))
-      ((= i n))
-      (display "(define (bench-func-" out)
-      (display i out)
-      (display " x) ;; 函数注释 " out)
-      (display i out)
-      (newline out)
-      (display "  (let ((y (* x " out)
-      (display i out)
-      (display ")))" out)
-      (newline out)
-      (display "    (list y \"中文字符串测试\" #\\A 'sym #(1 2 3) 3.14)))" out)
-      (newline out)
-      (newline out)
-    ) ;do
-    (with-output-to-file bench-file (lambda () (display (get-output-string out))))
+(define (collect-scm-files dir)
+  (let loop
+    ((acc '()) (entries (vector->list (listdir dir))))
+    (if (null? entries)
+      acc
+      (let ((p (string-append dir (string (os-sep)) (car entries))))
+        (cond ((and (path-dir? p)
+                 (not (string-contains p (string-append (string (os-sep)) "resources")))
+               ) ;and
+               ;; 跳过 resources 目录：其中包含故意损坏的括号测试文件
+               (loop (append (collect-scm-files p) acc) (cdr entries))
+              ) ;
+              ((string-suffix? ".scm" (car entries)) (loop (cons p acc) (cdr entries)))
+              (else (loop acc (cdr entries)))
+        ) ;cond
+      ) ;let
+    ) ;if
   ) ;let
 ) ;define
-
-(define form-count 500)
-(build-bench-file form-count)
 
 (define (report title iterations time-val)
   (display "[")
@@ -56,42 +55,45 @@
 ) ;define
 
 (define (read-all-from-file file)
-  (let ((p (open-input-file file)))
-    (let loop
-      ()
-      (let ((x (read p)))
-        (if (eof-object? x) (begin (close-input-port p) 'done) (loop))
+  ;; 个别测试文件故意包含语法错误（括号不匹配、未闭合字符串等），读取出错时跳过
+  (catch #t
+    (lambda ()
+      (let ((p (open-input-file file)))
+        (let loop
+          ()
+          (let ((x (read p)))
+            (if (eof-object? x) (begin (close-input-port p) 'done) (loop))
+          ) ;let
+        ) ;let
       ) ;let
-    ) ;let
-  ) ;let
+    ) ;lambda
+    (lambda args 'skipped)
+  ) ;catch
+) ;define
+
+(define bench-dirs '("goldfish" "tests"))
+
+(define scm-files (apply append (map collect-scm-files bench-dirs)))
+
+(display "=== read 性能基准测试 ===")
+(newline)
+(display "文件: ")
+(display (length scm-files))
+(display " 个 .scm 文件 (goldfish/ + tests/)")
+(newline)
+(newline)
+
+(define (read-all-files)
+  (for-each read-all-from-file scm-files)
 ) ;define
 
 ;; warmup
-(do ((i 0 (+ i 1)))
-  ((= i 3))
-  (read-all-from-file bench-file)
-) ;do
+(read-all-files)
 
-(define read-iter 30)
+(define read-iter 10)
 
-(define load-iter 30)
-
-(display "=== read/load 性能基准测试 ===")
-(newline)
-(display "文件: ")
-(display bench-file)
-(display " (")
-(display form-count)
-(display " 个顶层 form)")
-(newline)
-(newline)
-
-(let ((t (timeit (lambda () (read-all-from-file bench-file)) '() read-iter)))
-  (report "读取文件(open-input-file+read)" read-iter t)
-) ;let
-
-(let ((t (timeit (lambda () (load bench-file)) '() load-iter)))
-  (report "加载文件(load)" load-iter t)
+(let ((t (timeit (lambda () (read-all-files)) '() read-iter)))
+  (report "读取全部文件(open-input-file+read)" read-iter t)
 ) ;let
 
 (newline)

--- a/bench/read-perf.scm
+++ b/bench/read-perf.scm
@@ -1,0 +1,99 @@
+;;
+;; Copyright (C) 2026 The Goldfish Scheme Authors
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+;; License for the specific language governing permissions and limitations
+;; under the License.
+;;
+
+(import (liii base) (liii timeit))
+
+(define bench-file "bench/read-perf-data.scm")
+
+;; 生成一个较大的测试文件：若干个 define 与列表/字符串/数字混合的 form
+
+(define (build-bench-file n)
+  (let ((out (open-output-string)))
+    (do ((i 0 (+ i 1)))
+      ((= i n))
+      (display "(define (bench-func-" out)
+      (display i out)
+      (display " x) ;; 函数注释 " out)
+      (display i out)
+      (newline out)
+      (display "  (let ((y (* x " out)
+      (display i out)
+      (display ")))" out)
+      (newline out)
+      (display "    (list y \"中文字符串测试\" #\\A 'sym #(1 2 3) 3.14)))" out)
+      (newline out)
+      (newline out)
+    ) ;do
+    (with-output-to-file bench-file (lambda () (display (get-output-string out))))
+  ) ;let
+) ;define
+
+(define form-count 500)
+(build-bench-file form-count)
+
+(define (report title iterations time-val)
+  (display "[")
+  (display title)
+  (display "] iterations=")
+  (display iterations)
+  (display " time=")
+  (display time-val)
+  (display "s")
+  (newline)
+) ;define
+
+(define (read-all-from-file file)
+  (let ((p (open-input-file file)))
+    (let loop
+      ()
+      (let ((x (read p)))
+        (if (eof-object? x) (begin (close-input-port p) 'done) (loop))
+      ) ;let
+    ) ;let
+  ) ;let
+) ;define
+
+;; warmup
+(do ((i 0 (+ i 1)))
+  ((= i 3))
+  (read-all-from-file bench-file)
+) ;do
+
+(define read-iter 30)
+
+(define load-iter 30)
+
+(display "=== read/load 性能基准测试 ===")
+(newline)
+(display "文件: ")
+(display bench-file)
+(display " (")
+(display form-count)
+(display " 个顶层 form)")
+(newline)
+(newline)
+
+(let ((t (timeit (lambda () (read-all-from-file bench-file)) '() read-iter)))
+  (report "读取文件(open-input-file+read)" read-iter t)
+) ;let
+
+(let ((t (timeit (lambda () (load bench-file)) '() load-iter)))
+  (report "加载文件(load)" load-iter t)
+) ;let
+
+(newline)
+(display "=== 测试完成 ===")
+(newline)

--- a/devel/0135.md
+++ b/devel/0135.md
@@ -28,7 +28,17 @@ load/open-input-file 最终都走 `read_file()`。非 Windows 平台会把整个
 - `size > 0 && (max_size < 0 || size < max_size)` 时一次 `fread` 读入，转 string port（`input_string_functions_1`），此逻辑全平台共用
 - MSVC 是唯一支持的 Windows 编译器（`MS_WINDOWS` 即 `_MSC_VER`）
 
-### 性能对比（bench/read-perf.scm，30 次迭代，500 个顶层 form）
+### 性能对比
+
+bench/read-perf.scm 会递归收集仓库 goldfish/ 与 tests/ 下全部 .scm 文件（跳过 resources 目录，个别故意包含语法错误的测试文件用 catch 跳过），对每个文件 open-input-file + read 到 EOF 计时。
+
+真实仓库文件（1618 个 .scm，10 次迭代）：
+
+| 基准 | 优化前 | 优化后 | 加速比 |
+|---|---|---|---|
+| 读取全部文件 | 3.568s | 2.335s | ~1.5x |
+
+合成大文件（500 个顶层 form，30 次迭代，旧版基准）：
 
 | 基准 | 优化前 | 优化后 | 加速比 |
 |---|---|---|---|

--- a/devel/0135.md
+++ b/devel/0135.md
@@ -1,0 +1,39 @@
+# [0135] 优化 Windows 上 load/read 的性能
+
+## 任务相关的代码文件
+- src/s7.c
+- bench/read-perf.scm
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf bench/read-perf.scm
+bin/gf tests/scheme/read/read-test.scm
+bin/gf tests/scheme/read-test.scm
+```
+
+## 2026-08-20 Windows 上启用整体读入快路径
+
+### What
+1. `read_file()`（src/s7.c）原来 `#if MS_WINDOWS` 分支无条件使用 file port + 逐字符 `fgetc` 慢路径；现在 Windows 也走与非 Windows 相同的整体读入 + string port 快路径
+2. Windows 下用 `_fseeki64`/`_ftelli64` 获取文件大小（`fseek`/`ftell` 在 MS C 上对大文件会截断）
+3. 修正短读警告：Windows 文本模式下 CRLF -> LF 转换会使 `fread` 返回的字节数小于文件大小，这是正常现象；只有在 `ferror` 或读到 0 字节时才输出警告
+4. 新增 `bench/read-perf.scm` 性能基准（自动生成 500 个顶层 form 的测试文件，用 (liii timeit) 计时）
+
+### Why
+load/open-input-file 最终都走 `read_file()`。非 Windows 平台会把整个文件一次读入内存转成 string port，reader 走大量指针级快路径（`terminated_string_read_white_space`、`string_read_name` 直接在 `port_data` 指针上扫描等）；而 Windows 分支因历史上 `fseek`/`ftell` 不可靠而退化为逐字符 `fgetc`，性能差距明显。本仓库开发环境是 Windows，一直运行在最慢路径上。
+
+### How
+- 取文件大小的平台差异保留在 `#if MS_WINDOWS` 中：MSVC 用 `_fseeki64`/`_ftelli64`，失败时 size 置 0 回退 file port 分支（兼容 pseudo file 等场景）
+- `size > 0 && (max_size < 0 || size < max_size)` 时一次 `fread` 读入，转 string port（`input_string_functions_1`），此逻辑全平台共用
+- MSVC 是唯一支持的 Windows 编译器（`MS_WINDOWS` 即 `_MSC_VER`）
+
+### 性能对比（bench/read-perf.scm，30 次迭代，500 个顶层 form）
+
+| 基准 | 优化前 | 优化后 | 加速比 |
+|---|---|---|---|
+| open-input-file + read | 0.0453s | 0.0150s | ~3.0x |
+| load | 0.0760s | 0.0457s | ~1.7x |
+
+### 回归测试
+- 全部 tests/ 下测试通过，唯 tests/srfi/srfi-78-200_12_2_test.scm 失败，但该测试在优化前的基线上以相同方式失败，是既有问题，与本次改动无关

--- a/src/s7.c
+++ b/src/s7.c
@@ -18486,9 +18486,7 @@ static port_functions_t input_string_functions_1 =
 static s7_pointer read_file(s7_scheme *sc, FILE *fp, const char *name, s7_int max_size, const char *caller)
 {
   s7_pointer port;
-#if !MS_WINDOWS
   s7_int size;
-#endif
   block_t *b = mallocate_port(sc);
   new_cell(sc, port, T_INPUT_PORT);
   gc_protect_via_stack(sc, port);
@@ -18502,11 +18500,17 @@ static s7_pointer read_file(s7_scheme *sc, FILE *fp, const char *name, s7_int ma
   port_file_number(port) = 0;
   add_input_port(sc, port);
 
-#if !MS_WINDOWS
-  /* this doesn't work in MS C */
+#if MS_WINDOWS
+  /* MS C's fseek/ftell truncate large files: use the 64-bit-safe variants */
+  if ((_fseeki64(fp, 0, SEEK_END) != 0) ||
+      ((size = _ftelli64(fp)) < 0))
+    size = 0;
+  rewind(fp);
+#else
   fseek(fp, 0, SEEK_END);
   size = ftell(fp);
   rewind(fp);
+#endif
   /* pseudo files (under /proc for example) have size=0, but we can read them, so don't assume a 0 length file is empty */
   if ((size > 0) &&   /* if (size != 0) we get (open-input-file "/dev/tty") -> (open "/dev/tty") read 0 bytes of an expected -1? */
       ((max_size < 0) || (size < max_size))) /* load uses max_size = -1 */
@@ -18516,11 +18520,15 @@ static s7_pointer read_file(s7_scheme *sc, FILE *fp, const char *name, s7_int ma
       const size_t bytes = fread(content, sizeof(uint8_t), size, fp);
       if (bytes != (size_t)size)
 	{
-	  if (current_output_port(sc) != sc->F)
+	  /* in MS Windows text mode, CRLF -> LF translation makes the read size smaller than the file size */
+	  if (ferror(fp) || (bytes == 0))
 	    {
-	      char tmp[256];
-	      int32_t len = snprintf(tmp, 256, "(%s \"%s\") read %ld bytes of an expected %" ld64 "?", caller, name, (long)bytes, size);
-	      port_write_string(current_output_port(sc))(sc, tmp, clamp_length(len, 256), current_output_port(sc));
+	      if (current_output_port(sc) != sc->F)
+		{
+		  char tmp[256];
+		  int32_t len = snprintf(tmp, 256, "(%s \"%s\") read %ld bytes of an expected %" ld64 "?", caller, name, (long)bytes, size);
+		  port_write_string(current_output_port(sc))(sc, tmp, clamp_length(len, 256), current_output_port(sc));
+		}
 	    }
 	  size = bytes;
 	}
@@ -18548,20 +18556,6 @@ static s7_pointer read_file(s7_scheme *sc, FILE *fp, const char *name, s7_int ma
       port_needs_free(port) = false;
       port_port(port)->pf = &input_file_functions;
     }
-#else
-  /* _stat64 is no better than the fseek/ftell route, and
-   *    GetFileSizeEx and friends requires Windows.h which makes hash of everything else.
-   *    fread until done takes too long on big files, so use a file port
-   */
-  port_file(port) = fp;
-  port_type(port) = file_port;
-  port_needs_free(port) = false;
-  port_data(port) = NULL;
-  port_data_block(port) = NULL;
-  port_data_size(port) = 0;
-  port_position(port) = 0;
-  port_port(port)->pf = &input_file_functions;
-#endif
   unstack_gc_protect(sc);
   return(port);
 }


### PR DESCRIPTION
## 概述

优化 Windows 上 load/read 的性能。read_file()（src/s7.c）原来在 MS_WINDOWS 分支无条件使用 file port + 逐字符 fgetc 慢路径，现在 Windows 也走与非 Windows 相同的整体读入 + string port 快路径。

## 改动
- Windows 用 _fseeki64/_ftelli64 获取文件大小（fseek/ftell 在 MS C 上对大文件会截断），失败时回退 file port
- 修正短读警告：文本模式 CRLF→LF 转换导致的字节数缩小是正常现象，仅在 ferror 或读到 0 字节时报警
- 新增 bench/read-perf.scm 性能基准（(liii timeit)）
- 新增 devel/0135.md 开发文档

## 性能对比（bench/read-perf.scm，30 次迭代，500 个顶层 form）

| 基准 | 优化前 | 优化后 | 加速比 |
|---|---|---|---|
| open-input-file + read | 0.0453s | 0.0150s | ~3.0x |
| load | 0.0760s | 0.0457s | ~1.7x |

## 测试
- xmake b goldfish 构建通过
- tests/ 下全部测试通过（tests/srfi/srfi-78-200_12_2_test.scm 为既有失败，与本次无关）

🤖 Generated with [Claude Code](https://claude.com/claude-code)