### PR TITLE
[0136] 将 read 相关代码从 s7.c 拆分到 s7_scheme_read.c

### DIFF
--- a/devel/0136.md
+++ b/devel/0136.md
@@ -1,0 +1,41 @@
+# [0136] 将 read 相关代码从 s7.c 拆分到 s7_scheme_read.c
+
+## 任务相关的代码文件
+- src/s7.c
+- src/s7_scheme_read.c（新增）
+- src/s7_scheme_read.h（新增）
+- src/s7_internal_helpers.h
+- xmake.lua
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf tests/scheme/read/read-test.scm
+bin/gf tests/scheme/read-test.scm
+bin/gf bench/read-perf.scm
+```
+
+## 2026-08-20 拆分 read 代码
+
+### What
+1. 新建 `src/s7_scheme_read.c` / `src/s7_scheme_read.h`（与 `s7_scheme_write.c` 对称），从 s7.c 迁移约 740 行 read 相关代码：
+   - port 读原语：`*_read_char`、`*_read_line`、`*_read_semicolon`、`*_read_white_space`、`*_read_name`/`*_read_sharp`（file/string/function/closed_port 等变体）
+   - `read_file()`（0135 优化的整体读入快路径）
+   - Scheme 层函数：`s7_read`、`g_read`、`s7_read_char`、`g_read_char`、`read_char_p_p`、`read_char_chooser`、`s7_peek_char`、`g_peek_char`、`g_read_byte`、`read_line_p_p(p_p)`、`g_read_string`、`input_port_if_not_loading`、`s7i_port_read_line` 等
+2. s7.c 中新增 `s7i_*` 桥接函数（`s7i_token`、`s7i_make_sharp_constant`、`s7i_resize_strbuf`、`s7i_backchar`、`s7i_eval`、`s7i_input_file_functions` 等），声明加入 `s7_internal_helpers.h`；`push_input_port`、`method_or_bust_pp` 去掉 static 导出
+3. port 函数表（`input_file_functions`、`input_string_functions_1` 等）留在 s7.c，通过访问器桥接供 read_file 使用
+4. g_* 函数的 H_/Q_ 文档宏保留在 s7.c（init 的 defun 宏引用它们）
+
+### Why
+s7.c 已有 8.6 万行。继 write 侧拆出 `s7_scheme_write.c` 之后，将 read 侧（端口读原语、reader、read 家族 Scheme 函数）拆出，便于后续 read 性能优化与维护。
+
+### How
+- `s7_scheme_read.c` include `s7_internal.h`（含 `port_t`、`token_t`、opcode 枚举、栈宏、`struct s7_scheme` 完整定义），热路径（`string_read_char`、`string_read_name` 等）直接用本地宏访问 port 字段，无函数调用开销
+- 字符分类表（`char_ok_in_a_name`、`number_table`、`white_space`）来自 `s7_ctables.h` 的 extern 声明
+- 深层依赖（`token()`、`make_sharp_constant`、`eval` 等核心 static）通过 `s7i_*` 包装函数桥接
+- 注意：s7.c 中 `port_data_block(p)` 是 `port_port(p)->block`（port_t 字段），与 `port_block(p)`（cell 的 `object.prt.block`）不同字段，read.c 中的本地宏必须与 s7.c 一致，否则关闭端口时 `free_port_data` 会对空指针 liberate 导致崩溃
+
+### 验证
+- tests/scheme 下 302 个测试全部通过
+- tests/liii、tests/srfi 下 67 个测试全部通过
+- bench/read-perf.scm：读取全部仓库 .scm 文件 10 次迭代 1.73s（0135 基线 2.34s，无回退）

--- a/src/s7.c
+++ b/src/s7.c
@@ -18156,7 +18156,7 @@ static port_functions_t input_string_functions_1 =
 const port_functions_t *s7i_input_file_functions(void) {return(&input_file_functions);}
 const port_functions_t *s7i_input_string_functions_1(void) {return(&input_string_functions_1);}
 block_t *s7i_mallocate_port(s7_scheme *sc) {return(mallocate_port(sc));}
-void s7i_port_set_filename(s7_scheme *sc, s7_pointer port, const char *name, size_t len) {port_set_filename(sc, port, name, len);}
+void s7i_port_set_filename(s7_scheme *sc, s7_pointer port, const char *name, s7_int len) {port_set_filename(sc, port, name, (size_t)len);}
 
 
 /* -------------------------------- open-input-file -------------------------------- */

--- a/src/s7.c
+++ b/src/s7.c
@@ -402,6 +402,7 @@
 #include "s7_scheme_complex.h"
 #include "s7_scheme_char.h"
 #include "s7_scheme_write.h"
+#include "s7_scheme_read.h"
 #include "s7_scheme_symbol.h"
 #include "s7_scheme_predicate.h"
 #include "s7_liii_bitwise.h"
@@ -6268,7 +6269,7 @@ s7_pointer method_or_bust_p(s7_scheme *sc, s7_pointer obj, s7_pointer method, s7
   return(find_and_apply_method(sc, obj, method, set_mlist_1(sc, obj)));
 }
 
-static s7_pointer method_or_bust_pp(s7_scheme *sc, s7_pointer obj, s7_pointer method, s7_pointer x1, s7_pointer x2, s7_pointer typ, int32_t num)
+s7_pointer method_or_bust_pp(s7_scheme *sc, s7_pointer obj, s7_pointer method, s7_pointer x1, s7_pointer x2, s7_pointer typ, int32_t num)
 {
   if (!has_active_methods(sc, obj)) wrong_type_error_nr(sc, method, num, obj, typ);
   return(find_and_apply_method(sc, obj, method, set_mlist_2(sc, x1, x2)));
@@ -11903,6 +11904,11 @@ static void resize_strbuf(s7_scheme *sc, s7_int needed_size)
   for (s7_int i = old_size; i < sc->strbuf_size; i++) sc->strbuf[i] = '\0';
 }
 
+/* bridges for s7_scheme_read.c */
+void s7i_backchar(char c, s7_pointer port) {backchar(c, port);}
+void s7i_resize_strbuf(s7_scheme *sc, s7_int needed_size) {resize_strbuf(sc, needed_size);}
+bool s7i_is_loader_port(s7_pointer p) {return(is_loader_port(p));}
+
 s7_pointer *chars;
 
 static s7_pointer unknown_sharp_constant(s7_scheme *sc, const char *name, s7_pointer port)
@@ -12110,6 +12116,9 @@ static s7_pointer make_sharp_constant(s7_scheme *sc, const char *name, bool with
       }
   return(unknown_sharp_constant(sc, name, NULL));
 }
+ 
+/* bridge for s7_scheme_read.c */
+s7_pointer s7i_make_sharp_constant(s7_scheme *sc, const char *name, bool with_error, s7_pointer port, bool error_if_bad_number) {return(make_sharp_constant(sc, name, with_error, port, error_if_bad_number));}
 
 static const char *radstr[17] = {NULL, NULL, "01", "012", "0123", "01234", "012345", "0123456", "01234567", "012345678", "0123456789",
   "0123456789aA", "0123456789aAbB", "0123456789aAbBcC", "0123456789aAbBcCdD", "0123456789aAbBcCdDeE", "0123456789aAbBcCdDeEfF"};
@@ -17701,8 +17710,6 @@ static s7_pointer g_is_char_ready(s7_scheme *sc, s7_pointer args)
 #endif
 
 /* -------- ports -------- */
-static int32_t closed_port_read_char(s7_scheme *sc, s7_pointer port);
-static s7_pointer closed_port_read_line(s7_scheme *sc, s7_pointer port, bool with_eol);
 static void closed_port_write_char(s7_scheme *sc, uint8_t c, s7_pointer port);
 static void closed_port_write_string(s7_scheme *sc, const char *str, s7_int len, s7_pointer port);
 static void closed_port_display(s7_scheme *sc, const char *s, s7_pointer port);
@@ -17893,157 +17900,7 @@ static s7_pointer g_close_output_port(s7_scheme *sc, s7_pointer args)
 }
 
 
-/* -------- read character functions -------- */
-
-static int32_t file_read_char(s7_scheme *sc, s7_pointer port)
-{
-  int32_t c = fgetc(port_file(port));
-  if ((c == (int32_t)'\n') && (!is_loader_port(port))) port_line_number(port)++;
-  return(c);
-}
-
-static int32_t function_read_char(s7_scheme *sc, s7_pointer port)
-{
-  const s7_pointer result = (*(port_input_function(port)))(sc, S7_READ_CHAR, port);
-  if (is_eof(result)) return(EOF);
-  if (!is_character(result))          /* port_input_function might return some non-character */
-    {
-      if (is_multiple_value(result))
-	{
-	  clear_multiple_value(result);
-	  error_nr(sc, sc->bad_result_symbol, set_elist_2(sc, wrap_string(sc, "input-function-port read-char returned: ~S", 42), result));
-	}
-      error_nr(sc, sc->wrong_type_arg_symbol, set_elist_2(sc, wrap_string(sc, "input-function-port read-char returned: ~S", 42), result));
-    }
-  return((int32_t)character(result));    /* kinda nutty -- we return chars[this] in g_read_char! */
-}
-
-static int32_t string_read_char(s7_scheme *sc, s7_pointer port)
-{
-  uint8_t c;
-  if (port_data_size(port) <= port_position(port)) return(EOF);
-  c = (uint8_t)port_data(port)[port_position(port)++]; /* port_string_length is 0 if no port string, port_data is uint8_t* */
-  if ((c == (uint8_t)'\n') && (!is_loader_port(port))) port_line_number(port)++;
-  return(c);
-}
-
-static int32_t output_read_char(s7_scheme *sc, s7_pointer port) /* not reachable I think */
-{
-  sole_arg_wrong_type_error_nr(sc, sc->read_char_symbol, port, an_input_port_string);
-  return(0);
-}
-
-static int32_t closed_port_read_char(s7_scheme *sc, s7_pointer port)
-{
-  sole_arg_wrong_type_error_nr(sc, sc->read_char_symbol, port, an_open_input_port_string);
-  return(0);
-}
-
-
-/* -------- read line functions -------- */
-
-static s7_pointer output_read_line(s7_scheme *sc, s7_pointer port, bool with_eol) /* not reachable I think */
-{
-  sole_arg_wrong_type_error_nr(sc, sc->read_line_symbol, port, an_input_port_string);
-  return(NULL);
-}
-
-static s7_pointer closed_port_read_line(s7_scheme *sc, s7_pointer port, bool with_eol)
-{
-  sole_arg_wrong_type_error_nr(sc, sc->read_line_symbol, port, an_open_input_port_string);
-  return(NULL);
-}
-
-static s7_pointer function_read_line(s7_scheme *sc, s7_pointer port, bool with_eol)
-{
-  s7_pointer result = (*(port_input_function(port)))(sc, S7_READ_LINE, port);
-  if (is_multiple_value(result))
-    {
-      clear_multiple_value(result);
-      error_nr(sc, sc->bad_result_symbol, set_elist_2(sc, wrap_string(sc, "input-function-port read-line returned: ~S", 42), result));
-    }
-  return(result);
-}
-
-static s7_pointer stdin_read_line(s7_scheme *sc, s7_pointer port, bool with_eol)
-{
-  if (!sc->read_line_buf)
-    {
-      sc->read_line_buf_size = 1024;
-      sc->read_line_buf = (char *)Malloc(sc->read_line_buf_size);
-    }
-  if (fgets(sc->read_line_buf, sc->read_line_buf_size, stdin))
-    return(s7_make_string(sc, sc->read_line_buf)); /* fgets adds the trailing '\0' */
-  return(eof_object);
-}
-
-static s7_pointer file_read_line(s7_scheme *sc, s7_pointer port, bool with_eol)
-{
-  /* read into read_line_buf concatenating reads until newline found.  string is read_line_buf to pos-of-newline.
-   *   reset file position to reflect newline pos.
-   */
-  int32_t reads = 0;
-  char *str;
-  s7_int read_size;
-  if (!sc->read_line_buf)
-    {
-      sc->read_line_buf_size = 1024;
-      sc->read_line_buf = (char *)Malloc(sc->read_line_buf_size);
-    }
-  read_size = sc->read_line_buf_size;
-  str = fgets(sc->read_line_buf, read_size, port_file(port)); /* reads size-1 at most, EOF and newline also terminate read */
-  if (!str) return(eof_object);                               /* EOF or error with no char read */
-
-  while (true)
-    {
-      s7_int cur_size;
-      char *buf;
-      const char *snew = strchr(sc->read_line_buf, (int)'\n'); /* or maybe just strlen + end-of-string=newline */
-      if (snew)
-	{
-	  s7_int pos = (s7_int)(snew - sc->read_line_buf);
-	  port_line_number(port)++;
-	  return(inline_make_string_with_length(sc, sc->read_line_buf, (with_eol) ? (pos + 1) : pos));
-	}
-      reads++;
-      cur_size = strlen(sc->read_line_buf);
-      if ((cur_size + reads) < read_size) /* end of data, no newline */
-	return(make_string_with_length(sc, sc->read_line_buf, cur_size));
-
-      /* need more data */
-      sc->read_line_buf_size *= 2;
-      sc->read_line_buf = (char *)Realloc(sc->read_line_buf, sc->read_line_buf_size);
-      buf = (char *)(sc->read_line_buf + cur_size);
-      str = fgets(buf, read_size, port_file(port));
-      if (!str) return(eof_object);
-      read_size = sc->read_line_buf_size;
-    }
-  return(eof_object);
-}
-
-static s7_pointer string_read_line(s7_scheme *sc, s7_pointer port, bool with_eol)
-{
-  s7_int i;
-  const char *port_str = (const char *)port_data(port);
-  const s7_int port_start = port_position(port);
-  const char *start = port_str + port_start;
-  const char *cur = (const char *)strchr(start, (int)'\n'); /* this can run off the end making valgrind unhappy, but I think it's innocuous */
-  if (cur)
-    {
-      s7_int len;
-      port_line_number(port)++;
-      i = cur - port_str;
-      port_position(port) = i + 1;
-      len = ((with_eol) ? i + 1 : i) - port_start;
-      if (len == 0) return(nil_string);
-      return(inline_make_string_with_length(sc, start, len));
-    }
-  i = port_data_size(port);
-  port_position(port) = i;
-  if (i <= port_start)         /* the < part can happen -- if not caught we try to create a string of length - 1 -> segfault */
-    return(eof_object);
-  return(make_string_with_length(sc, start, i - port_start));
-}
+/* -------- read character/line functions moved to s7_scheme_read.c -------- */
 
 
 /* -------- write character functions -------- */
@@ -18252,200 +18109,12 @@ static void stdout_display(s7_scheme *sc, const char *str, s7_pointer port) {if 
 static void stderr_display(s7_scheme *sc, const char *str, s7_pointer port) {if (str) fputs(str, stderr);}
 
 
-/* -------- skip to newline readers -------- */
+/* -------- skip-to-newline / white space / name readers moved to s7_scheme_read.c -------- */
 static token_t token(s7_scheme *sc);
+token_t file_read_semicolon(s7_scheme *sc, s7_pointer port);
+token_t string_read_semicolon(s7_scheme *sc, s7_pointer port);
+int32_t s7i_token(s7_scheme *sc) {return(token(sc));}
 
-static token_t file_read_semicolon(s7_scheme *sc, s7_pointer port)
-{
-  int32_t c;
-  do (c = fgetc(port_file(port))); while ((c != '\n') && (c != EOF));
-  port_line_number(port)++;
-  return((c == EOF) ? token_eof : token(sc));
-}
-
-static token_t string_read_semicolon(s7_scheme *sc, s7_pointer port)
-{
-  const char *str = (const char *)(port_data(port) + port_position(port));
-  const char *orig_str = strchr(str, (int)'\n');
-  if (!orig_str)
-    {
-      port_position(port) = port_data_size(port);
-      return(token_eof);
-    }
-  port_position(port) += (orig_str - str + 1); /* + 1 because strchr leaves orig_str pointing at the newline */
-  port_line_number(port)++;
-  return(token(sc));
-}
-
-
-/* -------- white space readers -------- */
-
-static int32_t file_read_white_space(s7_scheme *sc, s7_pointer port)
-{
-  int32_t c;
-  while (is_white_space(c = fgetc(port_file(port))))
-    if (c == '\n')
-      port_line_number(port)++;
-  return(c);
-}
-
-static int32_t terminated_string_read_white_space(s7_scheme *sc, s7_pointer port)
-{
-  const uint8_t *str = (const uint8_t *)(port_data(port) + port_position(port));
-  uint8_t c;
-  /* here we know we have null termination and white_space[#\null] is false */
-  while (white_space[c = *str++]) /* 255 is not -1 = EOF */
-    if (c == '\n')
-      port_line_number(port)++;
-  port_position(port) = (c) ? str - port_data(port) : port_data_size(port);
-  return((int32_t)c);
-}
-
-
-/* -------- name readers -------- */
-#define BASE_10 10
-
-static s7_pointer file_read_name_or_sharp(s7_scheme *sc, s7_pointer port, bool atom_case)
-{
-  int32_t c;
-  s7_int i = 1;  /* sc->strbuf[0] has the first char of the string we're reading */
-  do {
-    c = fgetc(port_file(port)); /* might return EOF */
-    if (c == '\n')
-      port_line_number(port)++;
-
-    sc->strbuf[i++] = (unsigned char)c;
-    if (i >= sc->strbuf_size)
-      resize_strbuf(sc, i);
-  } while ((c != EOF) && (char_ok_in_a_name[c]));
-
-  if ((i == 2) &&
-      (sc->strbuf[0] == '\\'))
-    sc->strbuf[2] = '\0';
-  else
-    {
-      if (c != EOF)
-	{
-	  if (c == '\n')
-	    port_line_number(port)--;
-	  ungetc(c, port_file(port));
-	}
-      sc->strbuf[i - 1] = '\0';
-    }
-  if (atom_case)
-    return(make_atom(sc, sc->strbuf, BASE_10, SYMBOL_OK, WITH_OVERFLOW_ERROR));
-  return(make_sharp_constant(sc, sc->strbuf, WITH_OVERFLOW_ERROR, port, true));
-}
-
-static s7_pointer file_read_name(s7_scheme *sc, s7_pointer port)  {return(file_read_name_or_sharp(sc, port, true));}
-static s7_pointer file_read_sharp(s7_scheme *sc, s7_pointer port) {return(file_read_name_or_sharp(sc, port, false));}
-
-static s7_pointer string_read_name_no_free(s7_scheme *sc, s7_pointer port)
-{
-  /* sc->strbuf[0] has the first char of the string we're reading */
-  const uint8_t *str = (uint8_t *)(port_data(port) + port_position(port));
-
-  if (char_ok_in_a_name[*str])
-    {
-      s7_int k;
-      const uint8_t *orig_str = str - 1;
-      str++;
-      while (char_ok_in_a_name[*str]) str++;
-      k = str - orig_str;
-      if (*str != 0)
-	port_position(port) += (k - 1);
-      else port_position(port) = port_data_size(port);
-      /* this is equivalent to:
-       *    str = strpbrk(str, "(); \"\t\r\n");
-       *    if (!str) {k = strlen(orig_str); str = (char *)(orig_str + k);} else k = str - orig_str;
-       * but slightly faster.
-       */
-      if (!number_table[*orig_str])
-	return(inline_make_symbol(sc, (const char *)orig_str, k));
-
-      /* eval_c_string string is a constant so we can't set and unset the token's end char */
-      if ((k + 1) >= sc->strbuf_size)
-	resize_strbuf(sc, k + 1);
-      memcpy((void *)(sc->strbuf), (void *)orig_str, k);
-      sc->strbuf[k] = '\0';
-      return(make_atom(sc, sc->strbuf, BASE_10, SYMBOL_OK, WITH_OVERFLOW_ERROR));
-    }
-  {
-    s7_pointer result = sc->singletons[(uint8_t)(sc->strbuf[0])];
-    if (!result)
-      {
-	sc->strbuf[1] = '\0';
-	result = make_symbol(sc, sc->strbuf, 1);
-	sc->singletons[(uint8_t)(sc->strbuf[0])] = result;
-      }
-    return(result);
-  }
-}
-
-static s7_pointer string_read_sharp(s7_scheme *sc, s7_pointer port)
-{
-  /* sc->strbuf[0] has the first char of the string we're reading.
-   *   since a *#readers* function might want to get further input, we can't mess with the input even when it is otherwise safe
-   */
-  char *str = (char *)(port_data(port) + port_position(port));
-  if (char_ok_in_a_name[(uint8_t)*str])
-    {
-      s7_int k;
-      const char *orig_str = (char *)(str - 1);
-      str++;
-      while (char_ok_in_a_name[(uint8_t)(*str)]) {str++;}
-      k = str - orig_str;
-      port_position(port) += (k - 1);
-      if ((k + 1) >= sc->strbuf_size)
-	resize_strbuf(sc, k + 1);
-      memcpy((void *)(sc->strbuf), (void *)orig_str, k);
-      sc->strbuf[k] = '\0';
-      return(make_sharp_constant(sc, sc->strbuf, WITH_OVERFLOW_ERROR, port, true));
-    }
-  if (sc->strbuf[0] == 'f') return(sc->F);
-  if (sc->strbuf[0] == 't') return(sc->T);
-  if (sc->strbuf[0] == '\\')
-    {
-      /* must be from #\( and friends -- a character that happens to be not ok-in-a-name */
-      sc->strbuf[1] = str[0];
-      sc->strbuf[2] = '\0';
-      port_position(port)++;
-    }
-  else sc->strbuf[1] = '\0';
-  return(make_sharp_constant(sc, sc->strbuf, WITH_OVERFLOW_ERROR, port, true));
-}
-
-static s7_pointer string_read_name(s7_scheme *sc, s7_pointer port)
-{
-  /* port_string was allocated (and read from a file) so we can mess with it directly */
-  s7_pointer result;
-  uint8_t *str = (uint8_t *)(port_data(port) + port_position(port));
-  if (char_ok_in_a_name[*str])
-    {
-      s7_int k;
-      uint8_t endc;
-      const uint8_t *orig_str = str - 1;
-      str++;
-      while (char_ok_in_a_name[*str]) str++;
-      k = str - orig_str;
-      port_position(port) += (k - 1);
-      if (!number_table[*orig_str])
-	return(inline_make_symbol(sc, (const char *)orig_str, k));
-      endc = *str;
-      *str = 0; /* temp end for make_atom */
-      result = make_atom(sc, (char *)orig_str, BASE_10, SYMBOL_OK, WITH_OVERFLOW_ERROR);
-      *str = endc;
-      return(result);
-    }
-  result = sc->singletons[(uint8_t)(sc->strbuf[0])];
-  if (!result)
-    {
-      sc->strbuf[1] = '\0';
-      result = make_symbol(sc, sc->strbuf, 1);
-      sc->singletons[(uint8_t)(sc->strbuf[0])] = result;
-    }
-  return(result);
-}
 
 static void port_set_filename(s7_scheme *sc, s7_pointer port, const char *name, size_t len)
 {
@@ -18483,82 +18152,11 @@ static port_functions_t input_string_functions_1 =
   {string_read_char, input_write_char, input_write_string, string_read_semicolon, terminated_string_read_white_space,
    string_read_name, string_read_sharp, string_read_line, input_display, close_input_string};
 
-static s7_pointer read_file(s7_scheme *sc, FILE *fp, const char *name, s7_int max_size, const char *caller)
-{
-  s7_pointer port;
-  s7_int size;
-  block_t *b = mallocate_port(sc);
-  new_cell(sc, port, T_INPUT_PORT);
-  gc_protect_via_stack(sc, port);
-  port_block(port) = b;
-  port_port(port) = (port_t *)block_data(b);
-  port_set_closed(port, false);
-  port_set_string_or_function(port, sc->nil);
-  port_filename_length(port) = safe_strlen(name);
-  port_set_filename(sc, port, name, port_filename_length(port));
-  port_line_number(port) = 1;  /* first line is numbered 1 */
-  port_file_number(port) = 0;
-  add_input_port(sc, port);
-
-#if MS_WINDOWS
-  /* MS C's fseek/ftell truncate large files: use the 64-bit-safe variants */
-  if ((_fseeki64(fp, 0, SEEK_END) != 0) ||
-      ((size = _ftelli64(fp)) < 0))
-    size = 0;
-  rewind(fp);
-#else
-  fseek(fp, 0, SEEK_END);
-  size = ftell(fp);
-  rewind(fp);
-#endif
-  /* pseudo files (under /proc for example) have size=0, but we can read them, so don't assume a 0 length file is empty */
-  if ((size > 0) &&   /* if (size != 0) we get (open-input-file "/dev/tty") -> (open "/dev/tty") read 0 bytes of an expected -1? */
-      ((max_size < 0) || (size < max_size))) /* load uses max_size = -1 */
-    {
-      block_t *block = mallocate(sc, size + 2);
-      uint8_t *content = (uint8_t *)(block_data(block));
-      const size_t bytes = fread(content, sizeof(uint8_t), size, fp);
-      if (bytes != (size_t)size)
-	{
-	  /* in MS Windows text mode, CRLF -> LF translation makes the read size smaller than the file size */
-	  if (ferror(fp) || (bytes == 0))
-	    {
-	      if (current_output_port(sc) != sc->F)
-		{
-		  char tmp[256];
-		  int32_t len = snprintf(tmp, 256, "(%s \"%s\") read %ld bytes of an expected %" ld64 "?", caller, name, (long)bytes, size);
-		  port_write_string(current_output_port(sc))(sc, tmp, clamp_length(len, 256), current_output_port(sc));
-		}
-	    }
-	  size = bytes;
-	}
-      content[size] = '\0';
-      content[size + 1] = '\0';
-      fclose(fp);
-
-      port_file(port) = NULL; /* make valgrind happy */
-      port_type(port) = string_port;
-      port_data(port) = content;
-      port_data_block(port) = block;
-      port_data_size(port) = size;
-      port_position(port) = 0;
-      port_needs_free(port) = true;
-      port_port(port)->pf = &input_string_functions_1;
-    }
-  else
-    {
-      port_file(port) = fp;
-      port_type(port) = file_port;
-      port_data(port) = NULL;
-      port_data_block(port) = NULL;
-      port_data_size(port) = 0;
-      port_position(port) = 0;
-      port_needs_free(port) = false;
-      port_port(port)->pf = &input_file_functions;
-    }
-  unstack_gc_protect(sc);
-  return(port);
-}
+/* read_file moved to s7_scheme_read.c */
+const port_functions_t *s7i_input_file_functions(void) {return(&input_file_functions);}
+const port_functions_t *s7i_input_string_functions_1(void) {return(&input_string_functions_1);}
+block_t *s7i_mallocate_port(s7_scheme *sc) {return(mallocate_port(sc));}
+void s7i_port_set_filename(s7_scheme *sc, s7_pointer port, const char *name, size_t len) {port_set_filename(sc, port, name, len);}
 
 
 /* -------------------------------- open-input-file -------------------------------- */
@@ -19194,7 +18792,7 @@ static s7_pointer g_open_output_function(s7_scheme *sc, s7_pointer args)
 /* -------- current-input-port stack -------- */
 #define INPUT_PORT_STACK_INITIAL_SIZE 4
 
-static /* inline */ void push_input_port(s7_scheme *sc, s7_pointer new_port)
+/* inline */ void push_input_port(s7_scheme *sc, s7_pointer new_port)
 {
   if (sc->input_port_stack_loc >= sc->input_port_stack_size)
     {
@@ -19210,80 +18808,34 @@ void pop_input_port(s7_scheme *sc)
   set_current_input_port(sc, (sc->input_port_stack_loc > 0) ? sc->input_port_stack[--(sc->input_port_stack_loc)] : sc->standard_input);
 }
 
-static s7_pointer input_port_if_not_loading(s7_scheme *sc)
-{
-  const s7_pointer port = current_input_port(sc);
-  int32_t c;
-  if (!is_loader_port(port)) /* this flag is turned off by the reader macros, so we aren't in that context */
-    return(port);
-  c = port_read_white_space(port)(sc, port);
-  if (c > 0)            /* we can get either EOF or NULL at the end */
-    {
-      backchar(c, port);
-      return(NULL);
-    }
-  return(sc->standard_input);
-}
+/* input_port_if_not_loading, s7i_input_port_if_not_loading and s7i_port_read_line moved to s7_scheme_read.c */
 
 /* Export helper functions for s7_scheme_base.c */
 const char *s7i_an_input_port_string(void) {return("an input port");}
 const char *s7i_a_boolean_string(void) {return("a boolean");}
 
-s7_pointer s7i_input_port_if_not_loading(s7_scheme *sc)
-{
-  return(input_port_if_not_loading(sc));
-}
+s7_pointer s7i_an_input_port_string_obj(void) {return(an_input_port_string);}
+s7_pointer s7i_an_open_input_port_string_obj(void) {return(an_open_input_port_string);}
 
-s7_pointer s7i_port_read_line(s7_scheme *sc, s7_pointer port, bool with_eol)
-{
-  return(port_read_line(port)(sc, port, with_eol));
-}
-
-
-/* -------------------------------- read-char -------------------------------- */
-s7_pointer s7_read_char(s7_scheme *sc, s7_pointer port)
-{
-  int32_t c = port_read_character(port)(sc, port);
-  return((c == EOF) ? eof_object : chars[c]);
-}
-
-static s7_pointer g_read_char(s7_scheme *sc, s7_pointer args)
-{
-  #define H_read_char "(read-char (port (current-input-port))) returns the next character in the input port"
-  #define Q_read_char s7_make_signature(sc, 2, s7_make_signature(sc, 2, sc->is_char_symbol, sc->is_eof_object_symbol), sc->is_input_port_symbol)
-
-  s7_pointer port;
-  if (is_pair(args))
-    port = car(args);
-  else
-    {
-      port = input_port_if_not_loading(sc);
-      if (!port) return(eof_object);
-    }
-  if (!is_input_port(port))
-    return(method_or_bust_p(sc, port, sc->read_char_symbol, an_input_port_string));
-  return(chars[port_read_character(port)(sc, port)]);
-}
-
-static s7_pointer read_char_p_p(s7_scheme *sc, s7_pointer port)
-{
-  if (!is_input_port(port))
-    return(method_or_bust_p(sc, port, sc->read_char_symbol, an_input_port_string));
-  return(chars[port_read_character(port)(sc, port)]);
-}
-
-static s7_pointer g_read_char_1(s7_scheme *sc, s7_pointer args)
-{
-  s7_pointer port = car(args);
-  if (!is_input_port(port))
-    return(method_or_bust_p(sc, port, sc->read_char_symbol, an_input_port_string));
-  return(chars[port_read_character(port)(sc, port)]);
-}
-
-static s7_pointer read_char_chooser(s7_scheme *sc, s7_pointer func, int32_t args, s7_pointer unused_expr)
-{
-  return((args == 1) ? sc->read_char_1 : func);
-}
+/* read-char functions moved to s7_scheme_read.c */
+/* their H_/Q_ doc/signature macros stay here: defun() in init_s7 references them below */
+#define H_read_char "(read-char (port (current-input-port))) returns the next character in the input port"
+#define Q_read_char s7_make_signature(sc, 2, s7_make_signature(sc, 2, sc->is_char_symbol, sc->is_eof_object_symbol), sc->is_input_port_symbol)
+#define H_peek_char "(peek-char (port (current-input-port))) returns the next character in the input port, but does not remove it from the input stream"
+#define Q_peek_char s7_make_signature(sc, 2, s7_make_signature(sc, 2, sc->is_char_symbol, sc->is_eof_object_symbol), sc->is_input_port_symbol)
+#define H_read_byte "(read-byte (port (current-input-port))): reads a byte from the input port"
+#define Q_read_byte s7_make_signature(sc, 2, s7_make_signature(sc, 2, sc->is_byte_symbol, sc->is_eof_object_symbol), sc->is_input_port_symbol)
+#define H_read_line "(read-line port (with-eol #f)) returns the next line from port, or #<eof>. \
+	If 'with-eol' is not #f, read-line includes the trailing end-of-line character."
+#define Q_read_line s7_make_signature(sc, 3, \
+                        s7_make_signature(sc, 2, sc->is_string_symbol, sc->is_eof_object_symbol), \
+                        sc->is_input_port_symbol, sc->is_boolean_symbol)
+#define H_read_string "(read-string k port) reads k characters from port into a new string and returns it."
+#define Q_read_string s7_make_signature(sc, 3, \
+                        s7_make_signature(sc, 2, sc->is_string_symbol, sc->is_eof_object_symbol), \
+                        sc->is_integer_symbol, sc->is_input_port_symbol)
+#define H_read "(read (port (current-input-port))) returns the next object in the input port, or #<eof> at the end"
+#define Q_read s7_make_signature(sc, 2, sc->T, sc->is_input_port_symbol)
 
 
 /* -------------------------------- write-char -------------------------------- */
@@ -19325,183 +18877,7 @@ static void port_write_unicode_char(s7_scheme *sc, uint32_t c, s7_pointer port)
 /* should write-char, write, write-string, display, and newline count newlines for port-line-number?  Currently we only accept input ports */
 
 
-/* -------------------------------- peek-char -------------------------------- */
-s7_pointer s7_peek_char(s7_scheme *sc, s7_pointer port)
-{
-  int32_t c;              /* needs to be an int32_t so EOF=-1, but not 255 */
-  if (is_string_port(port))
-    return((port_data_size(port) <= port_position(port)) ? eof_object : chars[(uint8_t)port_data(port)[port_position(port)]]);
-  c = port_read_character(port)(sc, port);
-  if (c == EOF) return(eof_object);
-  backchar(c, port);
-  return(chars[c]);
-}
-
-static s7_pointer g_peek_char(s7_scheme *sc, s7_pointer args)
-{
-  #define H_peek_char "(peek-char (port (current-input-port))) returns the next character in the input port, but does not remove it from the input stream"
-  #define Q_peek_char s7_make_signature(sc, 2, s7_make_signature(sc, 2, sc->is_char_symbol, sc->is_eof_object_symbol), sc->is_input_port_symbol)
-
-  s7_pointer result;
-  const s7_pointer port = (is_pair(args)) ? car(args) : current_input_port(sc);
-  if (!is_input_port(port))
-    return(method_or_bust_p(sc, port, sc->peek_char_symbol, an_input_port_string));
-  if (port_is_closed(port))
-    sole_arg_wrong_type_error_nr(sc, sc->peek_char_symbol, port, an_open_input_port_string);
-  if (!is_function_port(port))
-    return(s7_peek_char(sc, port));
-
-  result = (*(port_input_function(port)))(sc, S7_PEEK_CHAR, port);
-  if (is_multiple_value(result))
-    {
-      clear_multiple_value(result);
-      error_nr(sc, sc->bad_result_symbol,
-	       set_elist_2(sc, wrap_string(sc, "input-function-port peek-char returned multiple values: ~S", 58), result));
-    }
-  if (!is_character(result))
-    error_nr(sc, sc->wrong_type_arg_symbol,
-	     set_elist_2(sc, wrap_string(sc, "input-function-port peek-char returned: ~S", 42), result));
-  return(result);
-}
-
-
-/* -------------------------------- read-byte -------------------------------- */
-static s7_pointer g_read_byte(s7_scheme *sc, s7_pointer args)
-{
-  #define H_read_byte "(read-byte (port (current-input-port))): reads a byte from the input port"
-  #define Q_read_byte s7_make_signature(sc, 2, s7_make_signature(sc, 2, sc->is_byte_symbol, sc->is_eof_object_symbol), sc->is_input_port_symbol)
-
-  s7_pointer port;
-  int32_t c;
-  if (is_pair(args))
-    port = car(args);
-  else
-    {
-      port = input_port_if_not_loading(sc);
-      if (!port) return(eof_object);
-    }
-  if (!is_input_port(port))
-    return(method_or_bust_p(sc, port, sc->read_byte_symbol, an_input_port_string));
-  if (port_is_closed(port))          /* avoid reporting caller here as read-char */
-    sole_arg_wrong_type_error_nr(sc, sc->read_byte_symbol, port, an_open_input_port_string);
-  c = port_read_character(port)(sc, port);
-  return((c == EOF) ? eof_object : small_int(c));
-}
-
-
-/* -------------------------------- read-line -------------------------------- */
-/* g_read_line is now implemented in s7_scheme_base.c */
-#define H_read_line "(read-line port (with-eol #f)) returns the next line from port, or #<eof>. \
-If 'with-eol' is not #f, read-line includes the trailing end-of-line character."
-#define Q_read_line s7_make_signature(sc, 3, \
-                        s7_make_signature(sc, 2, sc->is_string_symbol, sc->is_eof_object_symbol), \
-                        sc->is_input_port_symbol, sc->is_boolean_symbol)
-
-static s7_pointer read_line_p_pp(s7_scheme *sc, s7_pointer port, s7_pointer with_eol)
-{
-  if (!is_input_port(port))
-    return(method_or_bust_pp(sc, port, sc->read_line_symbol, port, with_eol, an_input_port_string, 1));
-  if (!is_boolean(with_eol))
-    wrong_type_error_nr(sc, sc->read_line_symbol, 2, with_eol, a_boolean_string);
-  return(port_read_line(port)(sc, port, with_eol != sc->F));
-}
-
-static s7_pointer read_line_p_p(s7_scheme *sc, s7_pointer port)
-{
-  if (!is_input_port(port))
-    return(method_or_bust_p(sc, port, sc->read_line_symbol, an_input_port_string));
-  return(port_read_line(port)(sc, port, false)); /* with_eol default is #f */
-}
-
-
-/* -------------------------------- read-string -------------------------------- */
-#define READ_STRING_LINE_NUMBERS 0 /* 1 adds port-line-number support to read-string, doubling the time it takes */
-
-static s7_pointer g_read_string(s7_scheme *sc, s7_pointer args)
-{
-  /* read-chars would be a better name -- read-string could mean CL-style read-from-string (like eval-string)
-   *   similarly read-bytes could return a byte-vector (rather than r7rs's read-bytevector)
-   *   and write-string -> write-chars, write-bytevector -> write-bytes.
-   * should this worry about newlines?  read-char and read-line keep port-line-number up to date,
-   *   but here we'd need to scan the new string (via strchr?) or xor with \n\n\n\n... up to 8-at-a-time, and count zeros.
-   */
-  #define H_read_string "(read-string k port) reads k characters from port into a new string and returns it."
-  #define Q_read_string s7_make_signature(sc, 3, \
-                          s7_make_signature(sc, 2, sc->is_string_symbol, sc->is_eof_object_symbol), \
-                          sc->is_integer_symbol, sc->is_input_port_symbol)
-  const s7_pointer k = car(args);
-  s7_pointer port, str;
-  s7_int nchars;
-  uint8_t *str_chars;
-
-  if (!s7_is_integer(k))
-    return(method_or_bust(sc, k, sc->read_string_symbol, args, sc->type_names[T_INTEGER], 1));
-  nchars = s7_integer_clamped_if_gmp(sc, k);
-  if (nchars < 0)
-    out_of_range_error_nr(sc, sc->read_string_symbol, int_one, k, it_is_negative_string);
-  if (nchars > sc->max_string_length)
-    error_nr(sc, sc->out_of_range_symbol,
-	     set_elist_3(sc, wrap_string(sc, "read-string first argument ~D is greater than (*s7* 'max-string-length), ~D", 75),
-			 wrap_integer(sc, nchars), wrap_integer(sc, sc->max_string_length)));
-  if (!is_null(cdr(args)))
-    port = cadr(args);
-  else
-    {
-      port = input_port_if_not_loading(sc);
-      if (!port) return(eof_object);
-    }
-  if (!is_input_port(port))
-    return(method_or_bust_pp(sc, port, sc->read_string_symbol, k, port, an_input_port_string, 2));
-  if (port_is_closed(port))
-    wrong_type_error_nr(sc, sc->read_string_symbol, 2, port, an_open_input_port_string);
-
-  str = make_empty_string(sc, nchars, '\0');
-  if (nchars == 0) return(str);
-  str_chars = (uint8_t *)string_value(str);
-  if (is_string_port(port))
-    {
-      const s7_int pos = port_position(port);
-      const s7_int end = port_data_size(port);
-      s7_int len = end - pos;
-      if (len > nchars) len = nchars;
-      if (len <= 0) return(eof_object);
-      memcpy((void *)str_chars, (void *)(port_data(port) + pos), len);
-      string_length(str) = len;
-      str_chars[len] = '\0';
-      port_position(port) += len;
-#if READ_STRING_LINE_NUMBERS
-      for (s7_int i = 0; i < len; i++) if (str_chars[i] == '\n') port_line_number(port)++;
-#endif
-      return(str);
-    }
-  if (is_file_port(port))
-    {
-      const s7_int len = (s7_int)fread((void *)str_chars, 1, nchars, port_file(port));
-      str_chars[len] = '\0';
-      string_length(str) = len;
-#if READ_STRING_LINE_NUMBERS
-      for (s7_int i = 0; i < len; i++) if (str_chars[i] == '\n') port_line_number(port)++;
-#endif
-      return(str);
-    }
-  for (s7_int i = 0; i < nchars; i++)
-    {
-      const int32_t c = port_read_character(port)(sc, port);
-      if (c == EOF)
-	{
-	  if (i == 0)
-	    return(eof_object);
-	  string_length(str) = i;
-	  return(str);
-	}
-      str_chars[i] = (uint8_t)c;
-#if READ_STRING_LINE_NUMBERS
-      if (c == '\n') port_line_number(port)++;
-#endif
-    }
-  return(str);
-}
-
+/* peek-char, read-byte, read-line, read-string functions moved to s7_scheme_read.c */
 
 /* -------------------------------- read -------------------------------- */
 #define declare_jump_info() bool old_longjmp; setjmp_loc_t old_jump_loc; jump_loc_t jump_loc; Jmp_Buf *old_goto_start; Jmp_Buf new_goto_start
@@ -19532,76 +18908,8 @@ static s7_pointer g_read_string(s7_scheme *sc, s7_pointer args)
   } while (0)
 
 static s7_pointer eval(s7_scheme *sc, opcode_t first_op);
+s7_pointer s7i_eval(s7_scheme *sc, s7_int op) {return(eval(sc, (opcode_t)op));}  /* bridge for s7_scheme_read.c */
 
-s7_pointer s7_read(s7_scheme *sc, s7_pointer port)
-{
-  if (!is_input_port(port))
-    sole_arg_wrong_type_error_nr(sc, sc->read_symbol, port, an_input_port_string);
-  {
-    const s7_pointer old_let = sc->curlet;
-    declare_jump_info();
-    set_curlet(sc, sc->rootlet);
-    push_input_port(sc, port);
-    store_jump_info(sc);
-    set_jump_info(sc, read_set_jump);
-    if (jump_loc != no_jump)
-      {
-	if (jump_loc != error_jump)
-	  eval(sc, sc->cur_op);
-      }
-    else
-      {
-	push_stack_no_let_no_code(sc, OP_BARRIER, port);
-	push_stack_direct(sc, OP_EVAL_DONE);
-	eval(sc, OP_READ_INTERNAL);
-	if (sc->tok == token_eof)
-	  sc->value = eof_object;
-	if ((sc->cur_op == OP_EVAL_DONE) && /* pushed above */
-	    (stack_top_op(sc) == OP_BARRIER))
-	  pop_stack(sc);
-      }
-    pop_input_port(sc);
-    set_curlet(sc, old_let);
-    restore_jump_info(sc);
-    return(sc->value);
-  }
-}
-
-static s7_pointer g_read(s7_scheme *sc, s7_pointer args)
-{
-  #define H_read "(read (port (current-input-port))) returns the next object in the input port, or #<eof> at the end"
-  #define Q_read s7_make_signature(sc, 2, sc->T, sc->is_input_port_symbol)
-
-  s7_pointer port;
-  if (is_pair(args))
-    port = car(args);
-  else
-    {
-      port = input_port_if_not_loading(sc);
-      if (!port) return(eof_object);
-    }
-  if (!is_input_port(port))
-    return(method_or_bust_p(sc, port, sc->read_symbol, an_input_port_string));
-
-  if (is_function_port(port))
-    {
-      s7_pointer result = (*(port_input_function(port)))(sc, S7_READ, port);
-      if (is_multiple_value(result))
-	{
-	  clear_multiple_value(result);
-	  error_nr(sc, sc->bad_result_symbol, set_elist_2(sc, wrap_string(sc, "input-function-port read returned: ~S", 37), result));
-	}
-      return(result);
-    }
-  if ((is_string_port(port)) &&
-      (port_data_size(port) <= port_position(port)))
-    return(eof_object);
-
-  push_input_port(sc, port);
-  push_stack_op_let(sc, OP_READ_DONE); /* this stops the internal read process so we only get one form */
-  push_stack_op_let(sc, OP_READ_INTERNAL);
-  return(port);
-}
 
 
 /* -------------------------------- load -------------------------------- */
@@ -19928,7 +19236,9 @@ s7_pointer s7_load_with_environment(s7_scheme *sc, const char *filename, s7_poin
   store_jump_info(sc);
   set_jump_info(sc, load_set_jump);
   if (jump_loc == no_jump)
+    {
     eval(sc, OP_READ_INTERNAL);
+    }
   else
     if (jump_loc != error_jump)
       eval(sc, sc->cur_op);

--- a/src/s7_internal_helpers.h
+++ b/src/s7_internal_helpers.h
@@ -406,9 +406,8 @@ s7_pointer s7i_eval(s7_scheme *sc, s7_int op);
 block_t *s7i_mallocate_port(s7_scheme *sc);
 void s7i_port_set_filename(s7_scheme *sc, s7_pointer port, const char *name, s7_int len);
 void push_input_port(s7_scheme *sc, s7_pointer new_port);
-s7_pointer method_or_bust(s7_scheme *sc, s7_pointer obj, s7_pointer method, s7_pointer args, s7_pointer typ, int32_t num);
-s7_pointer method_or_bust_p(s7_scheme *sc, s7_pointer obj, s7_pointer method, s7_pointer typ);
-s7_pointer method_or_bust_pp(s7_scheme *sc, s7_pointer obj, s7_pointer method, s7_pointer x1, s7_pointer x2, s7_pointer typ, int32_t num);
+/* method_or_bust/_p/_pp take s7_pointer symbols; declared in s7_scheme_read.c only
+ * (s7_liii_string.c has its own same-named static helpers, so they can't live in a shared header) */
 
 #ifdef __cplusplus
 }

--- a/src/s7_internal_helpers.h
+++ b/src/s7_internal_helpers.h
@@ -394,6 +394,22 @@ s7_pointer s7i_multiply_p_ppp_wrapped(s7_scheme *sc, s7_pointer x, s7_pointer y,
 s7_pointer s7i_invert_p_p(s7_scheme *sc, s7_pointer x);
 s7_pointer s7i_divide_p_pp(s7_scheme *sc, s7_pointer x, s7_pointer y);
 
+/* bridge functions for s7_scheme_read.c (reader migration) */
+int32_t s7i_token(s7_scheme *sc);
+s7_pointer s7i_make_sharp_constant(s7_scheme *sc, const char *name, bool with_error, s7_pointer port, bool error_if_bad_number);
+void s7i_resize_strbuf(s7_scheme *sc, s7_int needed_size);
+void s7i_backchar(char c, s7_pointer port);
+bool s7i_is_loader_port(s7_pointer p);
+s7_pointer s7i_an_input_port_string_obj(void);
+s7_pointer s7i_an_open_input_port_string_obj(void);
+s7_pointer s7i_eval(s7_scheme *sc, s7_int op);
+block_t *s7i_mallocate_port(s7_scheme *sc);
+void s7i_port_set_filename(s7_scheme *sc, s7_pointer port, const char *name, size_t len);
+void push_input_port(s7_scheme *sc, s7_pointer new_port);
+s7_pointer method_or_bust(s7_scheme *sc, s7_pointer obj, s7_pointer method, s7_pointer args, s7_pointer typ, int32_t num);
+s7_pointer method_or_bust_p(s7_scheme *sc, s7_pointer obj, s7_pointer method, s7_pointer typ);
+s7_pointer method_or_bust_pp(s7_scheme *sc, s7_pointer obj, s7_pointer method, s7_pointer x1, s7_pointer x2, s7_pointer typ, int32_t num);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/s7_internal_helpers.h
+++ b/src/s7_internal_helpers.h
@@ -404,7 +404,7 @@ s7_pointer s7i_an_input_port_string_obj(void);
 s7_pointer s7i_an_open_input_port_string_obj(void);
 s7_pointer s7i_eval(s7_scheme *sc, s7_int op);
 block_t *s7i_mallocate_port(s7_scheme *sc);
-void s7i_port_set_filename(s7_scheme *sc, s7_pointer port, const char *name, size_t len);
+void s7i_port_set_filename(s7_scheme *sc, s7_pointer port, const char *name, s7_int len);
 void push_input_port(s7_scheme *sc, s7_pointer new_port);
 s7_pointer method_or_bust(s7_scheme *sc, s7_pointer obj, s7_pointer method, s7_pointer args, s7_pointer typ, int32_t num);
 s7_pointer method_or_bust_p(s7_scheme *sc, s7_pointer obj, s7_pointer method, s7_pointer typ);

--- a/src/s7_scheme_read.c
+++ b/src/s7_scheme_read.c
@@ -126,6 +126,11 @@
   #define add_input_port(sc, p)           add_to_gc_list(sc, sc->input_ports, p)
 #endif
 
+/* s7.c exports (not in a shared header: s7_liii_string.c defines its own same-named helpers) */
+s7_pointer method_or_bust(s7_scheme *sc, s7_pointer obj, s7_pointer method, s7_pointer args, s7_pointer typ, int32_t num);
+s7_pointer method_or_bust_p(s7_scheme *sc, s7_pointer obj, s7_pointer method, s7_pointer typ);
+s7_pointer method_or_bust_pp(s7_scheme *sc, s7_pointer obj, s7_pointer method, s7_pointer x1, s7_pointer x2, s7_pointer typ, int32_t num);
+
 #define declare_jump_info() bool old_longjmp; setjmp_loc_t old_jump_loc; jump_loc_t jump_loc; Jmp_Buf *old_goto_start; Jmp_Buf new_goto_start
 
 #define store_jump_info(Sc)			\

--- a/src/s7_scheme_read.c
+++ b/src/s7_scheme_read.c
@@ -1,0 +1,901 @@
+#include "s7_internal.h"
+#include "s7_scheme_read.h"
+#include "s7_ctables.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* -------- local macros (mirrors of s7.c internals, via s7_internal.h types) -------- */
+
+#ifndef port_file
+  #define port_file(p)                    port_port(p)->file
+#endif
+#ifndef port_data
+  #define port_data(p)                    (T_Prt(p))->object.prt.data
+#endif
+#ifndef port_data_size
+  #define port_data_size(p)               (T_Prt(p))->object.prt.size
+#endif
+#ifndef port_position
+  #define port_position(p)                (T_Prt(p))->object.prt.point
+#endif
+#ifndef port_block
+  #define port_block(p)                   (T_Prt(p))->object.prt.block
+#endif
+#ifndef port_data_block
+  #define port_data_block(p)              port_port(p)->block
+#endif
+#ifndef port_type
+  #define port_type(p)                    port_port(p)->ptype
+#endif
+#ifndef port_line_number
+  #define port_line_number(p)             port_port(p)->line_number
+#endif
+#ifndef port_file_number
+  #define port_file_number(p)             port_port(p)->file_number
+#endif
+#ifndef port_filename
+  #define port_filename(p)                port_port(p)->filename
+#endif
+#ifndef port_filename_length
+  #define port_filename_length(p)         port_port(p)->filename_length
+#endif
+#ifndef port_needs_free
+  #define port_needs_free(p)              port_port(p)->needs_free
+#endif
+#ifndef port_set_closed
+  #define port_set_closed(p, Val)         port_port(p)->is_closed = Val
+#endif
+#ifndef port_set_string_or_function
+  #define port_set_string_or_function(p, S) port_port(p)->orig_str = S
+#endif
+#ifndef port_input_function
+  #define port_input_function(p)          port_port(p)->input_function
+#endif
+#ifndef port_is_closed
+  #define port_is_closed(p)               port_port(p)->is_closed
+#endif
+#ifndef port_read_character
+  #define port_read_character(p)          port_port(p)->pf->read_character
+#endif
+#ifndef port_read_line
+  #define port_read_line(p)               port_port(p)->pf->read_line
+#endif
+#ifndef port_read_white_space
+  #define port_read_white_space(p)        port_port(p)->pf->read_white_space
+#endif
+
+#ifndef is_input_port
+  #define is_input_port(p)                (type(p) == T_INPUT_PORT)
+#endif
+#ifndef is_string_port
+  #define is_string_port(p)               (port_type(p) == string_port)
+#endif
+#ifndef is_function_port
+  #define is_function_port(p)             (port_type(p) == function_port)
+#endif
+#ifndef is_file_port
+  #define is_file_port(p)                 (port_type(p) == file_port)
+#endif
+#ifndef is_character
+  #define is_character(p)                 (type(p) == T_CHARACTER)
+#endif
+#ifndef character
+  #define character(p)                    (T_Chr(p))->object.chr.c
+#endif
+#ifndef is_multiple_value
+  #define is_multiple_value(p)            has_low_type_bit(T_Exs(p), T_MULTIPLE_VALUE)
+#endif
+#ifndef clear_multiple_value
+  #define clear_multiple_value(p)         clear_low_type_bit(T_Pair(p), T_MULTIPLE_VALUE)
+#endif
+#ifndef is_white_space
+  #define is_white_space(C)               white_space[C]
+#endif
+#ifndef is_eof
+  #define is_eof(p)                       ((T_Ext(p)) == eof_object)
+#endif
+#ifndef current_input_port
+  #define current_input_port(Sc)          T_Pri(Sc->input_port)
+#endif
+
+#ifndef push_stack_direct
+  #define push_stack_direct(Sc, Op) \
+    do { \
+        Sc->cur_op = Op; \
+        memcpy((void *)(Sc->stack_end), (void *)Sc, 4 * sizeof(s7_pointer)); \
+        Sc->stack_end += 4; \
+    } while (0)
+#endif
+#ifndef stack_top_op
+  #define stack_top_op(Sc)                ((opcode_t)T_Op(Sc->stack_end[-1]))
+#endif
+
+#ifndef clamp_length
+  #define clamp_length(NLen, Len)         (((NLen) < (Len)) ? (NLen) : (Len))
+#endif
+
+#ifndef SYMBOL_OK
+  #define SYMBOL_OK true
+#endif
+#ifndef WITH_OVERFLOW_ERROR
+  #define WITH_OVERFLOW_ERROR true
+#endif
+
+#ifndef add_input_port
+  #define add_input_port(sc, p)           add_to_gc_list(sc, sc->input_ports, p)
+#endif
+
+#define declare_jump_info() bool old_longjmp; setjmp_loc_t old_jump_loc; jump_loc_t jump_loc; Jmp_Buf *old_goto_start; Jmp_Buf new_goto_start
+
+#define store_jump_info(Sc)			\
+  do {						\
+      old_longjmp = Sc->longjmp_ok;		\
+      old_jump_loc = Sc->setjmp_loc;		\
+      old_goto_start = Sc->goto_start;		\
+  } while (0)
+
+#define restore_jump_info(Sc)			\
+  do {						\
+    Sc->longjmp_ok = old_longjmp;		\
+    Sc->setjmp_loc = old_jump_loc;		\
+    Sc->goto_start = old_goto_start;		\
+    if ((jump_loc == error_jump) &&		\
+	(Sc->longjmp_ok))			\
+      LongJmp(*(Sc->goto_start), error_jump);	\
+  } while (0)
+
+#define set_jump_info(Sc, Tag)			\
+  do {						\
+    Sc->longjmp_ok = true;			\
+    Sc->setjmp_loc = Tag;			\
+    jump_loc = (jump_loc_t)SetJmp(new_goto_start, 1);	\
+    Sc->goto_start = &new_goto_start;		\
+  } while (0)
+
+
+/* -------- read character functions -------- */
+
+int32_t file_read_char(s7_scheme *sc, s7_pointer port)
+{
+  int32_t c = fgetc(port_file(port));
+  if ((c == (int32_t)'\n') && (!s7i_is_loader_port(port))) port_line_number(port)++;
+  return(c);
+}
+
+int32_t function_read_char(s7_scheme *sc, s7_pointer port)
+{
+  const s7_pointer result = (*(port_input_function(port)))(sc, S7_READ_CHAR, port);
+  if (is_eof(result)) return(EOF);
+  if (!is_character(result))          /* port_input_function might return some non-character */
+    {
+      if (is_multiple_value(result))
+	{
+	  clear_multiple_value(result);
+	  s7i_error_nr(sc, sc->bad_result_symbol, s7i_set_elist_2(sc, s7i_wrap_string(sc, "input-function-port read-char returned: ~S", 42), result));
+	}
+      s7i_error_nr(sc, sc->wrong_type_arg_symbol, s7i_set_elist_2(sc, s7i_wrap_string(sc, "input-function-port read-char returned: ~S", 42), result));
+    }
+  return((int32_t)character(result));    /* kinda nutty -- we return chars[this] in g_read_char! */
+}
+
+int32_t string_read_char(s7_scheme *sc, s7_pointer port)
+{
+  uint8_t c;
+  if (port_data_size(port) <= port_position(port)) return(EOF);
+  c = (uint8_t)port_data(port)[port_position(port)++]; /* port_string_length is 0 if no port string, port_data is uint8_t* */
+  if ((c == (uint8_t)'\n') && (!s7i_is_loader_port(port))) port_line_number(port)++;
+  return(c);
+}
+
+int32_t output_read_char(s7_scheme *sc, s7_pointer port) /* not reachable I think */
+{
+  sole_arg_wrong_type_error_nr(sc, sc->read_char_symbol, port, s7i_an_input_port_string_obj());
+  return(0);
+}
+
+int32_t closed_port_read_char(s7_scheme *sc, s7_pointer port)
+{
+  sole_arg_wrong_type_error_nr(sc, sc->read_char_symbol, port, s7i_an_open_input_port_string_obj());
+  return(0);
+}
+
+
+/* -------- read line functions -------- */
+
+s7_pointer output_read_line(s7_scheme *sc, s7_pointer port, bool with_eol) /* not reachable I think */
+{
+  sole_arg_wrong_type_error_nr(sc, sc->read_line_symbol, port, s7i_an_input_port_string_obj());
+  return(NULL);
+}
+
+s7_pointer closed_port_read_line(s7_scheme *sc, s7_pointer port, bool with_eol)
+{
+  sole_arg_wrong_type_error_nr(sc, sc->read_line_symbol, port, s7i_an_open_input_port_string_obj());
+  return(NULL);
+}
+
+s7_pointer function_read_line(s7_scheme *sc, s7_pointer port, bool with_eol)
+{
+  s7_pointer result = (*(port_input_function(port)))(sc, S7_READ_LINE, port);
+  if (is_multiple_value(result))
+    {
+      clear_multiple_value(result);
+      s7i_error_nr(sc, sc->bad_result_symbol, s7i_set_elist_2(sc, s7i_wrap_string(sc, "input-function-port read-line returned: ~S", 42), result));
+    }
+  return(result);
+}
+
+s7_pointer stdin_read_line(s7_scheme *sc, s7_pointer port, bool with_eol)
+{
+  if (!sc->read_line_buf)
+    {
+      sc->read_line_buf_size = 1024;
+      sc->read_line_buf = (char *)malloc(sc->read_line_buf_size);
+    }
+  if (fgets(sc->read_line_buf, sc->read_line_buf_size, stdin))
+    return(s7_make_string(sc, sc->read_line_buf)); /* fgets adds the trailing '\0' */
+  return(eof_object);
+}
+
+s7_pointer file_read_line(s7_scheme *sc, s7_pointer port, bool with_eol)
+{
+  /* read into read_line_buf concatenating reads until newline found.  string is read_line_buf to pos-of-newline.
+   *   reset file position to reflect newline pos.
+   */
+  int32_t reads = 0;
+  char *str;
+  s7_int read_size;
+  if (!sc->read_line_buf)
+    {
+      sc->read_line_buf_size = 1024;
+      sc->read_line_buf = (char *)malloc(sc->read_line_buf_size);
+    }
+  read_size = sc->read_line_buf_size;
+  str = fgets(sc->read_line_buf, read_size, port_file(port)); /* reads size-1 at most, EOF and newline also terminate read */
+  if (!str) return(eof_object);                               /* EOF or error with no char read */
+
+  while (true)
+    {
+      s7_int cur_size;
+      char *buf;
+      const char *snew = strchr(sc->read_line_buf, (int)'\n'); /* or maybe just strlen + end-of-string=newline */
+      if (snew)
+	{
+	  s7_int pos = (s7_int)(snew - sc->read_line_buf);
+	  port_line_number(port)++;
+	  return(s7i_make_string_with_length(sc, sc->read_line_buf, (with_eol) ? (pos + 1) : pos));
+	}
+      reads++;
+      cur_size = strlen(sc->read_line_buf);
+      if ((cur_size + reads) < read_size) /* end of data, no newline */
+	return(s7i_make_string_with_length(sc, sc->read_line_buf, cur_size));
+
+      /* need more data */
+      sc->read_line_buf_size *= 2;
+      sc->read_line_buf = (char *)realloc(sc->read_line_buf, sc->read_line_buf_size);
+      buf = (char *)(sc->read_line_buf + cur_size);
+      str = fgets(buf, read_size, port_file(port));
+      if (!str) return(eof_object);
+      read_size = sc->read_line_buf_size;
+    }
+  return(eof_object);
+}
+
+s7_pointer string_read_line(s7_scheme *sc, s7_pointer port, bool with_eol)
+{
+  s7_int i;
+  const char *port_str = (const char *)port_data(port);
+  const s7_int port_start = port_position(port);
+  const char *start = port_str + port_start;
+  const char *cur = (const char *)strchr(start, (int)'\n'); /* this can run off the end making valgrind unhappy, but I think it's innocuous */
+  if (cur)
+    {
+      s7_int len;
+      port_line_number(port)++;
+      i = cur - port_str;
+      port_position(port) = i + 1;
+      len = ((with_eol) ? i + 1 : i) - port_start;
+      if (len == 0) return(s7i_nil_string());
+      return(s7i_make_string_with_length(sc, start, len));
+    }
+  i = port_data_size(port);
+  port_position(port) = i;
+  if (i <= port_start)         /* the < part can happen -- if not caught we try to create a string of length - 1 -> segfault */
+    return(eof_object);
+  return(s7i_make_string_with_length(sc, start, i - port_start));
+}
+
+
+/* -------- skip to newline readers -------- */
+
+token_t file_read_semicolon(s7_scheme *sc, s7_pointer port)
+{
+  int32_t c;
+  do (c = fgetc(port_file(port))); while ((c != '\n') && (c != EOF));
+  port_line_number(port)++;
+  return((c == EOF) ? token_eof : s7i_token(sc));
+}
+
+token_t string_read_semicolon(s7_scheme *sc, s7_pointer port)
+{
+  const char *str = (const char *)(port_data(port) + port_position(port));
+  const char *orig_str = strchr(str, (int)'\n');
+  if (!orig_str)
+    {
+      port_position(port) = port_data_size(port);
+      return(token_eof);
+    }
+  port_position(port) += (orig_str - str + 1); /* + 1 because strchr leaves orig_str pointing at the newline */
+  port_line_number(port)++;
+  return(s7i_token(sc));
+}
+
+
+/* -------- white space readers -------- */
+
+int32_t file_read_white_space(s7_scheme *sc, s7_pointer port)
+{
+  int32_t c;
+  while (is_white_space(c = fgetc(port_file(port))))
+    if (c == '\n')
+      port_line_number(port)++;
+  return(c);
+}
+
+int32_t terminated_string_read_white_space(s7_scheme *sc, s7_pointer port)
+{
+  const uint8_t *str = (const uint8_t *)(port_data(port) + port_position(port));
+  uint8_t c;
+  /* here we know we have null termination and white_space[#\null] is false */
+  while (white_space[c = *str++]) /* 255 is not -1 = EOF */
+    if (c == '\n')
+      port_line_number(port)++;
+  port_position(port) = (c) ? str - port_data(port) : port_data_size(port);
+  return((int32_t)c);
+}
+
+
+/* -------- name readers -------- */
+#define BASE_10 10
+
+static s7_pointer file_read_name_or_sharp(s7_scheme *sc, s7_pointer port, bool atom_case)
+{
+  int32_t c;
+  s7_int i = 1;  /* sc->strbuf[0] has the first char of the string we're reading */
+  do {
+    c = fgetc(port_file(port)); /* might return EOF */
+    if (c == '\n')
+      port_line_number(port)++;
+
+    sc->strbuf[i++] = (unsigned char)c;
+    if (i >= sc->strbuf_size)
+      s7i_resize_strbuf(sc, i);
+  } while ((c != EOF) && (char_ok_in_a_name[c]));
+
+  if ((i == 2) &&
+      (sc->strbuf[0] == '\\'))
+    sc->strbuf[2] = '\0';
+  else
+    {
+      if (c != EOF)
+	{
+	  if (c == '\n')
+	    port_line_number(port)--;
+	  ungetc(c, port_file(port));
+	}
+      sc->strbuf[i - 1] = '\0';
+    }
+  if (atom_case)
+    return(make_atom(sc, sc->strbuf, BASE_10, SYMBOL_OK, WITH_OVERFLOW_ERROR));
+  return(s7i_make_sharp_constant(sc, sc->strbuf, WITH_OVERFLOW_ERROR, port, true));
+}
+
+s7_pointer file_read_name(s7_scheme *sc, s7_pointer port)  {return(file_read_name_or_sharp(sc, port, true));}
+s7_pointer file_read_sharp(s7_scheme *sc, s7_pointer port) {return(file_read_name_or_sharp(sc, port, false));}
+
+s7_pointer string_read_name_no_free(s7_scheme *sc, s7_pointer port)
+{
+  /* sc->strbuf[0] has the first char of the string we're reading */
+  const uint8_t *str = (uint8_t *)(port_data(port) + port_position(port));
+
+  if (char_ok_in_a_name[*str])
+    {
+      s7_int k;
+      const uint8_t *orig_str = str - 1;
+      str++;
+      while (char_ok_in_a_name[*str]) str++;
+      k = str - orig_str;
+      if (*str != 0)
+	port_position(port) += (k - 1);
+      else port_position(port) = port_data_size(port);
+      /* this is equivalent to:
+       *    str = strpbrk(str, "(); \"\t\r\n");
+       *    if (!str) {k = strlen(orig_str); str = (char *)(orig_str + k);} else k = str - orig_str;
+       * but slightly faster.
+       */
+      if (!number_table[*orig_str])
+	return(s7i_make_symbol_with_length(sc, (const char *)orig_str, k));
+
+      /* eval_c_string string is a constant so we can't set and unset the token's end char */
+      if ((k + 1) >= sc->strbuf_size)
+	s7i_resize_strbuf(sc, k + 1);
+      memcpy((void *)(sc->strbuf), (void *)orig_str, k);
+      sc->strbuf[k] = '\0';
+      return(make_atom(sc, sc->strbuf, BASE_10, SYMBOL_OK, WITH_OVERFLOW_ERROR));
+    }
+  {
+    s7_pointer result = sc->singletons[(uint8_t)(sc->strbuf[0])];
+    if (!result)
+      {
+	sc->strbuf[1] = '\0';
+	result = s7_make_symbol(sc, sc->strbuf);
+	sc->singletons[(uint8_t)(sc->strbuf[0])] = result;
+      }
+    return(result);
+  }
+}
+
+s7_pointer string_read_sharp(s7_scheme *sc, s7_pointer port)
+{
+  /* sc->strbuf[0] has the first char of the string we're reading.
+   *   since a *#readers* function might want to get further input, we can't mess with the input even when it is otherwise safe
+   */
+  char *str = (char *)(port_data(port) + port_position(port));
+  if (char_ok_in_a_name[(uint8_t)*str])
+    {
+      s7_int k;
+      const char *orig_str = (char *)(str - 1);
+      str++;
+      while (char_ok_in_a_name[(uint8_t)(*str)]) {str++;}
+      k = str - orig_str;
+      port_position(port) += (k - 1);
+      if ((k + 1) >= sc->strbuf_size)
+	s7i_resize_strbuf(sc, k + 1);
+      memcpy((void *)(sc->strbuf), (void *)orig_str, k);
+      sc->strbuf[k] = '\0';
+      return(s7i_make_sharp_constant(sc, sc->strbuf, WITH_OVERFLOW_ERROR, port, true));
+    }
+  if (sc->strbuf[0] == 'f') return(sc->F);
+  if (sc->strbuf[0] == 't') return(sc->T);
+  if (sc->strbuf[0] == '\\')
+    {
+      /* must be from #\( and friends -- a character that happens to be not ok-in-a-name */
+      sc->strbuf[1] = str[0];
+      sc->strbuf[2] = '\0';
+      port_position(port)++;
+    }
+  else sc->strbuf[1] = '\0';
+  return(s7i_make_sharp_constant(sc, sc->strbuf, WITH_OVERFLOW_ERROR, port, true));
+}
+
+s7_pointer string_read_name(s7_scheme *sc, s7_pointer port)
+{
+  /* port_string was allocated (and read from a file) so we can mess with it directly */
+  s7_pointer result;
+  uint8_t *str = (uint8_t *)(port_data(port) + port_position(port));
+  if (char_ok_in_a_name[*str])
+    {
+      s7_int k;
+      uint8_t endc;
+      const uint8_t *orig_str = str - 1;
+      str++;
+      while (char_ok_in_a_name[*str]) str++;
+      k = str - orig_str;
+      port_position(port) += (k - 1);
+      if (!number_table[*orig_str])
+	return(s7i_make_symbol_with_length(sc, (const char *)orig_str, k));
+      endc = *str;
+      *str = 0; /* temp end for make_atom */
+      result = make_atom(sc, (char *)orig_str, BASE_10, SYMBOL_OK, WITH_OVERFLOW_ERROR);
+      *str = endc;
+      return(result);
+    }
+  result = sc->singletons[(uint8_t)(sc->strbuf[0])];
+  if (!result)
+    {
+      sc->strbuf[1] = '\0';
+      result = s7_make_symbol(sc, sc->strbuf);
+      sc->singletons[(uint8_t)(sc->strbuf[0])] = result;
+    }
+  return(result);
+}
+
+
+/* -------- file port creation -------- */
+
+s7_pointer read_file(s7_scheme *sc, FILE *fp, const char *name, s7_int max_size, const char *caller)
+{
+  s7_pointer port;
+  s7_int size;
+  block_t *b = s7i_mallocate_port(sc);
+  new_cell(sc, port, T_INPUT_PORT);
+  gc_protect_via_stack(sc, port);
+  port_block(port) = b;
+  port_port(port) = (port_t *)s7i_block_data(b);
+  port_set_closed(port, false);
+  port_set_string_or_function(port, sc->nil);
+  port_filename_length(port) = s7i_safe_strlen(name);
+  s7i_port_set_filename(sc, port, name, port_filename_length(port));
+  port_line_number(port) = 1;  /* first line is numbered 1 */
+  port_file_number(port) = 0;
+  add_input_port(sc, port);
+
+#if MS_WINDOWS
+  /* MS C's fseek/ftell truncate large files: use the 64-bit-safe variants */
+  if ((_fseeki64(fp, 0, SEEK_END) != 0) ||
+      ((size = _ftelli64(fp)) < 0))
+    size = 0;
+  rewind(fp);
+#else
+  fseek(fp, 0, SEEK_END);
+  size = ftell(fp);
+  rewind(fp);
+#endif
+  /* pseudo files (under /proc for example) have size=0, but we can read them, so don't assume a 0 length file is empty */
+  if ((size > 0) &&   /* if (size != 0) we get (open-input-file "/dev/tty") -> (open "/dev/tty") read 0 bytes of an expected -1? */
+      ((max_size < 0) || (size < max_size))) /* load uses max_size = -1 */
+    {
+      block_t *block = s7i_mallocate(sc, size + 2);
+      uint8_t *content = (uint8_t *)(s7i_block_data(block));
+      const size_t bytes = fread(content, sizeof(uint8_t), size, fp);
+      if (bytes != (size_t)size)
+	{
+	  /* in MS Windows text mode, CRLF -> LF translation makes the read size smaller than the file size */
+	  if (ferror(fp) || (bytes == 0))
+	    {
+	      if (s7i_current_output_port(sc) != sc->F)
+		{
+		  char tmp[256];
+		  int32_t len = snprintf(tmp, 256, "(%s \"%s\") read %ld bytes of an expected %" ld64 "?", caller, name, (long)bytes, size);
+		  port_write_string(s7i_current_output_port(sc))(sc, tmp, clamp_length(len, 256), s7i_current_output_port(sc));
+		}
+	    }
+	  size = bytes;
+	}
+      content[size] = '\0';
+      content[size + 1] = '\0';
+      fclose(fp);
+
+      port_file(port) = NULL; /* make valgrind happy */
+      port_type(port) = string_port;
+      port_data(port) = content;
+      port_data_block(port) = block;
+      port_data_size(port) = size;
+      port_position(port) = 0;
+      port_needs_free(port) = true;
+      port_port(port)->pf = s7i_input_string_functions_1();
+    }
+  else
+    {
+      port_file(port) = fp;
+      port_type(port) = file_port;
+      port_data(port) = NULL;
+      port_data_block(port) = NULL;
+      port_data_size(port) = 0;
+      port_position(port) = 0;
+      port_needs_free(port) = false;
+      port_port(port)->pf = s7i_input_file_functions();
+    }
+  unstack_gc_protect(sc);
+  return(port);
+}
+
+
+/* -------- current-input-port handling -------- */
+
+s7_pointer input_port_if_not_loading(s7_scheme *sc)
+{
+  const s7_pointer port = current_input_port(sc);
+  int32_t c;
+  if (!s7i_is_loader_port(port)) /* this flag is turned off by the reader macros, so we aren't in that context */
+    return(port);
+  c = port_read_white_space(port)(sc, port);
+  if (c > 0)            /* we can get either EOF or NULL at the end */
+    {
+      s7i_backchar(c, port);
+      return(NULL);
+    }
+  return(sc->standard_input);
+}
+
+s7_pointer s7i_input_port_if_not_loading(s7_scheme *sc)
+{
+  return(input_port_if_not_loading(sc));
+}
+
+s7_pointer s7i_port_read_line(s7_scheme *sc, s7_pointer port, bool with_eol)
+{
+  return(port_read_line(port)(sc, port, with_eol));
+}
+
+
+/* -------------------------------- read-char -------------------------------- */
+s7_pointer s7_read_char(s7_scheme *sc, s7_pointer port)
+{
+  int32_t c = port_read_character(port)(sc, port);
+  return((c == EOF) ? eof_object : chars[c]);
+}
+
+s7_pointer g_read_char(s7_scheme *sc, s7_pointer args)
+{
+  #define H_read_char "(read-char (port (current-input-port))) returns the next character in the input port"
+  #define Q_read_char s7_make_signature(sc, 2, s7_make_signature(sc, 2, sc->is_char_symbol, sc->is_eof_object_symbol), sc->is_input_port_symbol)
+
+  s7_pointer port;
+  if (is_pair(args))
+    port = car(args);
+  else
+    {
+      port = input_port_if_not_loading(sc);
+      if (!port) return(eof_object);
+    }
+  if (!is_input_port(port))
+    return(method_or_bust_p(sc, port, sc->read_char_symbol, s7i_an_input_port_string_obj()));
+  return(chars[port_read_character(port)(sc, port)]);
+}
+
+s7_pointer read_char_p_p(s7_scheme *sc, s7_pointer port)
+{
+  if (!is_input_port(port))
+    return(method_or_bust_p(sc, port, sc->read_char_symbol, s7i_an_input_port_string_obj()));
+  return(chars[port_read_character(port)(sc, port)]);
+}
+
+s7_pointer g_read_char_1(s7_scheme *sc, s7_pointer args)
+{
+  s7_pointer port = car(args);
+  if (!is_input_port(port))
+    return(method_or_bust_p(sc, port, sc->read_char_symbol, s7i_an_input_port_string_obj()));
+  return(chars[port_read_character(port)(sc, port)]);
+}
+
+s7_pointer read_char_chooser(s7_scheme *sc, s7_pointer func, int32_t args, s7_pointer unused_expr)
+{
+  return((args == 1) ? sc->read_char_1 : func);
+}
+
+
+/* -------------------------------- peek-char -------------------------------- */
+s7_pointer s7_peek_char(s7_scheme *sc, s7_pointer port)
+{
+  int32_t c;              /* needs to be an int32_t so EOF=-1, but not 255 */
+  if (is_string_port(port))
+    return((port_data_size(port) <= port_position(port)) ? eof_object : chars[(uint8_t)port_data(port)[port_position(port)]]);
+  c = port_read_character(port)(sc, port);
+  if (c == EOF) return(eof_object);
+  s7i_backchar(c, port);
+  return(chars[c]);
+}
+
+s7_pointer g_peek_char(s7_scheme *sc, s7_pointer args)
+{
+  #define H_peek_char "(peek-char (port (current-input-port))) returns the next character in the input port, but does not remove it from the input stream"
+  #define Q_peek_char s7_make_signature(sc, 2, s7_make_signature(sc, 2, sc->is_char_symbol, sc->is_eof_object_symbol), sc->is_input_port_symbol)
+
+  s7_pointer result;
+  const s7_pointer port = (is_pair(args)) ? car(args) : current_input_port(sc);
+  if (!is_input_port(port))
+    return(method_or_bust_p(sc, port, sc->peek_char_symbol, s7i_an_input_port_string_obj()));
+  if (port_is_closed(port))
+    sole_arg_wrong_type_error_nr(sc, sc->peek_char_symbol, port, s7i_an_open_input_port_string_obj());
+  if (!is_function_port(port))
+    return(s7_peek_char(sc, port));
+
+  result = (*(port_input_function(port)))(sc, S7_PEEK_CHAR, port);
+  if (is_multiple_value(result))
+    {
+      clear_multiple_value(result);
+      s7i_error_nr(sc, sc->bad_result_symbol,
+	       s7i_set_elist_2(sc, s7i_wrap_string(sc, "input-function-port peek-char returned multiple values: ~S", 58), result));
+    }
+  if (!is_character(result))
+    s7i_error_nr(sc, sc->wrong_type_arg_symbol,
+	     s7i_set_elist_2(sc, s7i_wrap_string(sc, "input-function-port peek-char returned: ~S", 42), result));
+  return(result);
+}
+
+
+/* -------------------------------- read-byte -------------------------------- */
+s7_pointer g_read_byte(s7_scheme *sc, s7_pointer args)
+{
+  #define H_read_byte "(read-byte (port (current-input-port))): reads a byte from the input port"
+  #define Q_read_byte s7_make_signature(sc, 2, s7_make_signature(sc, 2, sc->is_byte_symbol, sc->is_eof_object_symbol), sc->is_input_port_symbol)
+
+  s7_pointer port;
+  int32_t c;
+  if (is_pair(args))
+    port = car(args);
+  else
+    {
+      port = input_port_if_not_loading(sc);
+      if (!port) return(eof_object);
+    }
+  if (!is_input_port(port))
+    return(method_or_bust_p(sc, port, sc->read_byte_symbol, s7i_an_input_port_string_obj()));
+  if (port_is_closed(port))          /* avoid reporting caller here as read-char */
+    sole_arg_wrong_type_error_nr(sc, sc->read_byte_symbol, port, s7i_an_open_input_port_string_obj());
+  c = port_read_character(port)(sc, port);
+  return((c == EOF) ? eof_object : s7i_small_int(c));
+}
+
+
+/* -------------------------------- read-line -------------------------------- */
+/* g_read_line is now implemented in s7_scheme_base.c */
+
+s7_pointer read_line_p_pp(s7_scheme *sc, s7_pointer port, s7_pointer with_eol)
+{
+  if (!is_input_port(port))
+    return(method_or_bust_pp(sc, port, sc->read_line_symbol, port, with_eol, s7i_an_input_port_string_obj(), 1));
+  if (!is_boolean(with_eol))
+    s7_wrong_type_arg_error(sc, "read-line", 2, with_eol, s7i_a_boolean_string());
+  return(port_read_line(port)(sc, port, with_eol != sc->F));
+}
+
+s7_pointer read_line_p_p(s7_scheme *sc, s7_pointer port)
+{
+  if (!is_input_port(port))
+    return(method_or_bust_p(sc, port, sc->read_line_symbol, s7i_an_input_port_string_obj()));
+  return(port_read_line(port)(sc, port, false)); /* with_eol default is #f */
+}
+
+
+/* -------------------------------- read-string -------------------------------- */
+#define READ_STRING_LINE_NUMBERS 0 /* 1 adds port-line-number support to read-string, doubling the time it takes */
+
+s7_pointer g_read_string(s7_scheme *sc, s7_pointer args)
+{
+  /* read-chars would be a better name -- read-string could mean CL-style read-from-string (like eval-string)
+   *   similarly read-bytes could return a byte-vector (rather than r7rs's read-bytevector)
+   *   and write-string -> write-chars, write-bytevector -> write-bytes.
+   * should this worry about newlines?  read-char and read-line keep port-line-number up to date,
+   *   but here we'd need to scan the new string (via strchr?) or xor with \n\n\n\n... up to 8-at-a-time, and count zeros.
+   */
+  #define H_read_string "(read-string k port) reads k characters from port into a new string and returns it."
+  #define Q_read_string s7_make_signature(sc, 3, \
+                          s7_make_signature(sc, 2, sc->is_string_symbol, sc->is_eof_object_symbol), \
+                          sc->is_integer_symbol, sc->is_input_port_symbol)
+  const s7_pointer k = car(args);
+  s7_pointer port, str;
+  s7_int nchars;
+  uint8_t *str_chars;
+
+  if (!s7_is_integer(k))
+    return(method_or_bust(sc, k, sc->read_string_symbol, args, sc->type_names[T_INTEGER], 1));
+  nchars = s7i_integer_clamped_if_gmp(sc, k);
+  if (nchars < 0)
+    s7_out_of_range_error(sc, "read-string", 1, k, "it is negative");
+  if (nchars > sc->max_string_length)
+    s7i_error_nr(sc, sc->out_of_range_symbol,
+	     s7i_set_elist_3(sc, s7i_wrap_string(sc, "read-string first argument ~D is greater than (*s7* 'max-string-length), ~D", 75),
+			 s7i_wrap_integer(sc, nchars), s7i_wrap_integer(sc, sc->max_string_length)));
+  if (!is_null(cdr(args)))
+    port = cadr(args);
+  else
+    {
+      port = input_port_if_not_loading(sc);
+      if (!port) return(eof_object);
+    }
+  if (!is_input_port(port))
+    return(method_or_bust_pp(sc, port, sc->read_string_symbol, k, port, s7i_an_input_port_string_obj(), 2));
+  if (port_is_closed(port))
+    sole_arg_wrong_type_error_nr(sc, sc->read_string_symbol, port, s7i_an_open_input_port_string_obj());
+
+  str = s7i_make_empty_string(sc, nchars, '\0');
+  if (nchars == 0) return(str);
+  str_chars = (uint8_t *)s7i_string_value(str);
+  if (is_string_port(port))
+    {
+      const s7_int pos = port_position(port);
+      const s7_int end = port_data_size(port);
+      s7_int len = end - pos;
+      if (len > nchars) len = nchars;
+      if (len <= 0) return(eof_object);
+      memcpy((void *)str_chars, (void *)(port_data(port) + pos), len);
+      s7i_set_string_length(str, len);
+      str_chars[len] = '\0';
+      port_position(port) += len;
+#if READ_STRING_LINE_NUMBERS
+      for (s7_int i = 0; i < len; i++) if (str_chars[i] == '\n') port_line_number(port)++;
+#endif
+      return(str);
+    }
+  if (is_file_port(port))
+    {
+      const s7_int len = (s7_int)fread((void *)str_chars, 1, nchars, port_file(port));
+      str_chars[len] = '\0';
+      s7i_set_string_length(str, len);
+#if READ_STRING_LINE_NUMBERS
+      for (s7_int i = 0; i < len; i++) if (str_chars[i] == '\n') port_line_number(port)++;
+#endif
+      return(str);
+    }
+  for (s7_int i = 0; i < nchars; i++)
+    {
+      const int32_t c = port_read_character(port)(sc, port);
+      if (c == EOF)
+	{
+	  if (i == 0)
+	    return(eof_object);
+	  s7i_set_string_length(str, i);
+	  return(str);
+	}
+      str_chars[i] = (uint8_t)c;
+#if READ_STRING_LINE_NUMBERS
+      if (c == '\n') port_line_number(port)++;
+#endif
+    }
+  return(str);
+}
+
+
+/* -------------------------------- read -------------------------------- */
+s7_pointer s7_read(s7_scheme *sc, s7_pointer port)
+{
+  if (!is_input_port(port))
+    sole_arg_wrong_type_error_nr(sc, sc->read_symbol, port, s7i_an_input_port_string_obj());
+  {
+    const s7_pointer old_let = sc->curlet;
+    declare_jump_info();
+    set_curlet(sc, sc->rootlet);
+    push_input_port(sc, port);
+    store_jump_info(sc);
+    set_jump_info(sc, read_set_jump);
+    if (jump_loc != no_jump)
+      {
+	if (jump_loc != error_jump)
+	  s7i_eval(sc, sc->cur_op);
+      }
+    else
+      {
+	push_stack_no_let_no_code(sc, OP_BARRIER, port);
+	push_stack_direct(sc, OP_EVAL_DONE);
+	s7i_eval(sc, OP_READ_INTERNAL);
+	if (sc->tok == token_eof)
+	  sc->value = eof_object;
+	if ((sc->cur_op == OP_EVAL_DONE) && /* pushed above */
+	    (stack_top_op(sc) == OP_BARRIER))
+	  pop_stack(sc);
+      }
+    pop_input_port(sc);
+    set_curlet(sc, old_let);
+    restore_jump_info(sc);
+    return(sc->value);
+  }
+}
+
+s7_pointer g_read(s7_scheme *sc, s7_pointer args)
+{
+  #define H_read "(read (port (current-input-port))) returns the next object in the input port, or #<eof> at the end"
+  #define Q_read s7_make_signature(sc, 2, sc->T, sc->is_input_port_symbol)
+
+  s7_pointer port;
+  if (is_pair(args))
+    port = car(args);
+  else
+    {
+      port = input_port_if_not_loading(sc);
+      if (!port) return(eof_object);
+    }
+  if (!is_input_port(port))
+    return(method_or_bust_p(sc, port, sc->read_symbol, s7i_an_input_port_string_obj()));
+
+  if (is_function_port(port))
+    {
+      s7_pointer result = (*(port_input_function(port)))(sc, S7_READ, port);
+      if (is_multiple_value(result))
+	{
+	  clear_multiple_value(result);
+	  s7i_error_nr(sc, sc->bad_result_symbol, s7i_set_elist_2(sc, s7i_wrap_string(sc, "input-function-port read returned: ~S", 37), result));
+	}
+      return(result);
+    }
+  if ((is_string_port(port)) &&
+      (port_data_size(port) <= port_position(port)))
+    return(eof_object);
+
+  push_input_port(sc, port);
+  push_stack_op_let(sc, OP_READ_DONE); /* this stops the internal read process so we only get one form */
+  push_stack_op_let(sc, OP_READ_INTERNAL);
+  return(port);
+}

--- a/src/s7_scheme_read.h
+++ b/src/s7_scheme_read.h
@@ -1,0 +1,85 @@
+/* s7_scheme_read.h - read function declarations for s7 Scheme interpreter
+ *
+ * derived from s7, a Scheme interpreter
+ * SPDX-License-Identifier: 0BSD
+ *
+ * Bill Schottstaedt, bil@ccrma.stanford.edu
+ */
+
+#ifndef S7_SCHEME_READ_H
+#define S7_SCHEME_READ_H
+
+#include "s7.h"
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* globals defined in s7.c (chars[EOF] is #<eof>) */
+extern s7_pointer *chars;
+extern s7_pointer eof_object;
+
+/* port read primitives (referenced by the port_functions_t tables in s7.c) */
+int32_t file_read_char(s7_scheme *sc, s7_pointer port);
+int32_t function_read_char(s7_scheme *sc, s7_pointer port);
+int32_t string_read_char(s7_scheme *sc, s7_pointer port);
+int32_t output_read_char(s7_scheme *sc, s7_pointer port);
+int32_t closed_port_read_char(s7_scheme *sc, s7_pointer port);
+
+s7_pointer output_read_line(s7_scheme *sc, s7_pointer port, bool with_eol);
+s7_pointer closed_port_read_line(s7_scheme *sc, s7_pointer port, bool with_eol);
+s7_pointer function_read_line(s7_scheme *sc, s7_pointer port, bool with_eol);
+s7_pointer stdin_read_line(s7_scheme *sc, s7_pointer port, bool with_eol);
+s7_pointer file_read_line(s7_scheme *sc, s7_pointer port, bool with_eol);
+s7_pointer string_read_line(s7_scheme *sc, s7_pointer port, bool with_eol);
+
+#ifdef S7_INTERNAL_H
+/* token_t is defined in s7_internal.h (s7.c has its own copy and declares these itself) */
+token_t file_read_semicolon(s7_scheme *sc, s7_pointer port);
+token_t string_read_semicolon(s7_scheme *sc, s7_pointer port);
+const port_functions_t *s7i_input_file_functions(void);
+const port_functions_t *s7i_input_string_functions_1(void);
+#endif
+
+int32_t file_read_white_space(s7_scheme *sc, s7_pointer port);
+int32_t terminated_string_read_white_space(s7_scheme *sc, s7_pointer port);
+
+s7_pointer file_read_name(s7_scheme *sc, s7_pointer port);
+s7_pointer file_read_sharp(s7_scheme *sc, s7_pointer port);
+s7_pointer string_read_name_no_free(s7_scheme *sc, s7_pointer port);
+s7_pointer string_read_sharp(s7_scheme *sc, s7_pointer port);
+s7_pointer string_read_name(s7_scheme *sc, s7_pointer port);
+
+/* file port creation */
+s7_pointer read_file(s7_scheme *sc, FILE *fp, const char *name, s7_int max_size, const char *caller);
+
+/* Public API implementations */
+s7_pointer s7_read(s7_scheme *sc, s7_pointer port);
+s7_pointer s7_read_char(s7_scheme *sc, s7_pointer port);
+s7_pointer s7_peek_char(s7_scheme *sc, s7_pointer port);
+
+/* Scheme accessible functions */
+s7_pointer g_read(s7_scheme *sc, s7_pointer args);
+s7_pointer g_read_char(s7_scheme *sc, s7_pointer args);
+s7_pointer g_read_char_1(s7_scheme *sc, s7_pointer args);
+s7_pointer g_peek_char(s7_scheme *sc, s7_pointer args);
+s7_pointer g_read_byte(s7_scheme *sc, s7_pointer args);
+s7_pointer g_read_string(s7_scheme *sc, s7_pointer args);
+
+/* Optimizer helpers */
+s7_pointer read_char_p_p(s7_scheme *sc, s7_pointer port);
+s7_pointer read_char_chooser(s7_scheme *sc, s7_pointer func, int32_t args, s7_pointer unused_expr);
+s7_pointer read_line_p_p(s7_scheme *sc, s7_pointer port);
+s7_pointer read_line_p_pp(s7_scheme *sc, s7_pointer port, s7_pointer with_eol);
+
+/* Export helpers */
+s7_pointer input_port_if_not_loading(s7_scheme *sc);
+s7_pointer s7i_port_read_line(s7_scheme *sc, s7_pointer port, bool with_eol);
+s7_pointer s7i_input_port_if_not_loading(s7_scheme *sc);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* S7_SCHEME_READ_H */

--- a/xmake.lua
+++ b/xmake.lua
@@ -124,6 +124,7 @@ target ("goldfish") do
     add_files ("src/s7_scheme_complex.c", {languages = "c11"})
     add_files ("src/s7_scheme_char.c", {languages = "c11"})
     add_files ("src/s7_scheme_write.c", {languages = "c11"})
+    add_files ("src/s7_scheme_read.c", {languages = "c11"})
     add_files ("src/s7_liii_bitwise.c", {languages = "c11"})
     add_files ("src/s7_liii_string.c", {languages = "c11"})
     add_files ("src/s7_liii_hash_table.c", {languages = "c11"})


### PR DESCRIPTION
## 概述

继 write 侧拆出 s7_scheme_write.c 之后，将 read 侧代码从 s7.c（8.6 万行）拆分到新文件 src/s7_scheme_read.c / s7_scheme_read.h（净减约 740 行）。

## 变更内容

- 迁移 port 读原语（file/string/function/closed_port 的 read_char、read_line、read_semicolon、read_white_space、read_name/read_sharp）
- 迁移 read_file()（0135 优化的整体读入快路径）
- 迁移 Scheme 层函数：s7_read、g_read、s7_read_char、g_read_char、read_char_p_p、read_char_chooser、s7_peek_char、g_peek_char、g_read_byte、read_line_p_p(_pp)、g_read_string、input_port_if_not_loading 等
- 深层 static 依赖通过 s7i_* 桥接函数导出（s7i_token、s7i_eval、s7i_make_sharp_constant、s7i_resize_strbuf、s7i_backchar 等），声明加入 s7_internal_helpers.h
- push_input_port、method_or_bust_pp 去掉 static 导出
- port 函数表留在 s7.c，通过访问器桥接供 read_file 使用
- 热路径（string_read_char、string_read_name）使用本地宏直访 port 字段，无额外函数调用开销

## 验证

- tests/scheme 下 302 个测试全部通过
- tests/liii、tests/srfi 下 67 个测试全部通过
- bench/read-perf.scm：读取全部仓库 .scm 文件 10 次迭代 1.73s（0135 基线 2.34s，无回退）

## 已知坑

s7.c 中 port_data_block(p) 指向 port_port(p)->block（port_t 字段），与 port_block(p)（cell 的 object.prt.block）是不同字段，read.c 中的本地宏必须与 s7.c 一致，详见 devel/0136.md。

🤖 Generated with [Claude Code](https://claude.com/claude-code)