### PR TITLE
[0139] CD deb 打包排除 curl 源码内构建目录，修复 CMakeCache 路径不匹配

### DIFF
--- a/devel/0139.md
+++ b/devel/0139.md
@@ -2,12 +2,41 @@
 
 ## 任务相关的代码文件
 - .github/workflows/package.yml
+- xmake.lua
 
 ## 如何测试
 ```bash
-xmake b goldfish
+# 按 package.yml 的 CD 步骤本地模拟：
+# 1. 取 xmake v3.0.8 的 deb 模板到 .tmp/xpack-deb-template/debian（见 package.yml）
+# 2. 对 xmake.lua 应用 CI 的三处 sed（见 package.yml "Config and Build" 步骤）
+xmake pack -f deb -vyD goldfish
 ```
-观察 CI package.yml 工作流是否正常执行。
+
+## 2026-08-24 CD deb 打包排除 curl 源码内构建目录
+
+### What
+1. 在 `xmake.lua` 的 xpack `add_sourcefiles` 列表中新增
+   `add_sourcefiles("__remove_(3rdparty/curl-*/build-*/**)")`
+2. 本地按 CD 步骤复现并验证：修复前报 CMakeCache 路径不匹配错误，修复后
+   `xmake pack -f deb` 成功生成 deb，`build-*` 目录 0 个文件被打包
+
+### Why
+- `xmake/packages/l/libcurl` 配方以 in-source 方式在
+  `3rdparty/curl-8.21.0/build-<hash>/` 构建 curl（按包实例拆分构建目录，见
+  devel/2092.md）；
+- CI 先 `xmake build goldfish` 在该目录留下含绝对路径的 `CMakeCache.txt`，
+  随后 `xmake pack -f deb` 的 `add_sourcefiles("(3rdparty/**)")` 把它复制进
+  deb 源码包（xpack 复制不理会 `.gitignore`）；
+- debuild 在复制出来的源码树里重新构建 curl 时，CMake 检测到缓存目录与
+  当前目录不一致即报错。
+
+### How
+- 用 xmake 的 `__remove_` 模式前缀（见
+  `xmake/core/base/private/match_copyfiles.lua`）把 `build-*` 目录从源码包
+  中剔除；
+- 不能用 `(3rdparty/**|3rdparty/curl-*/build-*/**)` 排除语法：`|` 之后的
+  内容会先被截断再计算 rootdir，导致结尾括号丢失、目录结构判断失效，整个
+  3rdparty 会被平铺复制到包根目录。
 
 ## 2026-08-24 Linux 打包 CD 增加 pkg-config 依赖
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -240,6 +240,10 @@ xpack ("goldfish")
     add_sourcefiles("(tests/**)")
     add_sourcefiles("(tools/**)")
     add_sourcefiles("(3rdparty/**)")
+    -- 排除 libcurl 配方在源码目录内的构建目录（xmake/packages/l/libcurl 用
+    -- build-<hash> 做 in-source 构建）：其 CMakeCache.txt 记录了打包机的绝对
+    -- 路径，随源码包复制到 deb 构建目录后 CMake 会因缓存路径不匹配而报错
+    add_sourcefiles("__remove_(3rdparty/curl-*/build-*/**)")
     add_sourcefiles("gfproject.json")
     add_sourcefiles("node-rules.json")
     on_load(function (package)


### PR DESCRIPTION
## 问题
CD 打包 deb 时报错：
```
CMake Error: The current CMakeCache.txt directory .../tmp/build/.xpack/goldfish/deb/source/deb/3rdparty/curl-8.21.0/build-731... is different than the directory .../3rdparty/curl-8.21.0/build-731... where CMakeCache.txt was created.
```

## 根因
- `xmake/packages/l/libcurl` 配方以 in-source 方式在 `3rdparty/curl-8.21.0/build-<hash>/` 构建 curl；
- CI 先 `xmake build goldfish`（在该目录留下含绝对路径的 `CMakeCache.txt`），再 `xmake pack -f deb` 时 `add_sourcefiles("(3rdparty/**)")` 把这个目录也复制进 deb 源码包（xpack 不理会 .gitignore）；
- debuild 在复制出来的源码树里重新构建 curl，CMake 检测到缓存路径与当前路径不一致即报错。

## 修复
在 xmake.lua 的 xpack 源文件列表中用 `__remove_` 模式排除该构建目录：
```lua
add_sourcefiles("__remove_(3rdparty/curl-*/build-*/**)")
```
（不能用 `(3rdparty/**|排除)` 语法：`|` 会截断 rootdir 计算，导致整个 3rdparty 目录平铺复制。）

## 验证
按 package.yml 的 CD 步骤本地复现：
- 修复前：本地完整复现 CI 报错（同样的 CMakeCache 路径不匹配 + installdir.failed）；
- 修复后：`xmake pack -f deb -vyD goldfish` 成功，日志确认 `build-731…/` 目录 0 个文件被复制，curl 源文件目录结构正常，生成 `goldfish-scheme-x86_64-v18.11.30.deb`（2.1M）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)