### PR TITLE
[0140] 导出 write-string 和 cyclic-sequences 并补充测试文档

### DIFF
--- a/devel/0140.md
+++ b/devel/0140.md
@@ -1,0 +1,82 @@
+# [0140] 将 object->port 打印引擎从 s7.c 拆分到 s7_scheme_write.c
+
+## 任务相关的代码文件
+- src/s7.c（cycles/object->port 区块：20612–24026，约 3400 行）
+- src/s7_scheme_write.c（接收方）
+- src/s7_scheme_write.h
+- src/s7_internal_helpers.h（s7i_* 桥接声明）
+- goldfish/scheme/write.scm（导出 write-string）
+- goldfish/liii/base.scm（导出 cyclic-sequences）
+- tests/scheme/write/write-string-test.scm（新增）
+- tests/liii/base/cyclic-sequences-test.scm（新增）
+
+## 如何测试
+```bash
+xmake b goldfish
+bin/gf tests/scheme/write/write-string-test.scm
+bin/gf tests/liii/base/cyclic-sequences-test.scm
+bin/gf tests/scheme/write/write-test.scm
+bin/gf tests/scheme/write/display-test.scm
+bin/gf tests/scheme/write/write-shared-test.scm
+bin/gf tests/scheme/write/write-simple-test.scm
+bin/gf tests/scheme/base/write-char-test.scm
+bin/gf tests/scheme/base/newline-test.scm
+bin/gf tests/scheme/base/number-to-string-test.scm
+bin/gf tests/liii/base/object-to-string-test.scm
+bin/gf tests/liii/base/format-test.scm
+bin/gf doc --build-json
+bin/gf tests/test_all.scm
+```
+
+## 涉及的 Scheme 函数及所属库
+
+object->port 区块本身是内部打印引擎（77 个 `*_to_port` 函数，无 Scheme 绑定），
+它对外支撑以下 Scheme 可见函数：
+
+| 函数 | 所属库 | 测试/文档现状 |
+|---|---|---|
+| write | (scheme write) | ✓ tests/scheme/write/write-test.scm |
+| display | (scheme write) | ✓ tests/scheme/write/display-test.scm |
+| write-shared | (scheme write) | ✓ tests/scheme/write/write-shared-test.scm |
+| write-simple | (scheme write) | ✓ tests/scheme/write/write-simple-test.scm |
+| write-char | (scheme base) | ✓ tests/scheme/base/write-char-test.scm |
+| newline | (scheme base) | ✓ tests/scheme/base/newline-test.scm |
+| number->string | (scheme base) | ✓ tests/scheme/base/number-to-string-test.scm |
+| object->string | (liii base) | ✓ tests/liii/base/object-to-string-test.scm |
+| format | (liii base) | ✓ tests/liii/base/format-test.scm |
+| write-string | (scheme write) | 本任务新增导出与测试 |
+| cyclic-sequences | (liii base) | 本任务新增导出与测试 |
+
+## 迁移耦合面（前期依赖调查结论）
+
+迁移单元：s7.c 20612–24026，即 cycles/shared-info 环检测机制 + object->port 打印引擎，约 3400 行。
+
+外部 → 区块（需导出，8 个）：
+- object_out（已有 s7i_object_out 桥接）、init_display_functions（init 调用一次）、symbol_to_port（已导出）
+- closure_name（eval/apply 报错用，10 处）、find_closure / find_typer / hash_table_typer_name（hash-table 代码用）
+- pair_append（21 处，通用 pair 工具，放错位置，需挪位或导出）
+- circular_list_entries（1 处）
+
+区块 → 外部（53 个，大头已就绪）：
+- 10 个 s7 公开 API、13 个已 extern/s7i 桥接，零工作量
+- 约 15 个 static 需 s7i_* 桥接：number_to_string_base_10 / integer_to_string / floatify / insert_spaces（数字打印）、
+  resize_port_data / string_write_string_resized（port 内部）、type_name / tree_is_cyclic / hash_table_iterate 等
+- pos_int_to_str 系列等小工具可随迁
+- eq/equal 区块（33975）仅用 clear_shared_info，导出声明即可
+
+## 2026-08-26 第一步：为涉及函数补齐测试与文档
+
+### What
+1. `write-string`：goldfish/scheme/write.scm 导出（符合 R7RS），新增 tests/scheme/write/write-string-test.scm
+2. `cyclic-sequences`：goldfish/liii/base.scm 导出，新增 tests/liii/base/cyclic-sequences-test.scm
+3. `bin/gf doc --build-json` 更新函数索引
+
+### Why
+迁移前先为打印引擎对外支撑的全部函数建立测试与文档基线（bin/gf doc 可访问），
+后续迁移过程中以这些测试保证行为不回退。
+
+## 后续步骤（迁移本体，另行提交）
+
+1. 第一步提交：cycles/shared-info 机制 + pair_append 挪位（约 450 行，小步验证）
+2. 第二步提交：object->port 主体（约 2966 行）
+3. 每步保证上表所有函数的测试全部通过

--- a/goldfish/liii/base.scm
+++ b/goldfish/liii/base.scm
@@ -5,7 +5,7 @@
     string->keyword symbol->keyword keyword->symbol loose-car loose-cdr compose
     identity any? typed-lambda make-hook hook-functions with-output-to-string
     with-input-from-string call-with-input-string call-with-output-string
-    reverse! sort! format
+    reverse! sort! format cyclic-sequences
   ) ;export
   (begin
 

--- a/goldfish/scheme/write.scm
+++ b/goldfish/scheme/write.scm
@@ -15,7 +15,7 @@
 ;;
 
 (define-library (scheme write)
-  (export display write write-shared write-simple)
+  (export display write write-shared write-simple write-string)
   (begin
 
     (define write-simple write)

--- a/tests/liii/base/cyclic-sequences-test.scm
+++ b/tests/liii/base/cyclic-sequences-test.scm
@@ -1,0 +1,57 @@
+(import (liii check))
+(import (liii base))
+
+
+(check-set-mode! 'report-failed)
+
+
+;; cyclic-sequences
+;; 返回对象内部所有环形（循环引用）子结构组成的列表。
+;;
+;; 语法
+;; ----
+;; (cyclic-sequences obj)
+;;
+;; 参数
+;; ----
+;; obj : any?
+;; 要检查的对象。
+;;
+;; 返回值
+;; ------
+;; list?
+;; 对象中所有环形子结构的列表；若不存在环形结构，返回空列表。
+;;
+;; 描述
+;; ----
+;; 1. 普通（无环）对象返回空列表。
+;; 2. 环形列表（如尾部的 cdr 指回自身）会被检测出来。
+;; 3. 嵌套结构中的环形子结构也会被检测出来。
+;; 4. 常用于在打印、遍历前检测循环引用，避免无限递归。
+
+
+;; 普通对象没有环形结构
+(check (cyclic-sequences 42) => '())
+(check (cyclic-sequences "hello") => '())
+(check (cyclic-sequences '(1 2 3)) => '())
+(check (cyclic-sequences #(1 2 3)) => '())
+
+
+;; 环形列表：尾部的 cdr 指回自身
+(let ((x (list 1 2 3)))
+  (set-cdr! (cddr x) x)
+  (check (pair? (cyclic-sequences x)) => #t)
+  (check (car (cyclic-sequences x)) => x)
+) ;let
+
+
+;; 嵌套结构中的环形子结构
+(let ((inner (list 'a 'b)))
+  (set-cdr! (cdr inner) inner)
+  (let ((outer (list 1 inner 3)))
+    (check (pair? (cyclic-sequences outer)) => #t)
+  ) ;let
+) ;let
+
+
+(check-report)

--- a/tests/scheme/write/write-string-test.scm
+++ b/tests/scheme/write/write-string-test.scm
@@ -1,0 +1,56 @@
+(import (liii check) (scheme write))
+(check-set-mode! 'report-failed)
+
+;; write-string
+;; 将字符串按 display 风格（不带引号）写入输出端口。
+;;
+;; 语法
+;; ----
+;; (write-string string)
+;; (write-string string port)
+;; (write-string string port start)
+;; (write-string string port start end)
+;;
+;; 参数
+;; ----
+;; string : string?
+;; 要输出的字符串。
+;;
+;; port : output-port? (可选)
+;; 输出端口。省略时，写入当前输出端口。
+;;
+;; start : integer? (可选)
+;; 起始下标（含），默认为 0。
+;;
+;; end : integer? (可选)
+;; 结束下标（不含），默认为字符串长度。
+;;
+;; 返回值
+;; ----
+;; unspecified
+;; 主要用于副作用输出。
+;;
+;; 描述
+;; ----
+;; 1. `write-string` 输出字符串内容本身，不带双引号（与 `display` 风格一致）。
+;; 2. 可以通过 start 和 end 只输出字符串的一个区间。
+
+(define (capture-output thunk)
+  (let ((port (open-output-string)))
+    (thunk port)
+    (get-output-string port)
+  ) ;let
+) ;define
+
+(check-true (procedure? write-string))
+
+(check (capture-output (lambda (port) (write-string "goldfish" port))) => "goldfish")
+
+;; 输出不带双引号，与 write 不同
+(check (capture-output (lambda (port) (write-string "a\"b" port))) => "a\"b")
+
+;; start 和 end 指定输出区间：[start, end)
+(check (capture-output (lambda (port) (write-string "goldfish" port 4))) => "fish")
+(check (capture-output (lambda (port) (write-string "goldfish" port 0 4))) => "gold")
+
+(check-report)


### PR DESCRIPTION
## 概述

object->port 迁移（s7.c → s7_scheme_write.c）的第一步：为打印引擎涉及的全部函数建立测试与文档基线。

## 改动

- `(scheme write)` 导出 `write-string`（符合 R7RS），新增 `tests/scheme/write/write-string-test.scm`
- `(liii base)` 导出 `cyclic-sequences`，新增 `tests/liii/base/cyclic-sequences-test.scm`
- 新增 `devel/0140.md` 任务文档（涉及函数清单、耦合面调查、迁移计划）

## 验证

- 新增测试 12 个用例全部通过
- `bin/gf test --all`：1515 个测试全部通过
- `bin/gf doc write-string` / `bin/gf doc cyclic-sequences` 可访问

🤖 Generated with [Claude Code](https://claude.com/claude-code)