### PR TITLE
[0139] CD 增加 de-gitee 并禁用 libcurl 系统包回退

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -46,6 +46,9 @@ jobs:
     - name: git add safe directory
       run: git config --global --add safe.directory '*'
 
+    - name: de-gitee
+      run: sed -i '/gitee\.com/d' xmake/packages/s/s7/xmake.lua
+
     - name: Determine Version
       id: get_version
       run: |

--- a/xmake/packages/l/libcurl/xmake.lua
+++ b/xmake/packages/l/libcurl/xmake.lua
@@ -54,14 +54,8 @@ package("libcurl")
                          "iphlpapi", "secur32", "bcrypt", "normaliz")
         end
 
-        if package:is_plat("mingw") and is_subhost("msys") then
-            package:add("extsources", "pacman::curl")
-        elseif package:is_plat("linux") then
-            package:add("extsources", "pacman::curl", "apt::libcurl4-gnutls-dev", "apt::libcurl4-nss-dev", "apt::libcurl4-openssl-dev")
-        elseif package:is_plat("macosx") then
-            package:add("extsources", "brew::curl")
-        end
-
+        -- 只使用 3rdparty 内的 curl 源码构建，禁止回退到系统包
+        -- （CD 环境装了 devscripts/debhelper 会带入系统 libcurl，与静态 openssl 混链出问题）
         if package:is_plat("windows", "mingw") then
             if not package:config("shared") then
                 package:add("defines", "CURL_STATICLIB")


### PR DESCRIPTION
## 修改内容
1. `package.yml` Linux job 增加 de-gitee 步骤（与 CI 保持一致），避免容器内拉取 gitee 源失败
2. `libcurl` 配方删除 `extsources`（apt/pacman/brew 系统 libcurl 回退），强制只使用 `3rdparty/curl-8.21.0` 源码构建——CD 环境因 devscripts/debhelper 引入系统 libcurl 导致 xmake config 阶段命中系统包

## 测试
- [ ] 手动触发 XPack Build workflow 验证 Linux job 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)