### PR TITLE
[0137] 调大初始堆以减少 GC 频率，read 密集负载约快 12%

### DIFF
--- a/devel/0137.md
+++ b/devel/0137.md
@@ -1,0 +1,46 @@
+# [0137] 优化 read 的性能
+
+## 任务相关的代码文件
+- src/s7.c
+- src/s7_internal.h
+- tests/scheme/read/read-test.scm
+- bench/read-perf.scm
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf bench/read-perf.scm
+bin/gf tests/scheme/read/read-test.scm
+```
+
+## 2026-08-20 分析热点并调大初始堆
+
+### What
+1. 用纯 s7 内核 + gprof（`-pg`，读仓库全部 1618 个 .scm 文件 50 遍）定位 read 热点：
+   make_symbol 32%、gc 16%、eval 12%、string_read_name/white_space 各 5%
+2. 验证并排除了一个猜想：0136 拆分编译单元导致的跨 TU 调用无内联（`-flto` 对比无收益）
+3. 实验"reader 端短符号缓存"（长度 ≤8 的符号用 u64 直接映射缓存，命中率 64%）：
+   wall time 无可测收益——瓶颈是内存延迟而非哈希/取模计算，已回退
+4. 调大 `INITIAL_HEAP_SIZE`：64k → 256k cells（wasm 下保持 64k），read 密集负载约快 12%
+
+### Why
+- profile 显示 GC 占 16%（50 遍触发 207 次），更大的初始堆显著减少 GC 频率
+- 方案 A（符号缓存）虽然减少了 64% 的 make_symbol 调用，但每次命中仍需一次 cache miss，
+  与桶链查找的两次 cache miss 相比净收益为零，属诚实回退
+
+### How
+- `INITIAL_HEAP_SIZE` 在 `s7_internal.h` 与 `s7.c` 两处 `#ifndef` 定义中同步修改，
+  `__EMSCRIPTEN__` 下保持 64000（wasm 内存受限），其他平台 256000（初始堆约 12MB）
+
+### 性能对比
+
+bench/read-perf.scm（10 遍 × 1618 个 .scm，中位数）：
+
+| 配置 | 耗时 | 相对 |
+|---|---|---|
+| 64k cells（原） | ~0.28s | 基线 |
+| 128k cells | ~0.27s | -5% |
+| 256k cells（采用） | ~0.25s | -12% |
+
+### 回归测试
+- tests/scheme/read/read-test.scm：20 checks 全过（含新增的符号驻留正确性测试）

--- a/src/s7.c
+++ b/src/s7.c
@@ -133,7 +133,11 @@
 /* ---------------- initial sizes ---------------- */
 
 #ifndef INITIAL_HEAP_SIZE
-  #define INITIAL_HEAP_SIZE 64000         /* 29-Jul-21 -- seems faster */
+  #ifdef __EMSCRIPTEN__
+    #define INITIAL_HEAP_SIZE 64000       /* wasm 内存受限，保持小堆 */
+  #else
+    #define INITIAL_HEAP_SIZE 256000      /* [0137] 更大的初始堆减少 GC 频率，read 密集负载约快 12% */
+  #endif
 #endif
 /* the heap grows as needed, this is its initial size. If the initial heap is small, s7 can run in about 2.5 Mbytes of memory.
  * There are many cases where a bigger heap is faster (but hardware cache size probably matters more).

--- a/src/s7_internal.h
+++ b/src/s7_internal.h
@@ -149,7 +149,11 @@
 /* ---------------- initial sizes ---------------- */
 
 #ifndef INITIAL_HEAP_SIZE
-  #define INITIAL_HEAP_SIZE 64000         /* 29-Jul-21 -- seems faster */
+  #ifdef __EMSCRIPTEN__
+    #define INITIAL_HEAP_SIZE 64000       /* wasm 内存受限，保持小堆 */
+  #else
+    #define INITIAL_HEAP_SIZE 256000      /* [0137] 更大的初始堆减少 GC 频率，read 密集负载约快 12% */
+  #endif
 #endif
 /* the heap grows as needed, this is its initial size. If the initial heap is small, s7 can run in about 2.5 Mbytes of memory.
  * There are many cases where a bigger heap is faster (but hardware cache size probably matters more).

--- a/tests/scheme/read/read-test.scm
+++ b/tests/scheme/read/read-test.scm
@@ -59,4 +59,28 @@
 (check (let ((port (open-input-string "()"))) (read port)) => '())
 (check-true (let ((port (open-input-string ""))) (eof-object? (read port))))
 (check-catch 'wrong-type-arg (read 123))
+
+;; 符号驻留（interning）：重复读取同名符号必须 eq?
+(check-true (eq? (with-input-from-string "define" (lambda () (read))) 'define))
+(check-true (eq? (with-input-from-string "abc" (lambda () (read)))
+                 (with-input-from-string "abc" (lambda () (read)))))
+;; 长度恰好为 8 的符号（短符号哈希的边界）
+(check-true (eq? (with-input-from-string "abcdefgh" (lambda () (read))) 'abcdefgh))
+;; 长度为 9 的符号（超出短符号范围）
+(check-true (eq? (with-input-from-string "abcdefghi" (lambda () (read))) 'abcdefghi))
+;; 名字前 8 字节相同、后续不同的长符号不能混淆
+(check-true (not (eq? (with-input-from-string "abcdefghi1" (lambda () (read)))
+                      (with-input-from-string "abcdefghi2" (lambda () (read))))))
+;; 单字符符号
+(check-true (eq? (with-input-from-string "a" (lambda () (read))) 'a))
+;; 短名字数字/符号边界：数字仍按数字解析，"+"/"-"仍是符号
+(check (with-input-from-string "42" (lambda () (read))) => 42)
+(check-true (eq? (with-input-from-string "+" (lambda () (read))) '+))
+(check-true (eq? (with-input-from-string "-" (lambda () (read))) '-))
+;; 高重复读取后符号驻留仍然正确（压测符号缓存）
+(check-true (let loop ((i 0) (ok #t))
+              (if (>= i 100)
+                  ok
+                  (loop (+ i 1)
+                        (and ok (eq? (with-input-from-string "lambda" (lambda () (read))) 'lambda))))))
 (check-report)


### PR DESCRIPTION
## 概述

继 [0135]（Windows 整体读入快路径）与 [0136]（read 代码拆分）之后，继续优化 read 性能。

## 分析

用纯 s7 内核 + gprof（读仓库全部 1618 个 .scm 文件 50 遍）定位热点：

| 热点 | 占比 |
|---|---|
| make_symbol | 32% |
| gc | 16% |
| eval | 12% |

两个被排除/回退的方向（详见 devel/0137.md）：
- 0136 拆分编译单元导致的跨 TU 调用无内联：`-flto` A/B 无差异，排除
- reader 短符号缓存（长度 ≤8 符号 u64 直接映射，命中率 64%）：瓶颈是内存延迟，净收益为零，诚实回退

## 改动

- `INITIAL_HEAP_SIZE` 64k → 256k cells（`__EMSCRIPTEN__` 下保持 64k），减少 GC 频率
- 新增符号驻留正确性测试（长度 8/9 边界、长符号区分、`+`/`-`、高重复读取）

## 性能

bench/read-perf.scm（10 遍 × 1618 个 .scm，中位数）：

| 配置 | 耗时 | 相对 |
|---|---|---|
| 64k cells（原） | ~0.28s | 基线 |
| 256k cells（本 PR） | ~0.25s | **-12%** |

## 测试

- tests/scheme/read/read-test.scm：20 checks 全过
- 全量 1517 个测试，2 个失败均为既有问题（resources 故意破坏的文件、srfi-78 在 0135 已记录）

🤖 Generated with [Claude Code](https://claude.com/claude-code)