### PR TITLE
[0140] 将 cycles/shared-info 环检测机制从 s7.c 迁移到 s7_scheme_write.c

### DIFF
--- a/devel/0140.md
+++ b/devel/0140.md
@@ -64,6 +64,31 @@ object->port 区块本身是内部打印引擎（77 个 `*_to_port` 函数，无
 - pos_int_to_str 系列等小工具可随迁
 - eq/equal 区块（33975）仅用 clear_shared_info，导出声明即可
 
+## 2026-08-26 第二步：迁移 cycles/shared-info 机制（第一步提交）
+
+### What
+1. 将 s7.c 的 cycles 区块（shared_ref / flip_ref / peek_shared_ref_1 / peek_shared_ref /
+   enlarge_shared_info / check_collected / collect_shared_info / collect_vector_info /
+   make_shared_info / free_shared_info / clear_shared_info / load_shared_info /
+   cyclic_sequences_p_p，约 443 行）迁移到 s7_scheme_write.c
+2. `pair_append`（通用 pair 工具，eval 用 21 处）从 object->port 区块挪出，去掉 static 导出
+3. `hash_keys_not_cyclic`（s7.c 哈希表区块）去掉 static，声明加入 s7_internal_helpers.h
+4. `shared_info_t` 在两个定义处（s7.c / s7_internal.h）都加 `struct shared_info` 标签，
+   s7_scheme_write.h 用 `struct shared_info *` 前置声明导出走写模块接口
+5. s7_internal.h 新增镜像宏 42 个（is_collected_unchecked / set_cyclic / has_structure /
+   t_structure_p 等类型谓词表 extern 声明等），Malloc/Calloc/Realloc 带 S7_DEBUGGING 条件分支
+6. write.c 改用已有的 `s7i_check_free_heap_size` 桥接
+
+### How
+- 编译错误驱动的固定点迭代：gcc -fsyntax-only 收集未定义标识符，从 s7.c 提取对应
+  `#define` 块（含续行）追加到 s7_internal.h，直到收敛
+- s7_scheme_write.c 改为 include s7_internal.h（含完整 struct s7_scheme 与宏）
+
+### 验证
+- xmake b goldfish 编译通过
+- bin/gf test --all：1515 个测试全部通过
+- 所有 include s7_internal.h 的模块（write/read/let/continuation）语法检查通过
+
 ## 2026-08-26 第一步：为涉及函数补齐测试与文档
 
 ### What

--- a/src/s7.c
+++ b/src/s7.c
@@ -1074,7 +1074,7 @@ typedef struct heap_block_t {
   struct heap_block_t *next;
 } heap_block_t;
 
-typedef struct {
+typedef struct shared_info {
   s7_pointer *objs;
   int32_t size, top, ref, size2;
   bool has_hits;
@@ -20609,454 +20609,31 @@ static s7_pointer g_iterator_is_at_end(s7_scheme *sc, s7_pointer args)
 /* iterator-length and iterator-position run up against the function iterator */
 
 
-/* -------- cycles -------- */
-
-#define INITIAL_SHARED_INFO_SIZE 8
-
-static int32_t shared_ref(shared_info_t *ci, const s7_pointer p)
-{
-  /* from print after collecting refs, not called by equality check, only called in object_to_port_with_circle_check_1 */
-  s7_pointer *objs = ci->objs;
-  for (int32_t i = 0; i < ci->top; i++)
-    if (objs[i] == p)
-      {
-	int32_t val = ci->refs[i];
-	if (val > 0)
-	  ci->refs[i] = -ci->refs[i];
-	return(val);
-      }
-  return(0);
-}
-
-static void flip_ref(shared_info_t *ci, const s7_pointer p)
-{
-  s7_pointer *objs = ci->objs;
-  for (int32_t i = 0; i < ci->top; i++)
-    if (objs[i] == p)
-      {
-	ci->refs[i] = -ci->refs[i];
-	break;
-      }
-}
-
-static int32_t peek_shared_ref_1(shared_info_t *ci, const s7_pointer p)
-{
-  /* returns 0 if not found, otherwise the ref value for p */
-  s7_pointer *objs = ci->objs;
-  for (int32_t i = 0; i < ci->top; i++)
-    if (objs[i] == p)
-      return(ci->refs[i]);
-  return(0);
-}
-
-static int32_t peek_shared_ref(shared_info_t *ci, s7_pointer p)
-{
-  /* returns 0 if not found, otherwise the ref value for p */
-  return((is_collected_unchecked(p)) ? peek_shared_ref_1(ci, p) : 0);
-}
-
-static void enlarge_shared_info(shared_info_t *ci)
-{
-  ci->size *= 2;
-  ci->size2 = ci->size - 2;
-  ci->objs = (s7_pointer *)Realloc(ci->objs, ci->size * sizeof(s7_pointer));
-  ci->refs = (int32_t *)Realloc(ci->refs, ci->size * sizeof(int32_t));
-  ci->defined = (bool *)Realloc(ci->defined, ci->size * sizeof(bool));
-  /* this clearing is needed, memclr is not faster */
-  for (int32_t i = ci->top; i < ci->size; i++)
-    {
-      ci->refs[i] = 0;
-      ci->objs[i] = NULL;
-    }
-}
-
-static bool check_collected(s7_pointer top, shared_info_t *ci)
-{
-  const s7_pointer *objs_end = (s7_pointer *)(ci->objs + ci->top);
-  for (s7_pointer *p = ci->objs; p < objs_end; p++)
-    if ((*p) == top)
-      {
-	int32_t i = (int32_t)(p - ci->objs);
-	if (ci->refs[i] == 0)
-	  {
-	    ci->has_hits = true;
-	    ci->refs[i] = ++ci->ref;  /* if found, set the ref number */
-	  }
-	break;
-      }
-  set_cyclic(top);
-  return(true);
-}
-
-static bool collect_shared_info(s7_scheme *sc, shared_info_t *ci, s7_pointer top, bool stop_at_print_length);
-static bool hash_keys_not_cyclic(s7_scheme *sc, s7_pointer hash);
-
-static bool collect_vector_info(s7_scheme *sc, shared_info_t *ci, s7_pointer top, bool stop_at_print_length)
-{
-  s7_int plen;
-  bool cyclic = false;
-
-  if (stop_at_print_length)
-    {
-      plen = sc->print_length;
-      if (plen > vector_length(top))
-	plen = vector_length(top);
-    }
-  else plen = vector_length(top);
-  for (s7_int i = 0; i < plen; i++)
-    {
-      const s7_pointer vel = vector_element_unchecked(top, i);   /* "unchecked" because top might be rootlet, I think */
-      if ((has_structure(vel)) &&
-	  (collect_shared_info(sc, ci, vel, stop_at_print_length)))
-	{
-	  set_cyclic(vel);
-	  cyclic = true;
-	  if ((is_c_pointer(vel)) ||
-	      (is_iterator(vel)) ||
-	      (is_c_object(vel)))
-	    check_collected(top, ci);
-	}}
-  if (cyclic) set_cyclic(top);
-  return(cyclic);
-}
-
-static bool collect_shared_info(s7_scheme *sc, shared_info_t *ci, s7_pointer top, bool stop_at_print_length)
-{
-  /* look for top in current list.
-   * As we collect objects (guaranteed to have structure) we set the collected bit.  If we ever
-   *   encounter an object with that bit on, we've seen it before so we have a possible cycle.
-   *   Once the collection pass is done, we run through our list, and clear all these bits.
-   */
-  bool top_cyclic;
-
-  if (is_collected_or_shared(top))
-    return((!is_shared(top)) && (check_collected(top, ci)));
-
-  /* top not seen before -- add it to the list */
-  set_collected(top);
-  if (ci->top == ci->size)
-    enlarge_shared_info(ci);
-  ci->objs[ci->top++] = top;
-
-  top_cyclic = false;
-  /* now search the rest of this structure */
-  if (is_pair(top))
-    {
-      s7_pointer p;
-      if ((has_structure(car(top))) &&
-	  (collect_shared_info(sc, ci, car(top), stop_at_print_length)))
-	top_cyclic = true;
-
-      for (p = cdr(top); is_pair(p); p = cdr(p))
-	{
-	  if (is_collected_or_shared(p))
-	    {
-	      set_cyclic(top);
-	      set_cyclic(p);
-	      if (!is_shared(p))
-		return(check_collected(p, ci));
-	      if (!top_cyclic)
-		for (s7_pointer cp = top; cp != p; cp = cdr(cp)) set_shared(cp);
-	      return(top_cyclic);
-	    }
- 	  set_collected(p);
-	  if (ci->top == ci->size)
-	    enlarge_shared_info(ci);
-	  ci->objs[ci->top++] = p;
-	  if ((has_structure(car(p))) &&
-	      (collect_shared_info(sc, ci, car(p), stop_at_print_length)))
-	    top_cyclic = true;
-	}
-      if ((has_structure(p)) &&
-	  (collect_shared_info(sc, ci, p, stop_at_print_length)))
-	{
-	  set_cyclic(top);
-	  return(true);
-	}
-      if (!top_cyclic)
-	for (s7_pointer cp = top; is_pair(cp); cp = cdr(cp)) set_shared(cp);
-      else set_cyclic(top);
-      return(top_cyclic);
-    }
-  switch (type(top))
-    {
-    case T_VECTOR:
-      if (collect_vector_info(sc, ci, top, stop_at_print_length))
-	top_cyclic = true;
-      break;
-
-    case T_ITERATOR:
-      if ((is_sequence(iterator_sequence(top))) && /* might be a function with +iterator+ local */
-	  (collect_shared_info(sc, ci, iterator_sequence(top), stop_at_print_length)))
-	{
-	  if (peek_shared_ref(ci, iterator_sequence(top)) == 0)
-	    check_collected(iterator_sequence(top), ci);
-	  top_cyclic = true;
-	}
-      break;
-
-    case T_HASH_TABLE:
-      if (hash_table_entries(top) > 0)
-	{
-	  const s7_int len = (s7_int)hash_table_size(top);
-	  hash_entry_t **entries = hash_table_elements(top);
-	  const bool keys_safe = hash_keys_not_cyclic(sc, top);
-	  for (s7_int i = 0; i < len; i++)
-	    for (hash_entry_t *entry = entries[i]; entry; entry = hash_entry_next(entry))
-	      {
-		if ((!keys_safe) &&
-		    (has_structure(hash_entry_key(entry))) &&
-		    (collect_shared_info(sc, ci, hash_entry_key(entry), stop_at_print_length)))
-		  top_cyclic = true;
-		if ((has_structure(hash_entry_value(entry))) &&
-		    (collect_shared_info(sc, ci, hash_entry_value(entry), stop_at_print_length)))
-		  {
-		    if ((is_c_pointer(hash_entry_value(entry))) ||
-			(is_iterator(hash_entry_value(entry))) ||
-			(is_c_object(hash_entry_value(entry))))
-		      check_collected(top, ci);
-		    top_cyclic = true;
-		  }}}
-      break;
-
-    case T_SLOT: /* this can be hit if we somehow collect_shared_info on sc->rootlet via collect_vector_info (see the let case below) */
-      if ((has_structure(slot_value(top))) &&
-	  (collect_shared_info(sc, ci, slot_value(top), stop_at_print_length)))
-	top_cyclic = true;
-      break;
-
-    case T_LET:
-      if (top == sc->rootlet)
-	{
-	  if (collect_vector_info(sc, ci, top, stop_at_print_length))
-	    top_cyclic = true;
-	}
-      else
-	for (s7_pointer let = top; let; let = let_outlet(let))
-	  for (s7_pointer slot = let_slots(let); is_not_slot_end(slot); slot = next_slot(slot))
-	    if ((has_structure(slot_value(slot))) &&
-		(collect_shared_info(sc, ci, slot_value(slot), stop_at_print_length)))
-	      {
-		top_cyclic = true;
-		if ((is_c_pointer(slot_value(slot))) ||
-		    (is_iterator(slot_value(slot))) ||
-		    (is_c_object(slot_value(slot))))
-		  check_collected(top, ci);
-	      }
-      break;
-
-    case T_CLOSURE: case T_CLOSURE_STAR:
-      if (collect_shared_info(sc, ci, closure_body(top), stop_at_print_length))
-	{
-	  if (peek_shared_ref(ci, top) == 0)
-	    check_collected(top, ci);
-	  top_cyclic = true;
-	}
-      break;
-
-    case T_C_POINTER:
-      if ((has_structure(c_pointer_type(top))) &&
-	  (collect_shared_info(sc, ci, c_pointer_type(top), stop_at_print_length)))
-	{
-	  if (peek_shared_ref(ci, c_pointer_type(top)) == 0)
-	    check_collected(c_pointer_type(top), ci);
-	  top_cyclic = true;
-	}
-      if ((has_structure(c_pointer_info(top))) &&
-	  (collect_shared_info(sc, ci, c_pointer_info(top), stop_at_print_length)))
-	{
-	  if (peek_shared_ref(ci, c_pointer_info(top)) == 0)
-	    check_collected(c_pointer_info(top), ci);
-	  top_cyclic = true;
-	}
-      break;
-
-    case T_C_OBJECT:
-      if ((c_object_to_list(sc, top)) &&
-	  (c_object_set(sc, top)) &&
-	  (collect_shared_info(sc, ci, (*(c_object_to_list(sc, top)))(sc, set_plist_1(sc, top)), stop_at_print_length)))
-	{
-	  if (peek_shared_ref(ci, top) == 0)
-	    check_collected(top, ci);
-	  top_cyclic = true;
-	}
-      break;
-    }
-  if (!top_cyclic)
-    set_shared(top);
-  else set_cyclic(top);
-  return(top_cyclic);
-}
-
-static shared_info_t *make_shared_info(s7_scheme *sc)
-{
-  shared_info_t *ci = (shared_info_t *)Calloc(1, sizeof(shared_info_t));
-  ci->size = INITIAL_SHARED_INFO_SIZE;
-  ci->size2 = ci->size - 2;
-  ci->objs = (s7_pointer *)Malloc(ci->size * sizeof(s7_pointer));
-  ci->refs = (int32_t *)Calloc(ci->size, sizeof(int32_t));   /* finder expects 0 = unseen previously */
-  ci->defined = (bool *)Calloc(ci->size, sizeof(bool));
-  ci->cycle_port = sc->F;
-  ci->init_port = sc->F;
-  return(ci);
-}
-
-static void free_shared_info(shared_info_t *ci)
-{
-  if (ci)
-    {
-      free(ci->objs);
-      free(ci->refs);
-      free(ci->defined);
-      free(ci);
-    }
-}
-
-static inline shared_info_t *clear_shared_info(shared_info_t *ci)
-{
-  if (ci->top > 0)
-    {
-      memclr((void *)(ci->refs), ci->top * sizeof(int32_t));
-      memclr((void *)(ci->defined), ci->top * sizeof(bool));
-      for (int32_t i = 0; i < ci->top; i++)
-	clear_cyclic_bits(ci->objs[i]); /* LOOP_4 is not faster */
-      ci->top = 0;
-    }
-  ci->ref = 0;
-  ci->has_hits = false;
-  ci->ctr = 0;
-  return(ci);
-}
-
-static shared_info_t *load_shared_info(s7_scheme *sc, s7_pointer top, bool stop_at_print_length, shared_info_t *ci)
-{
-  /* for the printer, here only if is_structure(top) and top is not sc->rootlet */
-  bool no_problem = true;
-  s7_int stop_len;
-
-  /* check for simple cases first */
-  if (is_pair(top))
-    {
-      s7_pointer p = top;
-      if (stop_at_print_length)
-	{
-	  s7_pointer slow = top;
-	  stop_len = sc->print_length;
-	  for (s7_int k = 0; k < stop_len; k += 2)
-	    {
-	      if (!is_pair(p)) break;
-	      if (has_structure(car(p))) {no_problem = false; break;}
-	      p = cdr(p);
-	      if (!is_pair(p)) break;
-	      if (has_structure(car(p))) {no_problem = false; break;}
-	      p = cdr(p);
-	      slow = cdr(slow);
-	      if (p == slow) {no_problem = false; break;}
-	    }}
-      else
-	if (s7_list_length(sc, top) == 0) /* it is circular at the top level (following cdr) */
-	  no_problem = false;
-	else
-	  for (; is_pair(p); p = cdr(p))
-	    if (has_structure(car(p))) {no_problem = false; break;} /* perhaps (and (length > 0 via sequence_is_empty)) or vector typer etc */
-      if ((no_problem) &&
-	  (!is_null(p)) && (has_structure(p)))
-	no_problem = false;
-      if (no_problem) return(NULL);
-    }
-  else
-    if (is_t_vector(top)) /* any other vector can't happen */
-      {
-	stop_len = vector_length(top);
-	if ((stop_at_print_length) &&
-	    (stop_len > sc->print_length))
-	  stop_len = sc->print_length;
-	for (s7_int k = 0; k < stop_len; k++)
-	  if (has_structure(vector_element(top, k))) {no_problem = false; break;}
-	if (no_problem) return(NULL);
-      }
-
-    else /* added these 19-Oct-22 -- helps in tgc, but not much elsewhere */
-      if ((is_let(top)) && (top != sc->rootlet))
-	{
-	  for (s7_pointer let = top; (no_problem) && (let); let = let_outlet(let))
-	    for (s7_pointer slot = let_slots(let); is_not_slot_end(slot); slot = next_slot(slot))
-	      if (has_structure(slot_value(slot))) /* slot_symbol need not be checked? */
-		{no_problem = false; break;}
-	  if (no_problem) return(NULL);
-	}
-      else
-	if (is_hash_table(top))
-	  {
-	    hash_entry_t **entries = hash_table_elements(top);
-	    bool keys_safe = hash_keys_not_cyclic(sc, top);
-	    if (hash_table_entries(top) == 0) return(NULL);
-	    for (s7_int len = (s7_int)hash_table_size(top), i = 0; i < len; i++)
-	      for (hash_entry_t *entry = entries[i]; entry; entry = hash_entry_next(entry))
-		if (((!keys_safe) && (has_structure(hash_entry_key(entry)))) || (has_structure(hash_entry_value(entry))))
-		  {no_problem = false; break;}
-	    if (no_problem) return(NULL);
-	  }
-
-  if ((S7_DEBUGGING) && (is_any_vector(top)) && (!is_t_vector(top))) fprintf(stderr, "%s[%d]: got abnormal vector\n", __func__, __LINE__);
-  clear_shared_info(ci);
-  {
-    /* collect all pointers associated with top */
-    const bool cyclic = collect_shared_info(sc, ci, top, stop_at_print_length);
-    s7_pointer *ci_objs = ci->objs;
-    int32_t *ci_refs = ci->refs;
-    int32_t refs = 0;
-
-    for (int32_t i = 0; i < ci->top; i++)
-      clear_collected_and_shared(ci_objs[i]);
-    if (!cyclic)
-      return(NULL);
-    if (!(ci->has_hits))
-      return(NULL);
-
-    /* find if any were referenced twice (once for just being there, so twice=shared)
-     *   we know there's at least one such reference because has_hits is true.
-     */
-    for (int32_t i = 0; i < ci->top; i++)
-      if (ci_refs[i] > 0)
-	{
-	  set_collected(ci_objs[i]);
-	  if (i == refs)
-	    refs++;
-	  else
-	    {
-	      ci_objs[refs] = ci_objs[i];
-	      ci_refs[refs++] = ci_refs[i];
-	      ci_refs[i] = 0;
-	      ci_objs[i] = NULL;
-	    }}
-    ci->top = refs;
-    return(ci);
-  }
-}
-
-
-/* -------------------------------- cyclic-sequences -------------------------------- */
-static s7_pointer cyclic_sequences_p_p(s7_scheme *sc, s7_pointer obj)
-{
-  if (has_structure(obj))
-    {
-      shared_info_t *ci = (sc->object_out_locked) ? sc->circle_info : load_shared_info(sc, obj, false, sc->circle_info); /* false=don't stop at print length (vectors etc) */
-      if (ci)
-	{
-	  check_free_heap_size(sc, ci->top);
-	  begin_temp(sc->y, sc->nil);
-	  for (int32_t i = 0; i < ci->top; i++)
-	    sc->y = cons_unchecked(sc, ci->objs[i], sc->y);
-	  return_with_end_temp(sc->y);
-	}}
-  return(sc->nil);
-}
 
 /* g_cyclic_sequences is now defined in s7_scheme_predicate.c */
 #define H_cyclic_sequences "(cyclic-sequences obj) returns a list of elements that are cyclic."
 #define Q_cyclic_sequences s7_make_signature(sc, 2, sc->is_proper_list_symbol, sc->T)
 
+
+/* pair_append: general pair utility used by eval and the writer */
+s7_pointer pair_append(s7_scheme *sc, s7_pointer a, s7_pointer b)
+{
+  s7_pointer p = cdr(a), tp;
+  gc_protect_via_stack(sc, b);
+  if (is_null(p))
+    tp = cons(sc, car(a), b);
+  else
+    {
+      s7_pointer np;
+      tp = list_1(sc, car(a));
+      set_gc_protected2(sc, tp);
+      for (np = tp; is_pair(p); p = cdr(p), np = cdr(np))
+	set_cdr(np, list_1(sc, car(p)));
+      set_cdr(np, b);
+    }
+  unstack_gc_protect(sc);
+  return(tp);
+}
 
 /* -------------------------------- object->port (display format etc) -------------------------------- */
 static int32_t circular_list_entries(s7_pointer lst)
@@ -23175,24 +22752,6 @@ static s7_pointer closure_name(s7_scheme *sc, s7_pointer closure)
   return(closure); /* desperation -- the parameter list (caar here) will cause endless confusion in OP_APPLY errors! */
 }
 
-static s7_pointer pair_append(s7_scheme *sc, s7_pointer a, s7_pointer b)
-{
-  s7_pointer p = cdr(a), tp;
-  gc_protect_via_stack(sc, b);
-  if (is_null(p))
-    tp = cons(sc, car(a), b);
-  else
-    {
-      s7_pointer np;
-      tp = list_1(sc, car(a));
-      set_gc_protected2(sc, tp);
-      for (np = tp; is_pair(p); p = cdr(p), np = cdr(np))
-	set_cdr(np, list_1(sc, car(p)));
-      set_cdr(np, b);
-    }
-  unstack_gc_protect(sc);
-  return(tp);
-}
 
 static void write_closure_readably_1(s7_scheme *sc, s7_pointer obj, s7_pointer arglist, s7_pointer body, s7_pointer port)
 {
@@ -31053,7 +30612,7 @@ static hash_entry_t *hash_equivalent(s7_scheme *sc, s7_pointer table, s7_pointer
   return(sc->unentry);
 }
 
-static bool hash_keys_not_cyclic(s7_scheme *sc, s7_pointer hash)
+bool hash_keys_not_cyclic(s7_scheme *sc, s7_pointer hash)
 {
   return((is_null(hash_table_procedures(hash))) &&
 	 (hash_table_mapper(hash) == default_hash_map) &&

--- a/src/s7_internal.h
+++ b/src/s7_internal.h
@@ -1090,7 +1090,7 @@ typedef struct heap_block_t {
   struct heap_block_t *next;
 } heap_block_t;
 
-typedef struct {
+typedef struct shared_info {
   s7_pointer *objs;
   int32_t size, top, ref, size2;
   bool has_hits;
@@ -2033,6 +2033,11 @@ s7_pointer lookup_1(s7_scheme *sc, const s7_pointer symbol);
 
 /* type predicates tables (decls) */
 extern bool t_procedure_p[NUM_TYPES];
+extern bool t_structure_p[NUM_TYPES];
+extern bool t_sequence_p[NUM_TYPES];
+extern bool t_vector_p[NUM_TYPES];
+
+void memclr(void *s, size_t n);
 extern bool t_any_closure_p[NUM_TYPES];
 extern s7_pointer a_procedure_string;
 
@@ -2544,5 +2549,54 @@ void symbol_set_id(s7_pointer sym, s7_int id);
 void slot_set_value_with_hook_1(s7_scheme *sc, s7_pointer slot, s7_pointer value);
 no_return void wrong_type_error_nr(s7_scheme *sc, s7_pointer caller, s7_int arg_num, s7_pointer arg, s7_pointer typ);
 void immutable_object_error_nr(s7_scheme *sc, s7_pointer info);
+
+/* macros for s7_scheme_write.c (cycles/shared-info), mirrored from s7.c */
+#if S7_DEBUGGING
+void *Malloc(size_t bytes);
+void *Calloc(size_t nmemb, size_t size);
+void *Realloc(void *ptr, size_t size);
+#else
+#define Calloc(N, Size)    calloc(N, Size)
+#define Malloc(Size)       malloc(Size)
+#define Realloc(Ptr, Size) realloc(Ptr, Size)
+#endif
+#define c_object_set(Sc, p)            c_object_info(Sc, p)->set
+#define c_object_to_list(Sc, p)        c_object_info(Sc, p)->to_list
+#define c_pointer_info(p)              (T_Ptr(p))->object.cptr.info
+#define c_pointer_type(p)              (T_Ptr(p))->object.cptr.c_type
+#define clear_collected_and_shared(p)  clear_mid_type_bit(T_Seq(p), T_MID_COLLECTED | T_MID_SHARED) /* this can clear free cells = calloc */
+#define clear_cyclic_bits(p)           clear_type_bit(p, T_COLLECTED | T_SHARED | T_CYCLIC | T_CYCLIC_SET) /* not T_Seq, p can be free(!) */
+#define closure_body(p)                (T_Pair((T_Clo(p))->object.func.body))
+#define has_structure(P)               ((t_structure_p[type(P)]) && ((!is_t_vector(P)) || (!has_simple_elements(P))))
+#define hash_table_elements(p)         (T_Hsh(p))->object.hasher.elements /* block data (dx) */
+#define hash_table_entries(p)          hash_table_block(p)->nx.nx_uint
+#define hash_table_size(p)             ((T_Hsh(p))->object.hasher.mask + 1)
+#define is_any_vector(p)               t_vector_p[type(p)]
+#define is_c_pointer(p)                (type(p) == T_C_POINTER)
+#define is_collected_or_shared(p)      has_mid_type_bit(T_Seq(p), T_MID_COLLECTED | T_MID_SHARED)
+#define is_collected_unchecked(p)      has_mid_type_bit(p, T_MID_COLLECTED)
+#define is_hash_table(p)               (type(p) == T_HASH_TABLE)
+#define is_iterator(p)                 (type(p) == T_ITERATOR)
+#define is_sequence(P)                 ((t_sequence_p[type(P)]) || (has_methods(P)))
+#define is_shared(p)                   has_mid_type_bit(T_Seq(p), T_MID_SHARED)
+#define is_t_vector(p)                 (type(p) == T_VECTOR)
+#define iterator_sequence(p)           (T_Itr(p))->object.iter.seq
+#define return_with_end_temp(Temp)      do {s7_pointer Result = Temp; end_temp(Temp); return(Result);} while (0)
+#define set_collected(p)               set_mid_type_bit(T_Seq(p), T_MID_COLLECTED)
+#define set_cyclic(p)                  set_high_type_bit(T_Seq(p), T_SHORT_CYCLIC)
+#define set_shared(p)                  set_mid_type_bit(T_Seq(p), T_MID_SHARED)
+#define vector_element(p, i)           ((T_Nvc(p))->object.vector.elements.objects[i])
+#define T_COLLECTED                    (1 << (16 + 1))
+#define T_CYCLIC                       (1LL << (48 + 5))
+#define T_CYCLIC_SET                   (1LL << (48 + 6))
+#define T_MID_COLLECTED                (1 << 1)
+#define T_MID_SHARED                   (1 << 3)
+#define T_SHARED                       (1 << (16 + 3))
+#define T_SHORT_CYCLIC                 (1 << 5)
+#define c_object_info(Sc, p)           Sc->c_object_types[c_object_type(T_Obj(p))]
+#define has_simple_elements(p)         has_high_type_bit(T_Nvc(p), T_SIMPLE_ELEMENTS)
+#define hash_table_block(p)            (T_Hsh(p))->object.hasher.block
+#define T_SIMPLE_ELEMENTS              (1 << 8)
+#define c_object_type(p)               (T_Obj(p))->object.c_obj.type
 
 #endif /* S7_INTERNAL_H */

--- a/src/s7_internal_helpers.h
+++ b/src/s7_internal_helpers.h
@@ -406,6 +406,7 @@ s7_pointer s7i_eval(s7_scheme *sc, s7_int op);
 block_t *s7i_mallocate_port(s7_scheme *sc);
 void s7i_port_set_filename(s7_scheme *sc, s7_pointer port, const char *name, s7_int len);
 void push_input_port(s7_scheme *sc, s7_pointer new_port);
+bool hash_keys_not_cyclic(s7_scheme *sc, s7_pointer hash);
 /* method_or_bust/_p/_pp take s7_pointer symbols; declared in s7_scheme_read.c only
  * (s7_liii_string.c has its own same-named static helpers, so they can't live in a shared header) */
 

--- a/src/s7_scheme_write.c
+++ b/src/s7_scheme_write.c
@@ -6,8 +6,8 @@
  * Bill Schottstaedt, bil@ccrma.stanford.edu
  */
 
+#include "s7_internal.h"
 #include "s7_scheme_write.h"
-#include "s7_internal_helpers.h"
 
 #define IF_METHOD_EXISTS_RETURN_VALUE(Sc, Obj, Method_name, Args) \
   do { \
@@ -17,6 +17,449 @@
         return s7_apply_function(Sc, _func_, Args); \
     } \
   } while (0)
+
+/* -------- cycles -------- */
+
+#define INITIAL_SHARED_INFO_SIZE 8
+
+int32_t shared_ref(shared_info_t *ci, const s7_pointer p)
+{
+  /* from print after collecting refs, not called by equality check, only called in object_to_port_with_circle_check_1 */
+  s7_pointer *objs = ci->objs;
+  for (int32_t i = 0; i < ci->top; i++)
+    if (objs[i] == p)
+      {
+	int32_t val = ci->refs[i];
+	if (val > 0)
+	  ci->refs[i] = -ci->refs[i];
+	return(val);
+      }
+  return(0);
+}
+
+void flip_ref(shared_info_t *ci, const s7_pointer p)
+{
+  s7_pointer *objs = ci->objs;
+  for (int32_t i = 0; i < ci->top; i++)
+    if (objs[i] == p)
+      {
+	ci->refs[i] = -ci->refs[i];
+	break;
+      }
+}
+
+int32_t peek_shared_ref_1(shared_info_t *ci, const s7_pointer p)
+{
+  /* returns 0 if not found, otherwise the ref value for p */
+  s7_pointer *objs = ci->objs;
+  for (int32_t i = 0; i < ci->top; i++)
+    if (objs[i] == p)
+      return(ci->refs[i]);
+  return(0);
+}
+
+int32_t peek_shared_ref(shared_info_t *ci, s7_pointer p)
+{
+  /* returns 0 if not found, otherwise the ref value for p */
+  return((is_collected_unchecked(p)) ? peek_shared_ref_1(ci, p) : 0);
+}
+
+void enlarge_shared_info(shared_info_t *ci)
+{
+  ci->size *= 2;
+  ci->size2 = ci->size - 2;
+  ci->objs = (s7_pointer *)Realloc(ci->objs, ci->size * sizeof(s7_pointer));
+  ci->refs = (int32_t *)Realloc(ci->refs, ci->size * sizeof(int32_t));
+  ci->defined = (bool *)Realloc(ci->defined, ci->size * sizeof(bool));
+  /* this clearing is needed, memclr is not faster */
+  for (int32_t i = ci->top; i < ci->size; i++)
+    {
+      ci->refs[i] = 0;
+      ci->objs[i] = NULL;
+    }
+}
+
+static bool check_collected(s7_pointer top, shared_info_t *ci)
+{
+  const s7_pointer *objs_end = (s7_pointer *)(ci->objs + ci->top);
+  for (s7_pointer *p = ci->objs; p < objs_end; p++)
+    if ((*p) == top)
+      {
+	int32_t i = (int32_t)(p - ci->objs);
+	if (ci->refs[i] == 0)
+	  {
+	    ci->has_hits = true;
+	    ci->refs[i] = ++ci->ref;  /* if found, set the ref number */
+	  }
+	break;
+      }
+  set_cyclic(top);
+  return(true);
+}
+
+
+static bool collect_vector_info(s7_scheme *sc, shared_info_t *ci, s7_pointer top, bool stop_at_print_length)
+{
+  s7_int plen;
+  bool cyclic = false;
+
+  if (stop_at_print_length)
+    {
+      plen = sc->print_length;
+      if (plen > vector_length(top))
+	plen = vector_length(top);
+    }
+  else plen = vector_length(top);
+  for (s7_int i = 0; i < plen; i++)
+    {
+      const s7_pointer vel = vector_element_unchecked(top, i);   /* "unchecked" because top might be rootlet, I think */
+      if ((has_structure(vel)) &&
+	  (collect_shared_info(sc, ci, vel, stop_at_print_length)))
+	{
+	  set_cyclic(vel);
+	  cyclic = true;
+	  if ((is_c_pointer(vel)) ||
+	      (is_iterator(vel)) ||
+	      (is_c_object(vel)))
+	    check_collected(top, ci);
+	}}
+  if (cyclic) set_cyclic(top);
+  return(cyclic);
+}
+
+bool collect_shared_info(s7_scheme *sc, shared_info_t *ci, s7_pointer top, bool stop_at_print_length)
+{
+  /* look for top in current list.
+   * As we collect objects (guaranteed to have structure) we set the collected bit.  If we ever
+   *   encounter an object with that bit on, we've seen it before so we have a possible cycle.
+   *   Once the collection pass is done, we run through our list, and clear all these bits.
+   */
+  bool top_cyclic;
+
+  if (is_collected_or_shared(top))
+    return((!is_shared(top)) && (check_collected(top, ci)));
+
+  /* top not seen before -- add it to the list */
+  set_collected(top);
+  if (ci->top == ci->size)
+    enlarge_shared_info(ci);
+  ci->objs[ci->top++] = top;
+
+  top_cyclic = false;
+  /* now search the rest of this structure */
+  if (is_pair(top))
+    {
+      s7_pointer p;
+      if ((has_structure(car(top))) &&
+	  (collect_shared_info(sc, ci, car(top), stop_at_print_length)))
+	top_cyclic = true;
+
+      for (p = cdr(top); is_pair(p); p = cdr(p))
+	{
+	  if (is_collected_or_shared(p))
+	    {
+	      set_cyclic(top);
+	      set_cyclic(p);
+	      if (!is_shared(p))
+		return(check_collected(p, ci));
+	      if (!top_cyclic)
+		for (s7_pointer cp = top; cp != p; cp = cdr(cp)) set_shared(cp);
+	      return(top_cyclic);
+	    }
+ 	  set_collected(p);
+	  if (ci->top == ci->size)
+	    enlarge_shared_info(ci);
+	  ci->objs[ci->top++] = p;
+	  if ((has_structure(car(p))) &&
+	      (collect_shared_info(sc, ci, car(p), stop_at_print_length)))
+	    top_cyclic = true;
+	}
+      if ((has_structure(p)) &&
+	  (collect_shared_info(sc, ci, p, stop_at_print_length)))
+	{
+	  set_cyclic(top);
+	  return(true);
+	}
+      if (!top_cyclic)
+	for (s7_pointer cp = top; is_pair(cp); cp = cdr(cp)) set_shared(cp);
+      else set_cyclic(top);
+      return(top_cyclic);
+    }
+  switch (type(top))
+    {
+    case T_VECTOR:
+      if (collect_vector_info(sc, ci, top, stop_at_print_length))
+	top_cyclic = true;
+      break;
+
+    case T_ITERATOR:
+      if ((is_sequence(iterator_sequence(top))) && /* might be a function with +iterator+ local */
+	  (collect_shared_info(sc, ci, iterator_sequence(top), stop_at_print_length)))
+	{
+	  if (peek_shared_ref(ci, iterator_sequence(top)) == 0)
+	    check_collected(iterator_sequence(top), ci);
+	  top_cyclic = true;
+	}
+      break;
+
+    case T_HASH_TABLE:
+      if (hash_table_entries(top) > 0)
+	{
+	  const s7_int len = (s7_int)hash_table_size(top);
+	  hash_entry_t **entries = hash_table_elements(top);
+	  const bool keys_safe = hash_keys_not_cyclic(sc, top);
+	  for (s7_int i = 0; i < len; i++)
+	    for (hash_entry_t *entry = entries[i]; entry; entry = hash_entry_next(entry))
+	      {
+		if ((!keys_safe) &&
+		    (has_structure(hash_entry_key(entry))) &&
+		    (collect_shared_info(sc, ci, hash_entry_key(entry), stop_at_print_length)))
+		  top_cyclic = true;
+		if ((has_structure(hash_entry_value(entry))) &&
+		    (collect_shared_info(sc, ci, hash_entry_value(entry), stop_at_print_length)))
+		  {
+		    if ((is_c_pointer(hash_entry_value(entry))) ||
+			(is_iterator(hash_entry_value(entry))) ||
+			(is_c_object(hash_entry_value(entry))))
+		      check_collected(top, ci);
+		    top_cyclic = true;
+		  }}}
+      break;
+
+    case T_SLOT: /* this can be hit if we somehow collect_shared_info on sc->rootlet via collect_vector_info (see the let case below) */
+      if ((has_structure(slot_value(top))) &&
+	  (collect_shared_info(sc, ci, slot_value(top), stop_at_print_length)))
+	top_cyclic = true;
+      break;
+
+    case T_LET:
+      if (top == sc->rootlet)
+	{
+	  if (collect_vector_info(sc, ci, top, stop_at_print_length))
+	    top_cyclic = true;
+	}
+      else
+	for (s7_pointer let = top; let; let = let_outlet(let))
+	  for (s7_pointer slot = let_slots(let); is_not_slot_end(slot); slot = next_slot(slot))
+	    if ((has_structure(slot_value(slot))) &&
+		(collect_shared_info(sc, ci, slot_value(slot), stop_at_print_length)))
+	      {
+		top_cyclic = true;
+		if ((is_c_pointer(slot_value(slot))) ||
+		    (is_iterator(slot_value(slot))) ||
+		    (is_c_object(slot_value(slot))))
+		  check_collected(top, ci);
+	      }
+      break;
+
+    case T_CLOSURE: case T_CLOSURE_STAR:
+      if (collect_shared_info(sc, ci, closure_body(top), stop_at_print_length))
+	{
+	  if (peek_shared_ref(ci, top) == 0)
+	    check_collected(top, ci);
+	  top_cyclic = true;
+	}
+      break;
+
+    case T_C_POINTER:
+      if ((has_structure(c_pointer_type(top))) &&
+	  (collect_shared_info(sc, ci, c_pointer_type(top), stop_at_print_length)))
+	{
+	  if (peek_shared_ref(ci, c_pointer_type(top)) == 0)
+	    check_collected(c_pointer_type(top), ci);
+	  top_cyclic = true;
+	}
+      if ((has_structure(c_pointer_info(top))) &&
+	  (collect_shared_info(sc, ci, c_pointer_info(top), stop_at_print_length)))
+	{
+	  if (peek_shared_ref(ci, c_pointer_info(top)) == 0)
+	    check_collected(c_pointer_info(top), ci);
+	  top_cyclic = true;
+	}
+      break;
+
+    case T_C_OBJECT:
+      if ((c_object_to_list(sc, top)) &&
+	  (c_object_set(sc, top)) &&
+	  (collect_shared_info(sc, ci, (*(c_object_to_list(sc, top)))(sc, set_plist_1(sc, top)), stop_at_print_length)))
+	{
+	  if (peek_shared_ref(ci, top) == 0)
+	    check_collected(top, ci);
+	  top_cyclic = true;
+	}
+      break;
+    }
+  if (!top_cyclic)
+    set_shared(top);
+  else set_cyclic(top);
+  return(top_cyclic);
+}
+
+shared_info_t *make_shared_info(s7_scheme *sc)
+{
+  shared_info_t *ci = (shared_info_t *)Calloc(1, sizeof(shared_info_t));
+  ci->size = INITIAL_SHARED_INFO_SIZE;
+  ci->size2 = ci->size - 2;
+  ci->objs = (s7_pointer *)Malloc(ci->size * sizeof(s7_pointer));
+  ci->refs = (int32_t *)Calloc(ci->size, sizeof(int32_t));   /* finder expects 0 = unseen previously */
+  ci->defined = (bool *)Calloc(ci->size, sizeof(bool));
+  ci->cycle_port = sc->F;
+  ci->init_port = sc->F;
+  return(ci);
+}
+
+void free_shared_info(shared_info_t *ci)
+{
+  if (ci)
+    {
+      free(ci->objs);
+      free(ci->refs);
+      free(ci->defined);
+      free(ci);
+    }
+}
+
+shared_info_t *clear_shared_info(shared_info_t *ci)
+{
+  if (ci->top > 0)
+    {
+      memclr((void *)(ci->refs), ci->top * sizeof(int32_t));
+      memclr((void *)(ci->defined), ci->top * sizeof(bool));
+      for (int32_t i = 0; i < ci->top; i++)
+	clear_cyclic_bits(ci->objs[i]); /* LOOP_4 is not faster */
+      ci->top = 0;
+    }
+  ci->ref = 0;
+  ci->has_hits = false;
+  ci->ctr = 0;
+  return(ci);
+}
+
+shared_info_t *load_shared_info(s7_scheme *sc, s7_pointer top, bool stop_at_print_length, shared_info_t *ci)
+{
+  /* for the printer, here only if is_structure(top) and top is not sc->rootlet */
+  bool no_problem = true;
+  s7_int stop_len;
+
+  /* check for simple cases first */
+  if (is_pair(top))
+    {
+      s7_pointer p = top;
+      if (stop_at_print_length)
+	{
+	  s7_pointer slow = top;
+	  stop_len = sc->print_length;
+	  for (s7_int k = 0; k < stop_len; k += 2)
+	    {
+	      if (!is_pair(p)) break;
+	      if (has_structure(car(p))) {no_problem = false; break;}
+	      p = cdr(p);
+	      if (!is_pair(p)) break;
+	      if (has_structure(car(p))) {no_problem = false; break;}
+	      p = cdr(p);
+	      slow = cdr(slow);
+	      if (p == slow) {no_problem = false; break;}
+	    }}
+      else
+	if (s7_list_length(sc, top) == 0) /* it is circular at the top level (following cdr) */
+	  no_problem = false;
+	else
+	  for (; is_pair(p); p = cdr(p))
+	    if (has_structure(car(p))) {no_problem = false; break;} /* perhaps (and (length > 0 via sequence_is_empty)) or vector typer etc */
+      if ((no_problem) &&
+	  (!is_null(p)) && (has_structure(p)))
+	no_problem = false;
+      if (no_problem) return(NULL);
+    }
+  else
+    if (is_t_vector(top)) /* any other vector can't happen */
+      {
+	stop_len = vector_length(top);
+	if ((stop_at_print_length) &&
+	    (stop_len > sc->print_length))
+	  stop_len = sc->print_length;
+	for (s7_int k = 0; k < stop_len; k++)
+	  if (has_structure(vector_element(top, k))) {no_problem = false; break;}
+	if (no_problem) return(NULL);
+      }
+
+    else /* added these 19-Oct-22 -- helps in tgc, but not much elsewhere */
+      if ((is_let(top)) && (top != sc->rootlet))
+	{
+	  for (s7_pointer let = top; (no_problem) && (let); let = let_outlet(let))
+	    for (s7_pointer slot = let_slots(let); is_not_slot_end(slot); slot = next_slot(slot))
+	      if (has_structure(slot_value(slot))) /* slot_symbol need not be checked? */
+		{no_problem = false; break;}
+	  if (no_problem) return(NULL);
+	}
+      else
+	if (is_hash_table(top))
+	  {
+	    hash_entry_t **entries = hash_table_elements(top);
+	    bool keys_safe = hash_keys_not_cyclic(sc, top);
+	    if (hash_table_entries(top) == 0) return(NULL);
+	    for (s7_int len = (s7_int)hash_table_size(top), i = 0; i < len; i++)
+	      for (hash_entry_t *entry = entries[i]; entry; entry = hash_entry_next(entry))
+		if (((!keys_safe) && (has_structure(hash_entry_key(entry)))) || (has_structure(hash_entry_value(entry))))
+		  {no_problem = false; break;}
+	    if (no_problem) return(NULL);
+	  }
+
+  if ((S7_DEBUGGING) && (is_any_vector(top)) && (!is_t_vector(top))) fprintf(stderr, "%s[%d]: got abnormal vector\n", __func__, __LINE__);
+  clear_shared_info(ci);
+  {
+    /* collect all pointers associated with top */
+    const bool cyclic = collect_shared_info(sc, ci, top, stop_at_print_length);
+    s7_pointer *ci_objs = ci->objs;
+    int32_t *ci_refs = ci->refs;
+    int32_t refs = 0;
+
+    for (int32_t i = 0; i < ci->top; i++)
+      clear_collected_and_shared(ci_objs[i]);
+    if (!cyclic)
+      return(NULL);
+    if (!(ci->has_hits))
+      return(NULL);
+
+    /* find if any were referenced twice (once for just being there, so twice=shared)
+     *   we know there's at least one such reference because has_hits is true.
+     */
+    for (int32_t i = 0; i < ci->top; i++)
+      if (ci_refs[i] > 0)
+	{
+	  set_collected(ci_objs[i]);
+	  if (i == refs)
+	    refs++;
+	  else
+	    {
+	      ci_objs[refs] = ci_objs[i];
+	      ci_refs[refs++] = ci_refs[i];
+	      ci_refs[i] = 0;
+	      ci_objs[i] = NULL;
+	    }}
+    ci->top = refs;
+    return(ci);
+  }
+}
+
+
+/* -------------------------------- cyclic-sequences -------------------------------- */
+s7_pointer cyclic_sequences_p_p(s7_scheme *sc, s7_pointer obj)
+{
+  if (has_structure(obj))
+    {
+      shared_info_t *ci = (sc->object_out_locked) ? sc->circle_info : load_shared_info(sc, obj, false, sc->circle_info); /* false=don't stop at print length (vectors etc) */
+      if (ci)
+	{
+	  s7i_check_free_heap_size(sc, ci->top);
+	  begin_temp(sc->y, sc->nil);
+	  for (int32_t i = 0; i < ci->top; i++)
+	    sc->y = cons_unchecked(sc, ci->objs[i], sc->y);
+	  return_with_end_temp(sc->y);
+	}}
+  return(sc->nil);
+}
+
 
 /* -------------------------------- newline -------------------------------- */
 

--- a/src/s7_scheme_write.h
+++ b/src/s7_scheme_write.h
@@ -11,9 +11,26 @@
 
 #include "s7.h"
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* cycles / shared-info: circular reference detection for the printer */
+struct shared_info;
+int32_t shared_ref(struct shared_info *ci, s7_pointer p);
+void flip_ref(struct shared_info *ci, s7_pointer p);
+int32_t peek_shared_ref_1(struct shared_info *ci, s7_pointer p);
+int32_t peek_shared_ref(struct shared_info *ci, s7_pointer p);
+void enlarge_shared_info(struct shared_info *ci);
+struct shared_info *make_shared_info(s7_scheme *sc);
+void free_shared_info(struct shared_info *ci);
+struct shared_info *clear_shared_info(struct shared_info *ci);
+struct shared_info *load_shared_info(s7_scheme *sc, s7_pointer top, bool stop_at_print_length, struct shared_info *ci);
+bool collect_shared_info(s7_scheme *sc, struct shared_info *ci, s7_pointer top, bool stop_at_print_length);
+s7_pointer cyclic_sequences_p_p(s7_scheme *sc, s7_pointer obj);
 
 /* Public API implementations */
 void s7_newline(s7_scheme *sc, s7_pointer port);


### PR DESCRIPTION
## 概述

object->port 迁移的第二步（第一步 #958 已合并：测试文档基线）。本 PR 迁移打印引擎的前置依赖——环形引用检测机制，约 450 行。

## 改动

- s7.c cycles 区块（collect_shared_info / load_shared_info / make/free/clear_shared_info / peek/flip/shared_ref / cyclic_sequences_p_p 等 13 个函数）迁移到 `s7_scheme_write.c`
- `pair_append`（通用 pair 工具，eval 使用 21 处）从 object->port 区块挪出并导出
- `hash_keys_not_cyclic` 去掉 static，声明加入 `s7_internal_helpers.h`
- `shared_info_t` 加 `struct shared_info` 标签，`s7_scheme_write.h` 以前置声明导出迁移接口
- `s7_internal.h` 镜像 42 个宏（编译错误驱动收敛），含类型谓词表 extern 声明；Malloc/Calloc/Realloc 保留 S7_DEBUGGING 条件分支

## 验证

- `xmake b goldfish` 编译通过
- `bin/gf test --all`：1515 个测试全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)